### PR TITLE
fix: move Teams entry from sidebar nav to avatar dropdown menu

### DIFF
--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -143,14 +143,6 @@ export function AppSidebar() {
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton asChild>
-                  <Link to="/teams">
-                    <Users className="h-4 w-4" />
-                    <span>{t('nav.teams')}</span>
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
@@ -190,6 +182,12 @@ export function AppSidebar() {
               <Link to="/settings">
                 <Settings className="mr-2 h-4 w-4" />
                 {t('nav.settings')}
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link to="/teams">
+                <Users className="mr-2 h-4 w-4" />
+                {t('nav.teams')}
               </Link>
             </DropdownMenuItem>
             {isAdmin && (


### PR DESCRIPTION
## Summary
- Removes the Teams link from the main sidebar navigation list (it was alongside My Files / Photos / Trash)
- Adds a Teams entry to the user avatar dropdown menu in the sidebar footer, positioned between Settings and Admin Panel
- Uses the `Users` icon from lucide-react, navigates to `/teams`

## Checks
- [x] Sidebar main nav no longer contains a Teams link
- [x] Avatar dropdown menu shows a Teams entry (near Settings)
- [x] Clicking Teams navigates to `/teams`
- [x] TypeScript compilation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)