### PR TITLE
feat: remove Name field from registration form

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -10,9 +10,8 @@ test.describe('Auth flow', () => {
     await page.goto('/sign-up')
     await expect(page.getByRole('heading', { name: 'ZPan' })).toBeVisible()
 
-    await page.getByLabel('Username').fill(`test${Date.now()}`)
-    await page.getByLabel('Name', { exact: true }).fill('Test User')
     await page.getByLabel('Email').fill(`test-${Date.now()}@example.com`)
+    await page.getByLabel('Username').fill(`test${Date.now()}`)
     await page.getByLabel('Password').fill('password123456')
 
     // Listen for the sign-up API response
@@ -30,9 +29,8 @@ test.describe('Auth flow', () => {
 
     // Register via UI
     await page.goto('/sign-up')
-    await page.getByLabel('Username').fill(`login${Date.now()}`)
-    await page.getByLabel('Name', { exact: true }).fill('Login Test')
     await page.getByLabel('Email').fill(email)
+    await page.getByLabel('Username').fill(`login${Date.now()}`)
     await page.getByLabel('Password').fill('password123456')
     const [signUpResp] = await Promise.all([
       page.waitForResponse((r) => r.url().includes('/api/auth/sign-up')),
@@ -58,9 +56,8 @@ test.describe('Auth flow', () => {
 
   test('sidebar shows only My Files and Trash for regular users @desktop @tablet', async ({ page }) => {
     await page.goto('/sign-up')
-    await page.getByLabel('Username').fill(`sidebar${Date.now()}`)
-    await page.getByLabel('Name', { exact: true }).fill('Sidebar Test')
     await page.getByLabel('Email').fill(`sidebar-${Date.now()}@example.com`)
+    await page.getByLabel('Username').fill(`sidebar${Date.now()}`)
     await page.getByLabel('Password').fill('password123456')
 
     const [signUpResp] = await Promise.all([

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -32,9 +32,8 @@ export async function signInAsAdmin(page: Page) {
 /** Register a fresh user and land on /files. */
 export async function signUpAndGoToFiles(page: Page) {
   await page.goto('/sign-up')
-  await page.getByLabel('Username').fill(`e2e${Date.now()}`)
-  await page.getByLabel('Name', { exact: true }).fill('E2E Test')
   await page.getByLabel('Email').fill(`e2e-${Date.now()}@example.com`)
+  await page.getByLabel('Username').fill(`e2e${Date.now()}`)
   await page.getByLabel('Password').fill('password123456')
   const [resp] = await Promise.all([
     page.waitForResponse((r) => r.url().includes('/api/auth/sign-up')),

--- a/e2e/responsive-auth.spec.ts
+++ b/e2e/responsive-auth.spec.ts
@@ -48,9 +48,8 @@ test.describe('Auth pages responsive layout', () => {
   test('mobile: sign-up form fields are usable @mobile', async ({ page }) => {
     await page.goto('/sign-up')
 
-    await expect(page.getByLabel('Username')).toBeVisible()
-    await expect(page.getByLabel('Name', { exact: true })).toBeVisible()
     await expect(page.getByLabel('Email', { exact: true })).toBeVisible()
+    await expect(page.getByLabel('Username')).toBeVisible()
     await expect(page.getByLabel(/password/i)).toBeVisible()
     await expect(page.getByRole('button', { name: /sign up/i })).toBeVisible()
   })

--- a/e2e/responsive-trash.spec.ts
+++ b/e2e/responsive-trash.spec.ts
@@ -3,9 +3,8 @@ import { expect, test } from '@playwright/test'
 // Helper: register and go to recycle bin
 async function signUpAndGoToTrash(page: import('@playwright/test').Page) {
   await page.goto('/sign-up')
-  await page.getByLabel('Username').fill(`trash${Date.now()}`)
-  await page.getByLabel('Name', { exact: true }).fill('Trash Test')
   await page.getByLabel('Email').fill(`trash-${Date.now()}@example.com`)
+  await page.getByLabel('Username').fill(`trash${Date.now()}`)
   await page.getByLabel('Password').fill('password123456')
   const [resp] = await Promise.all([
     page.waitForResponse((r) => r.url().includes('/api/auth/sign-up')),

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -227,10 +227,14 @@ async function isFirstUser(db: Database): Promise<boolean> {
   return row.c === 0
 }
 
-async function createPersonalOrg(db: Database, user: { id: string; name: string }): Promise<void> {
+async function createPersonalOrg(
+  db: Database,
+  user: { id: string; name: string; username?: string | null },
+): Promise<void> {
   const orgId = nanoid()
   const now = new Date()
-  const orgName = user.name ? `${user.name}'s Space` : 'Personal Space'
+  const displayName = user.name || user.username
+  const orgName = displayName ? `${displayName}'s Space` : 'Personal Space'
   const defaultQuota = await getDefaultOrgQuota(db)
 
   await db.insert(authSchema.organization).values({

--- a/server/services/user.ts
+++ b/server/services/user.ts
@@ -5,6 +5,7 @@ import type { Database } from '../platform/interface'
 export interface UserWithOrg {
   id: string
   name: string
+  username: string
   email: string
   role: string | null
   banned: boolean | null
@@ -23,10 +24,11 @@ export async function listUsers(
   const countRows = await db.select({ total: count() }).from(user)
   const total = countRows[0]?.total ?? 0
 
-  const items = await db
+  const rows = await db
     .select({
       id: user.id,
       name: user.name,
+      username: user.username,
       email: user.email,
       role: user.role,
       banned: user.banned,
@@ -44,6 +46,11 @@ export async function listUsers(
     .orderBy(desc(user.createdAt))
     .limit(pageSize)
     .offset(offset)
+
+  const items: UserWithOrg[] = rows.map((row) => ({
+    ...row,
+    username: row.username ?? '',
+  }))
 
   return { items, total }
 }

--- a/shared/schemas/index.ts
+++ b/shared/schemas/index.ts
@@ -9,8 +9,8 @@ export const signInSchema = z.object({
 })
 
 export const signUpSchema = z.object({
-  name: z.string().min(1),
   email: z.string().email(),
+  username: z.string().min(3).max(30),
   password: z.string().min(6),
 })
 

--- a/shared/schemas/schemas.test.ts
+++ b/shared/schemas/schemas.test.ts
@@ -27,12 +27,17 @@ describe('signInSchema', () => {
 
 describe('signUpSchema', () => {
   it('accepts valid input', () => {
-    const result = signUpSchema.safeParse({ name: 'Test', email: 'a@b.com', password: '123456' })
+    const result = signUpSchema.safeParse({ email: 'a@b.com', username: 'testuser', password: '123456' })
     expect(result.success).toBe(true)
   })
 
-  it('rejects empty name', () => {
-    const result = signUpSchema.safeParse({ name: '', email: 'a@b.com', password: '123456' })
+  it('rejects short username', () => {
+    const result = signUpSchema.safeParse({ email: 'a@b.com', username: 'ab', password: '123456' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing username', () => {
+    const result = signUpSchema.safeParse({ email: 'a@b.com', password: '123456' })
     expect(result.success).toBe(false)
   })
 })

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -61,7 +61,7 @@ export function AppSidebar() {
   const navigate = useNavigate()
   const { data: session } = useSession()
   const { siteName } = useSiteOptions()
-  const user = session?.user as { name: string; role?: string } | undefined
+  const user = session?.user as { name: string; username?: string; role?: string } | undefined
   const isAdmin = user?.role === 'admin'
   const { data: quota } = useQuery({
     queryKey: ['user', 'quota'],
@@ -171,9 +171,9 @@ export function AppSidebar() {
               className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent"
             >
               <Avatar size="sm">
-                <AvatarFallback>{user?.name ? getInitials(user.name) : '?'}</AvatarFallback>
+                <AvatarFallback>{user ? getInitials(user.name || user.username || '?') : '?'}</AvatarFallback>
               </Avatar>
-              <span className="flex-1 truncate text-left font-medium">{user?.name ?? ''}</span>
+              <span className="flex-1 truncate text-left font-medium">{user?.name || user?.username}</span>
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent side="top" align="start" className="w-56">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -125,6 +125,7 @@ export function deleteStorage(id: string) {
 export interface UserWithOrg {
   id: string
   name: string
+  username: string
   email: string
   role: string | null
   banned: boolean

--- a/src/routes/(auth)/sign-up.tsx
+++ b/src/routes/(auth)/sign-up.tsx
@@ -17,9 +17,8 @@ function SignUp() {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { authSignupMode, isLoading: optionsLoading } = useSiteOptions()
-  const [username, setUsername] = useState('')
-  const [name, setName] = useState('')
   const [email, setEmail] = useState('')
+  const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [inviteCode, setInviteCode] = useState('')
   const [error, setError] = useState('')
@@ -51,7 +50,7 @@ function SignUp() {
     try {
       const result = await signUp.email({
         username,
-        name,
+        name: '',
         email,
         password,
         callbackURL: '/files',
@@ -76,6 +75,10 @@ function SignUp() {
         </div>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
+            <Label htmlFor="email">{t('auth.email')}</Label>
+            <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+          </div>
+          <div className="space-y-2">
             <Label htmlFor="username">{t('auth.username')}</Label>
             <Input
               id="username"
@@ -85,14 +88,6 @@ function SignUp() {
               title={t('auth.usernameHint')}
               required
             />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="name">{t('auth.name')}</Label>
-            <Input id="name" value={name} onChange={(e) => setName(e.target.value)} required />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="email">{t('auth.email')}</Label>
-            <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
           </div>
           <div className="space-y-2">
             <Label htmlFor="password">{t('auth.password')}</Label>

--- a/src/routes/_authenticated/admin/users/index.tsx
+++ b/src/routes/_authenticated/admin/users/index.tsx
@@ -70,7 +70,9 @@ function UsersPage() {
   const filtered = useMemo(() => {
     if (!search.trim()) return users
     const term = search.toLowerCase()
-    return users.filter((u) => u.name.toLowerCase().includes(term) || u.email.toLowerCase().includes(term))
+    return users.filter(
+      (u) => (u.name || u.username).toLowerCase().includes(term) || u.email.toLowerCase().includes(term),
+    )
   }, [users, search])
 
   const total = usersQuery.data?.total ?? 0
@@ -131,7 +133,7 @@ function UsersPage() {
                     status: user.banned ? 'active' : 'disabled',
                   })
                 }
-                onDelete={() => setDeleteDialogUser({ id: user.id, name: user.name })}
+                onDelete={() => setDeleteDialogUser({ id: user.id, name: user.name || user.username })}
               />
             ))}
             {filtered.length === 0 && (
@@ -165,7 +167,7 @@ function UsersPage() {
         user={
           quotaDialogUser?.orgId
             ? {
-                name: quotaDialogUser.name,
+                name: quotaDialogUser.name || quotaDialogUser.username,
                 orgId: quotaDialogUser.orgId,
                 quotaUsed: quotaDialogUser.quotaUsed,
                 quotaTotal: quotaDialogUser.quotaTotal,
@@ -208,7 +210,7 @@ function UserTableRow({
 
   return (
     <tr className="border-b last:border-0 hover:bg-muted/30">
-      <td className="px-4 py-3 font-medium">{user.name}</td>
+      <td className="px-4 py-3 font-medium">{user.name || user.username}</td>
       <td className="hidden px-4 py-3 text-muted-foreground sm:table-cell">{user.email}</td>
       <td className="px-4 py-3">
         <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${roleBadge}`}>{roleLabel}</span>


### PR DESCRIPTION
## Summary

- Remove the Name field from the sign-up form; registration now only requires Email, Username, and Password (+ Invite Code when applicable)
- Send `name: ''` (empty string) to satisfy the DB NOT NULL constraint — no migration needed
- `createPersonalOrg` falls back to username when name is empty: `"<username>'s Space"`
- Add `username: string` to `UserWithOrg` type in both server and frontend (never nullable)
- Sidebar and admin users table display `user.name || user.username` so users with empty name always show something
- Update all e2e helpers and specs to reflect the removed field and new form order

## Test plan

- [ ] Sign-up form shows Email → Username → Password order with no Name field
- [ ] Submitting sign-up without a name succeeds and redirects to /files
- [ ] Sidebar shows username (not blank) for user with empty name
- [ ] Admin users table shows username for user with empty name
- [ ] Settings page loads correctly when name is empty; user can set display name
- [ ] `username` typed as `string` everywhere (not `string | null`)
- [ ] `createPersonalOrg` uses username for org name when name is empty
- [ ] All e2e specs pass with updated sign-up flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)