### PR TITLE
feat: add organizationClient plugin to auth-client

### DIFF
--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -59,6 +59,17 @@ export interface Member {
   createdAt: string
 }
 
+export interface Invitation {
+  id: string
+  organizationId: string
+  email: string
+  role: string
+  status: 'pending' | 'accepted' | 'rejected' | 'canceled'
+  expiresAt: string
+  inviterId: string
+  createdAt: string
+}
+
 export interface SystemOption {
   key: string
   value: string

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,9 +1,23 @@
-import { usernameClient } from 'better-auth/client/plugins'
+import { organizationClient, usernameClient } from 'better-auth/client/plugins'
 import { createAuthClient } from 'better-auth/react'
 
 export const authClient = createAuthClient({
   baseURL: import.meta.env.VITE_API_URL || '',
-  plugins: [usernameClient()],
+  plugins: [usernameClient(), organizationClient()],
 })
 
 export const { signIn, signUp, signOut, useSession } = authClient
+
+export const {
+  organization: {
+    create: createOrganization,
+    list: listOrganizations,
+    getFullOrganization,
+    setActive,
+    inviteMember,
+    removeMember,
+    updateMemberRole,
+  },
+  useListOrganizations,
+  useActiveOrganization,
+} = authClient


### PR DESCRIPTION
## Summary

- Added `organizationClient()` to the `plugins` array in `src/lib/auth-client.ts`
- Exported convenience methods for team management: `createOrganization`, `listOrganizations`, `getFullOrganization`, `setActive`, `inviteMember`, `removeMember`, `updateMemberRole`
- Exported React hooks: `useListOrganizations`, `useActiveOrganization`
- Added `Invitation` type to `shared/types/index.ts`

## Checks

- [x] `organizationClient()` added to plugins array
- [x] `authClient.organization` methods exported with no type errors
- [x] Existing auth functionality (signIn/signUp/signOut/useSession) untouched
- [x] TypeScript compilation passes

## Test plan

- [ ] Verify login/registration still works
- [ ] Verify `authClient.organization.create()` is callable without type errors
- [ ] Verify `useActiveOrganization()` and `useListOrganizations()` hooks are importable

🤖 Generated with [Claude Code](https://claude.com/claude-code)