### PR TITLE
feat: add team members management page

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -294,5 +294,21 @@
   "teams.deleteConfirm": "Delete team \"{{name}}\"? This action cannot be undone.",
   "teams.deleted": "Team deleted",
   "teams.loadError": "Failed to load team",
-  "teams.ownerOnly": "Only the team owner can access this page."
+  "teams.ownerOnly": "Only the team owner can access this page.",
+  "teams.members.title": "Members",
+  "teams.members.you": "You",
+  "teams.members.joinedOn": "Joined {{date}}",
+  "teams.members.roleUpdated": "Role updated",
+  "teams.members.removed": "Member removed",
+  "teams.members.removeTitle": "Remove Member",
+  "teams.members.removeConfirm": "Remove {{name}} from this team?",
+  "teams.members.lastOwnerError": "Cannot demote the last owner",
+  "teams.members.leave": "Leave Team",
+  "teams.members.leaveTitle": "Leave Team",
+  "teams.members.leaveConfirm": "Are you sure you want to leave this team? You will lose access to all team resources.",
+  "teams.members.leaveDescription": "You can leave this team at any time.",
+  "teams.members.left": "You have left the team",
+  "teams.role.owner": "Owner",
+  "teams.role.admin": "Admin",
+  "teams.role.member": "Member"
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -294,5 +294,21 @@
   "teams.deleteConfirm": "删除团队「{{name}}」？此操作无法撤销。",
   "teams.deleted": "团队已删除",
   "teams.loadError": "加载团队失败",
-  "teams.ownerOnly": "只有团队所有者才能访问此页面。"
+  "teams.ownerOnly": "只有团队所有者才能访问此页面。",
+  "teams.members.title": "成员",
+  "teams.members.you": "你",
+  "teams.members.joinedOn": "加入于 {{date}}",
+  "teams.members.roleUpdated": "角色已更新",
+  "teams.members.removed": "成员已移除",
+  "teams.members.removeTitle": "移除成员",
+  "teams.members.removeConfirm": "将 {{name}} 从此团队移除？",
+  "teams.members.lastOwnerError": "不能降级最后一个所有者",
+  "teams.members.leave": "离开团队",
+  "teams.members.leaveTitle": "离开团队",
+  "teams.members.leaveConfirm": "确定要离开此团队吗？离开后将失去所有团队资源的访问权限。",
+  "teams.members.leaveDescription": "你可以随时离开此团队。",
+  "teams.members.left": "你已离开团队",
+  "teams.role.owner": "所有者",
+  "teams.role.admin": "管理员",
+  "teams.role.member": "成员"
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,9 +9,9 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as UUsernameRouteImport } from './routes/u/$username'
 import { Route as AuthenticatedRouteRouteImport } from './routes/_authenticated/route'
 import { Route as AuthenticatedIndexRouteImport } from './routes/_authenticated/index'
+import { Route as UUsernameRouteImport } from './routes/u/$username'
 import { Route as authSignUpRouteImport } from './routes/(auth)/sign-up'
 import { Route as authSignInRouteImport } from './routes/(auth)/sign-in'
 import { Route as AuthenticatedAdminRouteRouteImport } from './routes/_authenticated/admin/route'
@@ -25,6 +25,7 @@ import { Route as AuthenticatedAdminUsersIndexRouteImport } from './routes/_auth
 import { Route as AuthenticatedAdminStoragesIndexRouteImport } from './routes/_authenticated/admin/storages/index'
 import { Route as AuthenticatedAdminSettingsIndexRouteImport } from './routes/_authenticated/admin/settings/index'
 import { Route as AuthenticatedTeamsTeamIdSettingsRouteImport } from './routes/_authenticated/teams/$teamId/settings'
