### PR TITLE
fix: storage update error

### DIFF
--- a/internal/app/model/storage.go
+++ b/internal/app/model/storage.go
@@ -32,7 +32,7 @@ type Storage struct {
 	RootPath   string         `json:"root_path" gorm:"size:64;not null"`
 	FilePath   string         `json:"file_path" gorm:"size:1024;not null"`
 	Status     int8           `json:"status" gorm:"size:1;default:1;not null"`
-	Created    time.Time      `json:"created" gorm:"autoCreateTime;not null"`
+	Created    time.Time      `json:"created" gorm:"->;<-:create;autoCreateTime;not null"`
 	Updated    time.Time      `json:"updated" gorm:"autoUpdateTime;not null"`
 	Deleted    gorm.DeletedAt `json:"-"`
 }


### PR DESCRIPTION
api: PUT /api/storages/:id
error: Incorrect datetime value: '0000-00-00' for column 'created' at row 1

为 `model.Storage` `created` 字段添加 只读tag , 参考 https://gorm.io/docs/models.html#Field-Level-Permission