### PR TITLE
fix: sidebar not following dark mode theme switch

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -23,7 +23,7 @@
   --color-border: oklch(0.922 0 0);
   --color-input: oklch(0.922 0 0);
   --color-ring: oklch(0.708 0 0);
-  --color-sidebar-background: oklch(0.985 0 0);
+  --color-sidebar: oklch(0.985 0 0);
   --color-sidebar-foreground: oklch(0.445 0 0);
   --color-sidebar-primary: oklch(0.205 0 0);
   --color-sidebar-primary-foreground: oklch(0.985 0 0);
@@ -54,7 +54,7 @@
   --color-border: oklch(0.269 0 0);
   --color-input: oklch(0.269 0 0);
   --color-ring: oklch(0.439 0 0);
-  --color-sidebar-background: oklch(0.205 0 0);
+  --color-sidebar: oklch(0.205 0 0);
   --color-sidebar-foreground: oklch(0.708 0 0);
   --color-sidebar-primary: oklch(0.488 0.243 264.376);
   --color-sidebar-primary-foreground: oklch(0.985 0 0);
@@ -62,14 +62,6 @@
   --color-sidebar-accent-foreground: oklch(0.708 0 0);
   --color-sidebar-border: oklch(0.269 0 0);
   --color-sidebar-ring: oklch(0.439 0 0);
-  --sidebar: hsl(240 5.9% 10%);
-  --sidebar-foreground: hsl(240 4.8% 95.9%);
-  --sidebar-primary: hsl(224.3 76.3% 48%);
-  --sidebar-primary-foreground: hsl(0 0% 100%);
-  --sidebar-accent: hsl(240 3.7% 15.9%);
-  --sidebar-accent-foreground: hsl(240 4.8% 95.9%);
-  --sidebar-border: hsl(240 3.7% 15.9%);
-  --sidebar-ring: hsl(217.2 91.2% 59.8%);
 }
 
 @layer base {
@@ -82,24 +74,3 @@
   }
 }
 
-:root {
-  --sidebar: hsl(0 0% 98%);
-  --sidebar-foreground: hsl(240 5.3% 26.1%);
-  --sidebar-primary: hsl(240 5.9% 10%);
-  --sidebar-primary-foreground: hsl(0 0% 98%);
-  --sidebar-accent: hsl(240 4.8% 95.9%);
-  --sidebar-accent-foreground: hsl(240 5.9% 10%);
-  --sidebar-border: hsl(220 13% 91%);
-  --sidebar-ring: hsl(217.2 91.2% 59.8%);
-}
-
-@theme inline {
-  --color-sidebar: var(--sidebar);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-ring: var(--sidebar-ring);
-}


### PR DESCRIPTION
## Summary

- Renamed `--color-sidebar-background` → `--color-sidebar` in both `@theme` (light) and `.dark` blocks so `bg-sidebar` resolves to the correct token
- Removed the legacy `:root` block containing HSL `--sidebar-*` variables that were stale and unused after the oklch migration
- Removed the `@theme inline` block that remapped `--color-sidebar` → `var(--sidebar)`, which was overriding the oklch values and preventing dark mode overrides from taking effect
- Removed duplicate HSL `--sidebar-*` variables from `.dark` that were no longer needed

## Test plan

- [ ] Start dev server (`npm run dev`)
- [ ] Toggle to dark mode — sidebar background, text, accent, and border should all go dark
- [ ] Toggle back to light mode — sidebar should return to light colors
- [ ] Verify sidebar hover/active interactive states follow the theme in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)