+import { Route as AuthenticatedTeamsTeamIdMembersRouteImport } from './routes/_authenticated/teams/$teamId/members'
 import { Route as AuthenticatedAdminSettingsAuthRouteImport } from './routes/_authenticated/admin/settings/auth'
 
 const AuthenticatedRouteRoute = AuthenticatedRouteRouteImport.update({
@@ -35,6 +36,11 @@ const AuthenticatedIndexRoute = AuthenticatedIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AuthenticatedRouteRoute,
+} as any)
+const UUsernameRoute = UUsernameRouteImport.update({
+  id: '/u/$username',
+  path: '/u/$username',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const authSignUpRoute = authSignUpRouteImport.update({
   id: '/(auth)/sign-up',
@@ -108,23 +114,25 @@ const AuthenticatedTeamsTeamIdSettingsRoute =
     path: '/teams/$teamId/settings',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
+const AuthenticatedTeamsTeamIdMembersRoute =
+  AuthenticatedTeamsTeamIdMembersRouteImport.update({
+    id: '/teams/$teamId/members',
+    path: '/teams/$teamId/members',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
 const AuthenticatedAdminSettingsAuthRoute =
   AuthenticatedAdminSettingsAuthRouteImport.update({
     id: '/settings/auth',
     path: '/settings/auth',
     getParentRoute: () => AuthenticatedAdminRouteRoute,
   } as any)
-const UUsernameRoute = UUsernameRouteImport.update({
-  id: '/u/$username',
-  path: '/u/$username',
-  getParentRoute: () => rootRouteImport,
-} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof AuthenticatedIndexRoute
   '/admin': typeof AuthenticatedAdminRouteRouteWithChildren
   '/sign-in': typeof authSignInRoute
   '/sign-up': typeof authSignUpRoute
+  '/u/$username': typeof UUsernameRoute
   '/files/': typeof AuthenticatedFilesIndexRoute
   '/recycle-bin/': typeof AuthenticatedRecycleBinIndexRoute
   '/settings/': typeof AuthenticatedSettingsIndexRoute
@@ -132,16 +140,17 @@ export interface FileRoutesByFullPath {
   '/teams/': typeof AuthenticatedTeamsIndexRoute
   '/users/': typeof AuthenticatedUsersIndexRoute
   '/admin/settings/auth': typeof AuthenticatedAdminSettingsAuthRoute
+  '/teams/$teamId/members': typeof AuthenticatedTeamsTeamIdMembersRoute
   '/teams/$teamId/settings': typeof AuthenticatedTeamsTeamIdSettingsRoute
   '/admin/settings/': typeof AuthenticatedAdminSettingsIndexRoute
   '/admin/storages/': typeof AuthenticatedAdminStoragesIndexRoute
   '/admin/users/': typeof AuthenticatedAdminUsersIndexRoute
-  '/u/$username': typeof UUsernameRoute
 }
 export interface FileRoutesByTo {
   '/admin': typeof AuthenticatedAdminRouteRouteWithChildren
   '/sign-in': typeof authSignInRoute
   '/sign-up': typeof authSignUpRoute
+  '/u/$username': typeof UUsernameRoute
   '/': typeof AuthenticatedIndexRoute
   '/files': typeof AuthenticatedFilesIndexRoute
   '/recycle-bin': typeof AuthenticatedRecycleBinIndexRoute
@@ -150,11 +159,11 @@ export interface FileRoutesByTo {
   '/teams': typeof AuthenticatedTeamsIndexRoute
   '/users': typeof AuthenticatedUsersIndexRoute
   '/admin/settings/auth': typeof AuthenticatedAdminSettingsAuthRoute
+  '/teams/$teamId/members': typeof AuthenticatedTeamsTeamIdMembersRoute
   '/teams/$teamId/settings': typeof AuthenticatedTeamsTeamIdSettingsRoute
   '/admin/settings': typeof AuthenticatedAdminSettingsIndexRoute
   '/admin/storages': typeof AuthenticatedAdminStoragesIndexRoute
   '/admin/users': typeof AuthenticatedAdminUsersIndexRoute
-  '/u/$username': typeof UUsernameRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -162,6 +171,7 @@ export interface FileRoutesById {
   '/_authenticated/admin': typeof AuthenticatedAdminRouteRouteWithChildren
   '/(auth)/sign-in': typeof authSignInRoute
   '/(auth)/sign-up': typeof authSignUpRoute
+  '/u/$username': typeof UUsernameRoute
   '/_authenticated/': typeof AuthenticatedIndexRoute
   '/_authenticated/files/': typeof AuthenticatedFilesIndexRoute
   '/_authenticated/recycle-bin/': typeof AuthenticatedRecycleBinIndexRoute
@@ -170,11 +180,11 @@ export interface FileRoutesById {
   '/_authenticated/teams/': typeof AuthenticatedTeamsIndexRoute
   '/_authenticated/users/': typeof AuthenticatedUsersIndexRoute
   '/_authenticated/admin/settings/auth': typeof AuthenticatedAdminSettingsAuthRoute
+  '/_authenticated/teams/$teamId/members': typeof AuthenticatedTeamsTeamIdMembersRoute
   '/_authenticated/teams/$teamId/settings': typeof AuthenticatedTeamsTeamIdSettingsRoute
   '/_authenticated/admin/settings/': typeof AuthenticatedAdminSettingsIndexRoute
   '/_authenticated/admin/storages/': typeof AuthenticatedAdminStoragesIndexRoute
   '/_authenticated/admin/users/': typeof AuthenticatedAdminUsersIndexRoute
-  '/u/$username': typeof UUsernameRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -183,6 +193,7 @@ export interface FileRouteTypes {
     | '/admin'
     | '/sign-in'
     | '/sign-up'
+    | '/u/$username'
     | '/files/'
     | '/recycle-bin/'
     | '/settings/'
@@ -190,16 +201,17 @@ export interface FileRouteTypes {
     | '/teams/'
     | '/users/'
     | '/admin/settings/auth'
+    | '/teams/$teamId/members'
     | '/teams/$teamId/settings'
     | '/admin/settings/'
     | '/admin/storages/'
     | '/admin/users/'
-    | '/u/$username'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/admin'
     | '/sign-in'
     | '/sign-up'
+    | '/u/$username'
     | '/'
     | '/files'
     | '/recycle-bin'
@@ -208,17 +220,18 @@ export interface FileRouteTypes {
     | '/teams'
     | '/users'
     | '/admin/settings/auth'
+    | '/teams/$teamId/members'
     | '/teams/$teamId/settings'
     | '/admin/settings'
     | '/admin/storages'
     | '/admin/users'
-    | '/u/$username'
   id:
     | '__root__'
     | '/_authenticated'
     | '/_authenticated/admin'
     | '/(auth)/sign-in'
     | '/(auth)/sign-up'
+    | '/u/$username'
     | '/_authenticated/'
     | '/_authenticated/files/'
     | '/_authenticated/recycle-bin/'
@@ -227,11 +240,11 @@ export interface FileRouteTypes {
     | '/_authenticated/teams/'
     | '/_authenticated/users/'
     | '/_authenticated/admin/settings/auth'
+    | '/_authenticated/teams/$teamId/members'
     | '/_authenticated/teams/$teamId/settings'
     | '/_authenticated/admin/settings/'
     | '/_authenticated/admin/storages/'
     | '/_authenticated/admin/users/'
-    | '/u/$username'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -243,13 +256,6 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/u/$username': {
-      id: '/u/$username'
-      path: '/u/$username'
-      fullPath: '/u/$username'
-      preLoaderRoute: typeof UUsernameRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/_authenticated': {
       id: '/_authenticated'
       path: ''
@@ -263,6 +269,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/'
       preLoaderRoute: typeof AuthenticatedIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
+    }
+    '/u/$username': {
+      id: '/u/$username'
+      path: '/u/$username'
+      fullPath: '/u/$username'
+      preLoaderRoute: typeof UUsernameRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/(auth)/sign-up': {
       id: '/(auth)/sign-up'
@@ -355,6 +368,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedTeamsTeamIdSettingsRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
+    '/_authenticated/teams/$teamId/members': {
+      id: '/_authenticated/teams/$teamId/members'
+      path: '/teams/$teamId/members'
+      fullPath: '/teams/$teamId/members'
+      preLoaderRoute: typeof AuthenticatedTeamsTeamIdMembersRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
     '/_authenticated/admin/settings/auth': {
       id: '/_authenticated/admin/settings/auth'
       path: '/settings/auth'
@@ -394,6 +414,7 @@ interface AuthenticatedRouteRouteChildren {
   AuthenticatedStoragesIndexRoute: typeof AuthenticatedStoragesIndexRoute
   AuthenticatedTeamsIndexRoute: typeof AuthenticatedTeamsIndexRoute
   AuthenticatedUsersIndexRoute: typeof AuthenticatedUsersIndexRoute
+  AuthenticatedTeamsTeamIdMembersRoute: typeof AuthenticatedTeamsTeamIdMembersRoute
   AuthenticatedTeamsTeamIdSettingsRoute: typeof AuthenticatedTeamsTeamIdSettingsRoute
 }
 
@@ -406,6 +427,7 @@ const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
   AuthenticatedStoragesIndexRoute: AuthenticatedStoragesIndexRoute,
   AuthenticatedTeamsIndexRoute: AuthenticatedTeamsIndexRoute,
   AuthenticatedUsersIndexRoute: AuthenticatedUsersIndexRoute,
+  AuthenticatedTeamsTeamIdMembersRoute: AuthenticatedTeamsTeamIdMembersRoute,
   AuthenticatedTeamsTeamIdSettingsRoute: AuthenticatedTeamsTeamIdSettingsRoute,
 }
 

--- a/src/routes/_authenticated/teams/$teamId/members.tsx
+++ b/src/routes/_authenticated/teams/$teamId/members.tsx
@@ -1,0 +1,338 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { createFileRoute } from '@tanstack/react-router'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { authClient, useSession } from '@/lib/auth-client'
+
+export const Route = createFileRoute('/_authenticated/teams/$teamId/members')({
+  component: TeamMembersPage,
+})
+
+type Role = 'owner' | 'admin' | 'member'
+
+type OrgMember = {
+  id: string
+  userId: string
+  role: Role
+  createdAt: Date | string
+  user: {
+    id: string
+    name: string
+    email: string
+    image?: string | null
+  }
+}
+
+type FullOrganization = {
+  id: string
+  name: string
+  members: OrgMember[]
+}
+
+function RoleBadge({ role }: { role: Role }) {
+  const { t } = useTranslation()
+  const colorMap: Record<Role, string> = {
+    owner: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+    admin: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+    member: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+  }
+  return (
+    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${colorMap[role]}`}>{t(`teams.role.${role}`)}</span>
+  )
+}
+
+function RemoveMemberDialog({
+  open,
+  onOpenChange,
+  member,
+  orgId,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  member: OrgMember
+  orgId: string
+}) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const { error } = await authClient.organization.removeMember({
+        organizationId: orgId,
+        memberIdOrEmail: member.id,
+      })
+      if (error) throw error
+    },
+    onSuccess: () => {
+      toast.success(t('teams.members.removed'))
+      queryClient.invalidateQueries({ queryKey: ['organization', orgId] })
+      onOpenChange(false)
+    },
+    onError: (err: { message?: string }) => toast.error(err.message ?? String(err)),
+  })
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('teams.members.removeTitle')}</DialogTitle>
+          <DialogDescription>
+            {t('teams.members.removeConfirm', { name: member.user.name || member.user.email })}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            {t('common.cancel')}
+          </Button>
+          <Button type="button" variant="destructive" disabled={mutation.isPending} onClick={() => mutation.mutate()}>
+            {mutation.isPending ? t('common.loading') : t('common.delete')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function LeaveTeamDialog({
+  open,
+  onOpenChange,
+  member,
+  orgId,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  member: OrgMember
+  orgId: string
+}) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const { error } = await authClient.organization.removeMember({
+        organizationId: orgId,
+        memberIdOrEmail: member.id,
+      })
+      if (error) throw error
+    },
+    onSuccess: () => {
+      toast.success(t('teams.members.left'))
+      queryClient.invalidateQueries({ queryKey: ['organizations'] })
+      queryClient.invalidateQueries({ queryKey: ['organization', orgId] })
+      onOpenChange(false)
+    },
+    onError: (err: { message?: string }) => toast.error(err.message ?? String(err)),
+  })
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('teams.members.leaveTitle')}</DialogTitle>
+          <DialogDescription>{t('teams.members.leaveConfirm')}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            {t('common.cancel')}
+          </Button>
+          <Button type="button" variant="destructive" disabled={mutation.isPending} onClick={() => mutation.mutate()}>
+            {mutation.isPending ? t('common.loading') : t('teams.members.leave')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function MemberRow({
+  member,
+  orgId,
+  isCurrentUser,
+  isOwner,
+  ownerCount,
+}: {
+  member: OrgMember
+  orgId: string
+  isCurrentUser: boolean
+  isOwner: boolean
+  ownerCount: number
+}) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const [removeOpen, setRemoveOpen] = useState(false)
+
+  const roleMutation = useMutation({
+    mutationFn: async (role: Role) => {
+      const { error } = await authClient.organization.updateMemberRole({
+        organizationId: orgId,
+        memberId: member.id,
+        role,
+      })
+      if (error) throw error
+    },
+    onSuccess: () => {
+      toast.success(t('teams.members.roleUpdated'))
+      queryClient.invalidateQueries({ queryKey: ['organization', orgId] })
+    },
+    onError: (err: { message?: string }) => toast.error(err.message ?? String(err)),
+  })
+
+  const canChangeRole = isOwner && !isCurrentUser
+  const isLastOwner = member.role === 'owner' && ownerCount <= 1
+  const canRemove = isOwner && !isCurrentUser && member.role !== 'owner'
+
+  const joinedDate = new Date(member.createdAt as string).toLocaleDateString()
+
+  return (
+    <div className="flex items-center justify-between gap-4 rounded-md border p-3">
+      <div className="flex items-center gap-3 min-w-0">
+        <Avatar className="h-9 w-9 shrink-0">
+          <AvatarImage src={member.user.image ?? undefined} />
+          <AvatarFallback>{(member.user.name || member.user.email).charAt(0).toUpperCase()}</AvatarFallback>
+        </Avatar>
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-sm font-medium truncate">{member.user.name || member.user.email}</span>
+            {isCurrentUser && <span className="text-xs text-muted-foreground">({t('teams.members.you')})</span>}
+          </div>
+          <p className="text-xs text-muted-foreground truncate">{member.user.email}</p>
+          <p className="text-xs text-muted-foreground">{t('teams.members.joinedOn', { date: joinedDate })}</p>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 shrink-0">
+        {canChangeRole ? (
+          <Select
+            value={member.role}
+            onValueChange={(value) => {
+              if (isLastOwner && value !== 'owner') {
+                toast.error(t('teams.members.lastOwnerError'))
+                return
+              }
+              roleMutation.mutate(value as Role)
+            }}
+            disabled={roleMutation.isPending}
+          >
+            <SelectTrigger className="w-28 h-8 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="owner">{t('teams.role.owner')}</SelectItem>
+              <SelectItem value="admin">{t('teams.role.admin')}</SelectItem>
+              <SelectItem value="member">{t('teams.role.member')}</SelectItem>
+            </SelectContent>
+          </Select>
+        ) : (
+          <RoleBadge role={member.role} />
+        )}
+
+        {canRemove && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="text-destructive hover:text-destructive h-8 px-2"
+            onClick={() => setRemoveOpen(true)}
+          >
+            {t('common.delete')}
+          </Button>
+        )}
+      </div>
+
+      <RemoveMemberDialog open={removeOpen} onOpenChange={setRemoveOpen} member={member} orgId={orgId} />
+    </div>
+  )
+}
+
+function TeamMembersPage() {
+  const { t } = useTranslation()
+  const { teamId } = Route.useParams()
+  const { data: session } = useSession()
+  const [leaveOpen, setLeaveOpen] = useState(false)
+
+  const {
+    data: org,
+    isPending,
+    error,
+  } = useQuery({
+    queryKey: ['organization', teamId],
+    queryFn: async () => {
+      const { data, error: err } = await authClient.organization.getFullOrganization({
+        query: { organizationId: teamId },
+      })
+      if (err) throw err
+      return data as unknown as FullOrganization | null
+    },
+    enabled: !!teamId,
+  })
+
+  const userId = session?.user?.id ?? ''
+  const myMembership = org?.members.find((m) => m.userId === userId)
+  const isOwner = myMembership?.role === 'owner'
+  const ownerCount = org?.members.filter((m) => m.role === 'owner').length ?? 0
+
+  if (isPending) {
+    return (
+      <div className="space-y-3">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-16 animate-pulse rounded-md bg-muted" />
+        ))}
+      </div>
+    )
+  }
+
+  if (error || !org) {
+    return (
+      <div className="rounded-md border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+        {t('teams.loadError')}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">{t('teams.members.title')}</h2>
+        <span className="text-sm text-muted-foreground">{t('teams.memberCount', { count: org.members.length })}</span>
+      </div>
+
+      <div className="space-y-2">
+        {org.members.map((member) => (
+          <MemberRow
+            key={member.id}
+            member={member}
+            orgId={org.id}
+            isCurrentUser={member.userId === userId}
+            isOwner={isOwner}
+            ownerCount={ownerCount}
+          />
+        ))}
+      </div>
+
+      {myMembership && !isOwner && (
+        <div className="rounded-md border border-destructive/30 p-4">
+          <p className="text-sm text-muted-foreground mb-3">{t('teams.members.leaveDescription')}</p>
+          <Button type="button" variant="destructive" size="sm" onClick={() => setLeaveOpen(true)}>
+            {t('teams.members.leave')}
+          </Button>
+        </div>
+      )}
+
+      {myMembership && !isOwner && (
+        <LeaveTeamDialog open={leaveOpen} onOpenChange={setLeaveOpen} member={myMembership} orgId={org.id} />
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `/teams/:teamId/members` page for team member management
- Members list shows avatar, name/email, role badge, and join date with "You" label for current user
- Owner can change other members' roles (owner/admin/member) via Select dropdown
- Owner can remove non-owner members with confirmation dialog
- Non-owner members can leave the team via "Leave Team" button
- Prevents demoting the last owner
- Adds i18n keys for both English and Chinese locales

## Test plan

- [ ] Visit `/teams/:teamId/members` as owner — should see full member list with role selects and remove buttons
- [ ] Visit as non-owner — role selects and remove buttons should be hidden
- [ ] Change a member's role — should update and show success toast
- [ ] Try to demote the last owner — should show error toast, not proceed
- [ ] Remove a non-owner member — confirmation dialog appears, member removed on confirm
- [ ] Click "Leave Team" as non-owner — confirmation dialog appears, leaves team on confirm
- [ ] TypeScript: `npm run typecheck` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)