### PR TITLE
feat: support auto https #27

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ zpan.db
 
 # Editor auto file
 .idea
+.vscode
 
 
 # Dependency directories (remove the comment below to include it)

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,22 @@ type Config struct {
 	Email      mailutil.Config
 	Database   gormutil.Config
 	Provider   provider.Config
+	Server     Server
+	TLS        TLS
+}
+
+type Server struct {
+	Domain  []string
+	Port    int
+	SSLPort int
+}
+
+type TLS struct {
+	Enabled     bool
+	Auto        bool
+	CacheDir    string
+	CertPath    string
+	CertkeyPath string
 }
 
 func (c *Config) EmailAct() bool {

--- a/deployments/zpan.yml
+++ b/deployments/zpan.yml
@@ -17,3 +17,17 @@ provider:
 #  sender: no-reply@saltbo.fun
 #  username: Zpan
 #  password: mGxxxxxxxxxxh9
+
+server:
+#   domain:
+#     - example1.com
+#     - example2.com
+  port: 8222
+  sslport: 443
+
+# tls:
+#   enabled: true
+#   auto: true
+#   cacheDir: /opt/
+#   certPath: "/etc/domain/cert.pem"
+#   certkeyPath: "/etc/domain/cert.key"

--- a/docs/config.md
+++ b/docs/config.md
@@ -66,3 +66,32 @@ Sender，eg：Zpan
 ## password
 Sending password
 
+# server
+Configure the server
+
+## domain
+Domain list of the server
+
+## port
+Http port
+
+## sslport
+Https port, only support 443 at the moment
+
+# tls
+Configure the tls 
+
+## enable
+Whether to enable https
+
+## auto
+Whether to auto https using let's encrypt
+
+## cacheDir
+Let's encrypt cert cache dir, need write permission
+
+## certPath
+Manually set cert
+
+## certkeyPath
+Manually set certkey

--- a/docs/zh-cn/config.md
+++ b/docs/zh-cn/config.md
@@ -66,3 +66,32 @@
 ## password
 发信密码
 
+# server
+服务器配置
+
+## domain
+服务器域名列表
+
+## port
+Http端口
+
+## sslport
+Https端口, 当前只支持443
+
+# tls
+TLS配置
+
+## enable
+是否开启HTTPS
+
+## auto
+是否使用let's encrypt 自动申请证书
+
+## cacheDir
+Let's encrypt 证书缓存目录
+
+## certPath
+手动配置证书
+
+## certkeyPath
+手动配置证书

--- a/go.mod
+++ b/go.mod
@@ -17,4 +17,5 @@ require (
 	github.com/spf13/viper v1.7.1
 	github.com/storyicon/grbac v0.0.0-20200224041032-a0461737df7e
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd
 )


### PR DESCRIPTION
implement  #27 

config add:

```
server:
  domain:
    - example1.com
    - example2.com
  port: 8222
  sslport: 443

tls:
  enabled: true
  auto: true
  cacheDir: /opt/
  certPath: "/etc/domain/cert.pem"
  certkeyPath: "/etc/domain/cert.key"
```

sslport only support 443 for now