### PR TITLE
feat(shares): save to drive — cross-workspace copy with quota and name conflict handling

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -12,6 +12,7 @@ import { adminInviteCodes, publicInviteCodes } from './routes/invite-codes'
 import objects from './routes/objects'
 import profile from './routes/profile'
 import { adminQuotas, userQuotas } from './routes/quotas'
+import shares from './routes/shares'
 import storages from './routes/storages'
 import system from './routes/system'
 import { publicTeams, teams } from './routes/teams'
@@ -48,6 +49,7 @@ export function createApp(platform: Platform, auth: Auth) {
   // Mount routes separately to avoid deep type chain accumulation.
   // Each .route() call is independent — TypeScript doesn't stack types.
   app.route('/api/objects', objects)
+  app.route('/api/shares', shares)
   app.route('/api/recycle-bin', trash)
   app.route('/api/teams', teams)
   app.route('/api/admin/storages', storages)
@@ -69,6 +71,7 @@ export type AppType = ReturnType<typeof createApp>
 
 // Sub-router types for RPC clients — avoids combined AppType OOM
 export type ObjectsRoute = typeof objects
+export type SharesRoute = typeof shares
 export type TrashRoute = typeof trash
 export type StoragesRoute = typeof storages
 export type UsersRoute = typeof users

--- a/server/routes/shares.ts
+++ b/server/routes/shares.ts
@@ -1,0 +1,88 @@
+import { zValidator } from '@hono/zod-validator'
+import { Hono } from 'hono'
+import { getCookie } from 'hono/cookie'
+import { saveShareRequestSchema } from '../../shared/schemas/share'
+import { requireAuth } from '../middleware/auth'
+import type { Env } from '../middleware/platform'
+import { getMemberRole, isPersonalOrg } from '../services/org'
+import { computeSourceBytes, isQuotaSufficient, resolveShareByToken, saveShareToDrive } from '../services/save-to-drive'
+
+const ROLE_LEVELS: Record<string, number> = {
+  owner: 3,
+  editor: 2,
+  viewer: 1,
+  member: 1,
+}
+
+const app = new Hono<Env>()
+  .use(requireAuth)
+  .post('/:token/save', zValidator('json', saveShareRequestSchema), async (c) => {
+    const token = c.req.param('token')
+    const { targetOrgId, targetParent } = c.req.valid('json')
+    const currentUserId = c.get('userId')!
+    const db = c.get('platform').db
+
+    // 1. Resolve share — distinguish not_found/revoked from matter_trashed
+    const resolution = await resolveShareByToken(db, token)
+    if (resolution.status === 'matter_trashed') {
+      return c.json({ error: 'Share target has been deleted' }, 410)
+    }
+    if (resolution.status !== 'ok') {
+      return c.json({ error: 'Share not found' }, 404)
+    }
+
+    const { share, matter, recipients } = resolution
+
+    // 2. Reject direct shares — they cannot be saved to drive
+    if (share.kind === 'direct') {
+      return c.json(
+        {
+          error: 'Direct link shares cannot be saved. Ask the sender for a landing share.',
+          code: 'DIRECT_SAVE_FORBIDDEN',
+        },
+        400,
+      )
+    }
+
+    // 3. Password-protected share: recipient is exempt; others need the cookie
+    if (share.passwordHash) {
+      const isRecipient = recipients.some(
+        (r: { recipientUserId: string | null }) => r.recipientUserId === currentUserId,
+      )
+      if (!isRecipient) {
+        const cookieValue = getCookie(c, `sharetk_${token}`)
+        if (!cookieValue) {
+          return c.json({ error: 'Authentication required for password-protected share' }, 401)
+        }
+      }
+    }
+
+    // 4. Verify current user has editor+ role in targetOrgId
+    const role = await getMemberRole(db, targetOrgId, currentUserId)
+    if (role !== null) {
+      if ((ROLE_LEVELS[role] ?? 0) < ROLE_LEVELS.editor) {
+        return c.json({ error: 'Forbidden' }, 403)
+      }
+    } else if (!(await isPersonalOrg(db, targetOrgId))) {
+      return c.json({ error: 'Forbidden' }, 403)
+    }
+
+    // 5. Pre-flight quota check (non-atomic fast-fail)
+    const totalBytes = await computeSourceBytes(db, matter)
+    const quotaOk = await isQuotaSufficient(db, targetOrgId, totalBytes)
+    if (!quotaOk) {
+      return c.json({ error: 'Quota exceeded', code: 'QUOTA_EXCEEDED' }, 400)
+    }
+
+    const result = await saveShareToDrive(db, {
+      share,
+      matter,
+      currentUserId,
+      targetOrgId,
+      targetParent,
+    })
+
+    return c.json(result, 201)
+  })
+
+export default app

--- a/server/services/s3.ts
+++ b/server/services/s3.ts
@@ -81,6 +81,24 @@ export class S3Service {
     )
   }
 
+  async streamCopy(srcStorage: Storage, srcKey: string, dstStorage: Storage, dstKey: string): Promise<void> {
+    const srcClient = this.createClient(srcStorage)
+    const getResult = await srcClient.send(new GetObjectCommand({ Bucket: srcStorage.bucket, Key: srcKey }))
+    if (!getResult.Body) throw new Error('Empty body from source object')
+
+    const dstClient = this.createClient(dstStorage)
+    await dstClient.send(
+      new PutObjectCommand({
+        Bucket: dstStorage.bucket,
+        Key: dstKey,
+        // biome-ignore lint/suspicious/noExplicitAny: AWS SDK stream type differs across Node and CF Workers runtimes
+        Body: getResult.Body as any,
+        ContentType: getResult.ContentType,
+        ContentLength: getResult.ContentLength,
+      }),
+    )
+  }
+
   async deleteObject(storage: Storage, key: string): Promise<void> {
     const client = this.createClient(storage)
     await client.send(new DeleteObjectCommand({ Bucket: storage.bucket, Key: key }))

--- a/server/services/save-to-drive.cf-test.ts
+++ b/server/services/save-to-drive.cf-test.ts
@@ -1,0 +1,216 @@
+import { env } from 'cloudflare:workers'
+import { nanoid } from 'nanoid'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DirType } from '../../shared/constants'
+import { matters } from '../db/schema'
+import { createCloudflarePlatform } from '../platform/cloudflare'
+import { S3Service } from './s3'
+import { resolveShareByToken, saveShareToDrive } from './save-to-drive'
+import { createShare, revokeShare } from './share'
+
+function buildDb() {
+  return createCloudflarePlatform(env).db
+}
+
+async function seedStorage(db: ReturnType<typeof buildDb>, id: string) {
+  await db.run(
+    `INSERT OR IGNORE INTO storages (id, title, mode, bucket, endpoint, region, access_key, secret_key, file_path, custom_host, capacity, used, status, created_at, updated_at)
+     VALUES ('${id}', 'CF Test S3', 'private', 'cf-bucket', 'https://s3.amazonaws.com', 'us-east-1', 'AKIA...', 'secret...', '', '', 0, 0, 'active', ${Date.now()}, ${Date.now()})`,
+  )
+}
+
+async function seedMatter(db: ReturnType<typeof buildDb>, orgId: string, dirtype = DirType.FILE) {
+  const now = new Date()
+  const matter = {
+    id: nanoid(),
+    orgId,
+    alias: nanoid(10),
+    name: `cf-file-${nanoid(6)}.pdf`,
+    type: dirtype !== DirType.FILE ? 'folder' : 'application/pdf',
+    size: 1024,
+    dirtype,
+    parent: '',
+    object: dirtype !== DirType.FILE ? '' : `objects/${nanoid()}.pdf`,
+    storageId: 'cf-storage-1',
+    status: 'active',
+    trashedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  }
+  await db.insert(matters).values(matter)
+  return matter
+}
+
+// ─── resolveShareByToken on D1 ────────────────────────────────────────────────
+
+describe('[CF] resolveShareByToken', () => {
+  it('returns ok for an active landing share', async () => {
+    const db = buildDb()
+    const orgId = `org-${nanoid(6)}`
+    await seedStorage(db, 'cf-storage-1')
+    const matter = await seedMatter(db, orgId)
+
+    const share = await createShare(db, {
+      matterId: matter.id,
+      orgId,
+      creatorId: 'cf-user-1',
+      kind: 'landing',
+    })
+
+    const result = await resolveShareByToken(db, share.token)
+    expect(result.status).toBe('ok')
+    if (result.status !== 'ok') return
+    expect(result.share.id).toBe(share.id)
+  })
+
+  it('returns revoked when share is revoked', async () => {
+    const db = buildDb()
+    const orgId = `org-${nanoid(6)}`
+    await seedStorage(db, 'cf-storage-1')
+    const matter = await seedMatter(db, orgId)
+
+    const share = await createShare(db, { matterId: matter.id, orgId, creatorId: 'cf-user-2', kind: 'landing' })
+    await revokeShare(db, share.id, 'cf-user-2')
+
+    const result = await resolveShareByToken(db, share.token)
+    expect(result.status).toBe('revoked')
+  })
+
+  it('returns matter_trashed when matter is trashed', async () => {
+    const db = buildDb()
+    const orgId = `org-${nanoid(6)}`
+    await seedStorage(db, 'cf-storage-1')
+    const matter = await seedMatter(db, orgId)
+
+    const share = await createShare(db, { matterId: matter.id, orgId, creatorId: 'cf-user-3', kind: 'landing' })
+    await db.run(`UPDATE matters SET status = 'trashed' WHERE id = '${matter.id}'`)
+
+    const result = await resolveShareByToken(db, share.token)
+    expect(result.status).toBe('matter_trashed')
+  })
+})
+
+// ─── saveShareToDrive on D1 ───────────────────────────────────────────────────
+
+describe('[CF] saveShareToDrive — stream copy via D1', () => {
+  beforeEach(() => {
+    vi.spyOn(S3Service.prototype, 'copyObject').mockResolvedValue(undefined)
+    vi.spyOn(S3Service.prototype, 'streamCopy').mockResolvedValue(undefined)
+  })
+
+  it('saves a single file to the target org on D1', async () => {
+    const db = buildDb()
+    const srcOrgId = `src-${nanoid(6)}`
+    const dstOrgId = `dst-${nanoid(6)}`
+    await seedStorage(db, 'cf-storage-1')
+
+    const matter = await seedMatter(db, srcOrgId)
+    const share = await createShare(db, { matterId: matter.id, orgId: srcOrgId, creatorId: 'cf-u1', kind: 'landing' })
+
+    if (share.status === 'revoked') throw new Error('test setup failed')
+
+    const result = await saveShareToDrive(db, {
+      share,
+      matter,
+      currentUserId: 'cf-u2',
+      targetOrgId: dstOrgId,
+      targetParent: '',
+    })
+
+    expect(result.saved).toHaveLength(1)
+    expect(result.skipped).toHaveLength(0)
+    expect(result.saved[0].orgId).toBe(dstOrgId)
+    expect(result.saved[0].status).toBe('active')
+  })
+
+  it('does not increment downloads counter after save', async () => {
+    const db = buildDb()
+    const srcOrgId = `src-${nanoid(6)}`
+    const dstOrgId = `dst-${nanoid(6)}`
+    await seedStorage(db, 'cf-storage-1')
+
+    const matter = await seedMatter(db, srcOrgId)
+    const share = await createShare(db, { matterId: matter.id, orgId: srcOrgId, creatorId: 'cf-u3', kind: 'landing' })
+
+    if (share.status === 'revoked') throw new Error('test setup failed')
+    const downloadsBefore = share.downloads
+
+    await saveShareToDrive(db, {
+      share,
+      matter,
+      currentUserId: 'cf-u4',
+      targetOrgId: dstOrgId,
+      targetParent: '',
+    })
+
+    const rows = await db.select().from(matters).where(
+      // Check that the original share downloads didn't change
+    )
+    // Verify by re-querying the share
+    const updatedShareRows = await db.all<{ downloads: number }>(
+      `SELECT downloads FROM shares WHERE id = '${share.id}'`,
+    )
+    expect(updatedShareRows[0]?.downloads).toBe(downloadsBefore)
+  })
+
+  it('recursively saves a folder tree on D1', async () => {
+    const db = buildDb()
+    const srcOrgId = `src-${nanoid(6)}`
+    const dstOrgId = `dst-${nanoid(6)}`
+    await seedStorage(db, 'cf-storage-1')
+
+    // Create folder structure
+    const now = new Date()
+    const folder = {
+      id: nanoid(),
+      orgId: srcOrgId,
+      alias: nanoid(10),
+      name: 'cf-album',
+      type: 'folder',
+      size: 0,
+      dirtype: DirType.USER_FOLDER,
+      parent: '',
+      object: '',
+      storageId: 'cf-storage-1',
+      status: 'active',
+      trashedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    }
+    await db.insert(matters).values(folder)
+
+    const file1 = {
+      id: nanoid(),
+      orgId: srcOrgId,
+      alias: nanoid(10),
+      name: 'photo1.jpg',
+      type: 'image/jpeg',
+      size: 500,
+      dirtype: DirType.FILE,
+      parent: 'cf-album',
+      object: `objects/${nanoid()}.jpg`,
+      storageId: 'cf-storage-1',
+      status: 'active',
+      trashedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    }
+    await db.insert(matters).values(file1)
+
+    const share = await createShare(db, { matterId: folder.id, orgId: srcOrgId, creatorId: 'cf-u5', kind: 'landing' })
+
+    if (share.status === 'revoked') throw new Error('test setup failed')
+
+    const result = await saveShareToDrive(db, {
+      share,
+      matter: folder,
+      currentUserId: 'cf-u6',
+      targetOrgId: dstOrgId,
+      targetParent: '',
+    })
+
+    // 1 root folder + 1 file = 2
+    expect(result.saved).toHaveLength(2)
+    expect(result.skipped).toHaveLength(0)
+  })
+})

--- a/server/services/save-to-drive.integration.test.ts
+++ b/server/services/save-to-drive.integration.test.ts
@@ -1,0 +1,685 @@
+import { sql } from 'drizzle-orm'
+import { nanoid } from 'nanoid'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DirType } from '../../shared/constants'
+import { activityEvents, matters, orgQuotas, shares } from '../db/schema'
+import { S3Service } from '../services/s3.js'
+import { authedHeaders, createTestApp } from '../test/setup.js'
+import { computeSourceBytes, isQuotaSufficient, resolveShareByToken, saveShareToDrive } from './save-to-drive.js'
+import { createShare } from './share.js'
+
+// ─── Test fixtures ────────────────────────────────────────────────────────────
+
+const STORAGE_ID = 'st-save-1'
+const ALT_STORAGE_ID = 'st-save-2'
+
+type TestDb = Awaited<ReturnType<typeof createTestApp>>['db']
+
+async function insertStorage(db: TestDb, id = STORAGE_ID) {
+  const now = Date.now()
+  await db.run(sql`
+    INSERT INTO storages (id, title, mode, bucket, endpoint, region, access_key, secret_key, file_path, custom_host, capacity, used, status, created_at, updated_at)
+    VALUES (${id}, 'Test S3', 'private', 'test-bucket', 'https://s3.amazonaws.com', 'us-east-1', 'AKIAIOSFODNN7EXAMPLE', 'wJalrXUtnFEMI', '', '', 0, 0, 'active', ${now}, ${now})
+  `)
+}
+
+async function seedMatter(
+  db: TestDb,
+  opts: {
+    orgId: string
+    storageId?: string
+    dirtype?: number
+    status?: string
+    name?: string
+    parent?: string
+    size?: number
+  },
+) {
+  const now = new Date()
+  const dirtype = opts.dirtype ?? DirType.FILE
+  const matter = {
+    id: nanoid(),
+    orgId: opts.orgId,
+    alias: nanoid(10),
+    name: opts.name ?? `file-${nanoid(6)}.pdf`,
+    type: dirtype !== DirType.FILE ? 'folder' : 'application/pdf',
+    size: opts.size ?? 1024,
+    dirtype,
+    parent: opts.parent ?? '',
+    object: dirtype !== DirType.FILE ? '' : `objects/${nanoid()}.pdf`,
+    storageId: opts.storageId ?? STORAGE_ID,
+    status: opts.status ?? 'active',
+    trashedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  }
+  await db.insert(matters).values(matter)
+  return matter
+}
+
+async function seedOrgQuota(db: TestDb, orgId: string, quota: number, used = 0) {
+  await db.insert(orgQuotas).values({ id: nanoid(), orgId, quota, used })
+}
+
+async function getShare(db: TestDb, shareId: string) {
+  const rows = await db.select().from(shares).where(sql`id = ${shareId}`)
+  return rows[0] ?? null
+}
+
+async function getActivities(db: TestDb, orgId: string) {
+  return db.select().from(activityEvents).where(sql`org_id = ${orgId}`)
+}
+
+async function getMattersInOrg(db: TestDb, orgId: string) {
+  return db.select().from(matters).where(sql`org_id = ${orgId} AND status = 'active'`)
+}
+
+// ─── resolveShareByToken ──────────────────────────────────────────────────────
+
+describe('resolveShareByToken', () => {
+  it('returns ok with share, matter, and recipients', async () => {
+    const { db } = await createTestApp()
+    await insertStorage(db)
+    const orgId = nanoid()
+    const matter = await seedMatter(db, { orgId })
+    const share = await createShare(db, {
+      matterId: matter.id,
+      orgId,
+      creatorId: 'u1',
+      kind: 'landing',
+      recipients: [{ recipientUserId: 'u2' }],
+    })
+
+    const result = await resolveShareByToken(db, share.token)
+    expect(result.status).toBe('ok')
+    if (result.status !== 'ok') return
+    expect(result.share.id).toBe(share.id)
+    expect(result.matter.id).toBe(matter.id)
+    expect(result.recipients).toHaveLength(1)
+  })
+
+  it('returns not_found for unknown token', async () => {
+    const { db } = await createTestApp()
+    const result = await resolveShareByToken(db, 'unknown')
+    expect(result.status).toBe('not_found')
+  })
+
+  it('returns revoked for revoked share', async () => {
+    const { db } = await createTestApp()
+    await insertStorage(db)
+    const orgId = nanoid()
+    const matter = await seedMatter(db, { orgId })
+    const share = await createShare(db, { matterId: matter.id, orgId, creatorId: 'u1', kind: 'landing' })
+    await db.run(sql`UPDATE shares SET status = 'revoked' WHERE id = ${share.id}`)
+
+    const result = await resolveShareByToken(db, share.token)
+    expect(result.status).toBe('revoked')
+  })
+
+  it('returns matter_trashed when underlying matter is trashed', async () => {
+    const { db } = await createTestApp()
+    await insertStorage(db)
+    const orgId = nanoid()
+    const matter = await seedMatter(db, { orgId, status: 'active' })
+    const share = await createShare(db, { matterId: matter.id, orgId, creatorId: 'u1', kind: 'landing' })
+    await db.run(sql`UPDATE matters SET status = 'trashed' WHERE id = ${matter.id}`)
+
+    const result = await resolveShareByToken(db, share.token)
+    expect(result.status).toBe('matter_trashed')
+  })
+})
+
+// ─── computeSourceBytes ───────────────────────────────────────────────────────
+
+describe('computeSourceBytes', () => {
+  it('returns file size for a single file matter', async () => {
+    const { db } = await createTestApp()
+    await insertStorage(db)
+    const orgId = nanoid()
+    const matter = await seedMatter(db, { orgId, size: 5000 })
+    const bytes = await computeSourceBytes(db, matter)
+    expect(bytes).toBe(5000)
+  })
+
+  it('returns sum of all files in a folder tree', async () => {
+    const { db } = await createTestApp()
+    await insertStorage(db)
+    const orgId = nanoid()
+    const folder = await seedMatter(db, { orgId, dirtype: DirType.USER_FOLDER, name: 'Photos', size: 0 })
+    const folderPath = folder.name
+    await seedMatter(db, { orgId, parent: folderPath, size: 1000 })
+    await seedMatter(db, { orgId, parent: folderPath, size: 2000 })
+
+    const bytes = await computeSourceBytes(db, folder)
+    expect(bytes).toBe(3000)
+  })
+
+  it('returns 0 for empty folder', async () => {
+    const { db } = await createTestApp()
+    await insertStorage(db)
+    const orgId = nanoid()
+    const folder = await seedMatter(db, { orgId, dirtype: DirType.USER_FOLDER, name: 'Empty', size: 0 })
+    const bytes = await computeSourceBytes(db, folder)
+    expect(bytes).toBe(0)
+  })
+})
+
+// ─── isQuotaSufficient ────────────────────────────────────────────────────────
+
+describe('isQuotaSufficient', () => {
+  it('returns true when no quota row exists (unlimited)', async () => {
+    const { db } = await createTestApp()
+    const orgId = nanoid()
+    expect(await isQuotaSufficient(db, orgId, 9999999)).toBe(true)
+  })
+
+  it('returns true when quota is 0 (unlimited)', async () => {
+    const { db } = await createTestApp()
+    const orgId = nanoid()
+    await seedOrgQuota(db, orgId, 0)
+    expect(await isQuotaSufficient(db, orgId, 9999999)).toBe(true)
+  })
+
+  it('returns true when bytes fit within quota', async () => {
+    const { db } = await createTestApp()
+    const orgId = nanoid()
+    await seedOrgQuota(db, orgId, 10000, 0)
+    expect(await isQuotaSufficient(db, orgId, 5000)).toBe(true)
+  })
+
+  it('returns false when bytes exceed remaining quota', async () => {
+    const { db } = await createTestApp()
+    const orgId = nanoid()
+    await seedOrgQuota(db, orgId, 10000, 9500)
+    expect(await isQuotaSufficient(db, orgId, 600)).toBe(false)
+  })
+})
+
+// ─── saveShareToDrive ─────────────────────────────────────────────────────────
+
+describe('saveShareToDrive', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(S3Service.prototype, 'copyObject').mockResolvedValue(undefined)
+    vi.spyOn(S3Service.prototype, 'streamCopy').mockResolvedValue(undefined)
+  })
+
+  it('saves a single file to target org (same storage)', async () => {
+    const { db } = await createTestApp()
+    await insertStorage(db)
+    const srcOrgId = nanoid()
+    const dstOrgId = nanoid()
+    const matter = await seedMatter(db, { orgId: srcOrgId, size: 2048 })
+    const share = await createShare(db, { matterId: matter.id, orgId: srcOrgId, creatorId: 'u1', kind: 'landing' })
+
+    if (share.status === 'revoked') throw new Error('test setup failed')
+
+    const result = await saveShareToDrive(db, {
+      share,
+      matter,
+      currentUserId: 'u2',
+      targetOrgId: dstOrgId,
+      targetParent: '',
+    })
+
+    expect(result.saved).toHaveLength(1)
+    expect(result.skipped).toHaveLength(0)
+    expect(result.saved[0].orgId).toBe(dstOrgId)
+    expect(result.saved[0].name).toBe(matter.name)
+    expect(result.saved[0].status).toBe('active')
+  })
+
+  it('uses streamCopy for cross-storage save', async () => {
+    const { db } = await createTestApp()
+    // STORAGE_ID is the source storage; make it full so selectStorage skips it as target
+    await insertStorage(db, STORAGE_ID)
+    await insertStorage(db, ALT_STORAGE_ID)
+    // Mark source storage as at capacity so selectStorage picks ALT_STORAGE_ID as target
+    await db.run(sql`UPDATE storages SET capacity = 1, used = 1 WHERE id = ${STORAGE_ID}`)
+
+    const srcOrgId = nanoid()
+    const dstOrgId = nanoid()
+    const matter = await seedMatter(db, { orgId: srcOrgId, storageId: STORAGE_ID, size: 1024 })
+    const share = await createShare(db, { matterId: matter.id, orgId: srcOrgId, creatorId: 'u1', kind: 'landing' })
+
+    const streamCopySpy = vi.spyOn(S3Service.prototype, 'streamCopy').mockResolvedValue(undefined)
+
+    if (share.status === 'revoked') throw new Error('test setup failed')
+
+    await saveShareToDrive(db, {
+      share,
+      matter,
+      currentUserId: 'u2',
+      targetOrgId: dstOrgId,
+      targetParent: '',
+    })
+
+    // copyObject (same-storage) must NOT have been used; streamCopy MUST have been called
+    expect(streamCopySpy).toHaveBeenCalled()
+  })
+
+  it('auto-renames file when name already exists in target org', async () => {
+    const { db } = await createTestApp()
+    await insertStorage(db)
+    const srcOrgId = nanoid()
+    const dstOrgId = nanoid()
+    const fileName = `photo-${nanoid(4)}.pdf`
+    const matter = await seedMatter(db, { orgId: srcOrgId, name: fileName, size: 1024 })
+    const share = await createShare(db, { matterId: matter.id, orgId: srcOrgId, creatorId: 'u1', kind: 'landing' })
+
+    // Pre-create a file with the same name in the target org
+    await seedMatter(db, { orgId: dstOrgId, name: fileName })
+
+    if (share.status === 'revoked') throw new Error('test setup failed')
+
+    const result = await saveShareToDrive(db, {
+      share,
+      matter,
+      currentUserId: 'u2',
+      targetOrgId: dstOrgId,
+      targetParent: '',
+    })
+
+    expect(result.saved).toHaveLength(1)
+    // Name should have been renamed (not equal to original)
+    expect(result.saved[0].name).not.toBe(fileName)
+    expect(result.saved[0].name).toContain('photo-')
+  })
+
+  it('records activity with save_from_share action', async () => {
+    const { db } = await createTestApp()
+    await insertStorage(db)
+    const srcOrgId = nanoid()
+    const dstOrgId = nanoid()
+    const matter = await seedMatter(db, { orgId: srcOrgId, size: 512 })
+    const share = await createShare(db, { matterId: matter.id, orgId: srcOrgId, creatorId: 'u1', kind: 'landing' })
+
+    if (share.status === 'revoked') throw new Error('test setup failed')
+
+    await saveShareToDrive(db, {
+      share,
+      matter,
+      currentUserId: 'u2',
+      targetOrgId: dstOrgId,
+      targetParent: '',
+    })
+
+    const activities = await getActivities(db, dstOrgId)
+    expect(activities).toHaveLength(1)
+    expect(activities[0].action).toBe('save_from_share')
+    expect(activities[0].userId).toBe('u2')
+
+    const metadata = JSON.parse(activities[0].metadata ?? '{}')
+    expect(metadata.sourceShareId).toBe(share.id)
+  })
+
+  it('does NOT increment share downloads counter', async () => {
+    const { db } = await createTestApp()
+    await insertStorage(db)
+    const srcOrgId = nanoid()
+    const dstOrgId = nanoid()
+    const matter = await seedMatter(db, { orgId: srcOrgId, size: 512 })
+    const share = await createShare(db, { matterId: matter.id, orgId: srcOrgId, creatorId: 'u1', kind: 'landing' })
+
+    if (share.status === 'revoked') throw new Error('test setup failed')
+
+    const downloadsBefore = share.downloads
+
+    await saveShareToDrive(db, {
+      share,
+      matter,
+      currentUserId: 'u2',
+      targetOrgId: dstOrgId,
+      targetParent: '',
+    })
+
+    const updatedShare = await getShare(db, share.id)
+    expect(updatedShare?.downloads).toBe(downloadsBefore)
+  })
+
+  it('increments target org quota usage after save', async () => {
+    const { db } = await createTestApp()
+    await insertStorage(db)
+    const srcOrgId = nanoid()
+    const dstOrgId = nanoid()
+    const fileSize = 4096
+    const matter = await seedMatter(db, { orgId: srcOrgId, size: fileSize })
+    const share = await createShare(db, { matterId: matter.id, orgId: srcOrgId, creatorId: 'u1', kind: 'landing' })
+
+    // Set up a quota row for target org
+    await seedOrgQuota(db, dstOrgId, 100000, 0)
+
+    if (share.status === 'revoked') throw new Error('test setup failed')
+
+    await saveShareToDrive(db, {
+      share,
+      matter,
+      currentUserId: 'u2',
+      targetOrgId: dstOrgId,
+      targetParent: '',
+    })
+
+    const rows = await db.select().from(orgQuotas).where(sql`org_id = ${dstOrgId}`)
+    expect(rows[0]?.used).toBe(fileSize)
+  })
+
+  it('recursively copies a folder tree to target org', async () => {
+    const { db } = await createTestApp()
+    await insertStorage(db)
+    const srcOrgId = nanoid()
+    const dstOrgId = nanoid()
+
+    // Build source tree: Photos/ → [img1.jpg, img2.jpg, Sub/ → [img3.jpg]]
+    const folder = await seedMatter(db, { orgId: srcOrgId, dirtype: DirType.USER_FOLDER, name: 'Photos', size: 0 })
+    await seedMatter(db, { orgId: srcOrgId, parent: 'Photos', name: 'img1.jpg', size: 100 })
+    await seedMatter(db, { orgId: srcOrgId, parent: 'Photos', name: 'img2.jpg', size: 200 })
+    const sub = await seedMatter(db, {
+      orgId: srcOrgId,
+      dirtype: DirType.USER_FOLDER,
+      parent: 'Photos',
+      name: 'Sub',
+      size: 0,
+    })
+    await seedMatter(db, { orgId: srcOrgId, parent: 'Photos/Sub', name: 'img3.jpg', size: 300 })
+
+    const share = await createShare(db, { matterId: folder.id, orgId: srcOrgId, creatorId: 'u1', kind: 'landing' })
+
+    if (share.status === 'revoked' || !sub) throw new Error('test setup failed')
+
+    const result = await saveShareToDrive(db, {
+      share,
+      matter: folder,
+      currentUserId: 'u2',
+      targetOrgId: dstOrgId,
+      targetParent: '',
+    })
+
+    expect(result.skipped).toHaveLength(0)
+    // 1 root folder + 1 sub folder + 3 files = 5
+    expect(result.saved).toHaveLength(5)
+
+    const dstMatters = await getMattersInOrg(db, dstOrgId)
+    expect(dstMatters).toHaveLength(5)
+
+    const dstFolder = dstMatters.find((m) => m.dirtype !== DirType.FILE && m.parent === '')
+    expect(dstFolder?.name).toBe('Photos')
+  })
+
+  it('quota check blocks file save when quota exceeded atomically', async () => {
+    const { db } = await createTestApp()
+    await insertStorage(db)
+    const srcOrgId = nanoid()
+    const dstOrgId = nanoid()
+    const matter = await seedMatter(db, { orgId: srcOrgId, size: 5000 })
+    const share = await createShare(db, { matterId: matter.id, orgId: srcOrgId, creatorId: 'u1', kind: 'landing' })
+
+    // Set quota below file size
+    await seedOrgQuota(db, dstOrgId, 1000, 0)
+
+    if (share.status === 'revoked') throw new Error('test setup failed')
+
+    // The service's atomic increment will catch quota exceeded
+    await expect(
+      saveShareToDrive(db, {
+        share,
+        matter,
+        currentUserId: 'u2',
+        targetOrgId: dstOrgId,
+        targetParent: '',
+      }),
+    ).rejects.toThrow('QUOTA_EXCEEDED')
+
+    // No matters should have been created
+    const dstMatters = await getMattersInOrg(db, dstOrgId)
+    expect(dstMatters).toHaveLength(0)
+  })
+})
+
+// ─── Route-level integration tests ───────────────────────────────────────────
+
+describe('POST /api/shares/:token/save', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(S3Service.prototype, 'copyObject').mockResolvedValue(undefined)
+    vi.spyOn(S3Service.prototype, 'streamCopy').mockResolvedValue(undefined)
+  })
+
+  async function setup() {
+    const { app, db } = await createTestApp()
+    await insertStorage(db)
+    const srcOrgId = nanoid()
+
+    const matter = await seedMatter(db, { orgId: srcOrgId, size: 512 })
+    const share = await createShare(db, { matterId: matter.id, orgId: srcOrgId, creatorId: 'u1', kind: 'landing' })
+
+    // Create an authenticated user with their personal org
+    const headers = await authedHeaders(app)
+
+    // Get the user's personal org ID
+    const sessionRes = await app.request('/api/auth/get-session', { headers: new Headers(headers) })
+    const sessionData = (await sessionRes.json()) as { user?: { id?: string } }
+    const userId: string = sessionData?.user?.id ?? ''
+
+    const orgRows = await db.all<{ id: string }>(sql`
+      SELECT id FROM organization WHERE slug LIKE ${'personal-' + userId} LIMIT 1
+    `)
+    const personalOrgId = orgRows[0]?.id ?? ''
+
+    return { app, db, share, matter, srcOrgId, headers, personalOrgId }
+  }
+
+  it('returns 401 without authentication', async () => {
+    const { app, share } = await setup()
+    const res = await app.request(`/api/shares/${share.token}/save`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ targetOrgId: 'any-org' }),
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 404 for unknown token', async () => {
+    const { app, headers, personalOrgId } = await setup()
+    const res = await app.request('/api/shares/nonexistent-tok/save', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ targetOrgId: personalOrgId }),
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 410 when shared matter is trashed', async () => {
+    const { app, db, share, matter, headers, personalOrgId } = await setup()
+    await db.run(sql`UPDATE matters SET status = 'trashed' WHERE id = ${matter.id}`)
+
+    const res = await app.request(`/api/shares/${share.token}/save`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ targetOrgId: personalOrgId }),
+    })
+    expect(res.status).toBe(410)
+  })
+
+  it('returns 404 when share is revoked', async () => {
+    const { app, db, share, headers, personalOrgId } = await setup()
+    await db.run(sql`UPDATE shares SET status = 'revoked' WHERE id = ${share.id}`)
+
+    const res = await app.request(`/api/shares/${share.token}/save`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ targetOrgId: personalOrgId }),
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 400 DIRECT_SAVE_FORBIDDEN for direct-kind shares', async () => {
+    const { app, db, headers, personalOrgId } = await setup()
+    const srcOrgId = nanoid()
+    const m = await seedMatter(db, { orgId: srcOrgId })
+    const directShare = await createShare(db, { matterId: m.id, orgId: srcOrgId, creatorId: 'u1', kind: 'direct' })
+
+    const res = await app.request(`/api/shares/${directShare.token}/save`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ targetOrgId: personalOrgId }),
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { code?: string }
+    expect(body.code).toBe('DIRECT_SAVE_FORBIDDEN')
+  })
+
+  it('returns 401 when password-protected share requires cookie and user is not recipient', async () => {
+    const { app, db, headers, personalOrgId } = await setup()
+    const srcOrgId = nanoid()
+    const m = await seedMatter(db, { orgId: srcOrgId })
+    const pwShare = await createShare(db, {
+      matterId: m.id,
+      orgId: srcOrgId,
+      creatorId: 'u1',
+      kind: 'landing',
+      password: 'secret123',
+    })
+
+    const res = await app.request(`/api/shares/${pwShare.token}/save`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ targetOrgId: personalOrgId }),
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('allows recipient to save password-protected share without cookie', async () => {
+    const { app, db, headers, personalOrgId } = await setup()
+
+    // Get the current user's ID
+    const sessionRes = await app.request('/api/auth/get-session', { headers: new Headers(headers) })
+    const sessionData = (await sessionRes.json()) as { user?: { id?: string } }
+    const userId: string = sessionData?.user?.id ?? ''
+
+    const srcOrgId = nanoid()
+    const m = await seedMatter(db, { orgId: srcOrgId, size: 256 })
+    const pwShare = await createShare(db, {
+      matterId: m.id,
+      orgId: srcOrgId,
+      creatorId: 'u1',
+      kind: 'landing',
+      password: 'secret123',
+      recipients: [{ recipientUserId: userId }],
+    })
+
+    const res = await app.request(`/api/shares/${pwShare.token}/save`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ targetOrgId: personalOrgId }),
+    })
+    expect(res.status).toBe(201)
+  })
+
+  it('returns 403 when user has viewer role in target org', async () => {
+    const { app, db, share, headers } = await setup()
+
+    // Create an org where the current user has viewer role
+    const viewerOrgId = nanoid()
+    await db.run(sql`
+      INSERT INTO organization (id, name, slug, created_at) VALUES (${viewerOrgId}, 'Test Org', ${nanoid()}, ${Date.now()})
+    `)
+
+    // Get user ID
+    const sessionRes = await app.request('/api/auth/get-session', { headers: new Headers(headers) })
+    const sessionData = (await sessionRes.json()) as { user?: { id?: string } }
+    const userId: string = sessionData?.user?.id ?? ''
+
+    await db.run(sql`
+      INSERT INTO member (id, organization_id, user_id, role, created_at)
+      VALUES (${nanoid()}, ${viewerOrgId}, ${userId}, 'viewer', ${Date.now()})
+    `)
+
+    const res = await app.request(`/api/shares/${share.token}/save`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ targetOrgId: viewerOrgId }),
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 400 QUOTA_EXCEEDED when target org has insufficient quota', async () => {
+    const { app, db, share, headers } = await setup()
+
+    // Get the current user's ID to add them as editor in the quota-restricted org
+    const sessionRes = await app.request('/api/auth/get-session', { headers: new Headers(headers) })
+    const sessionData = (await sessionRes.json()) as { user?: { id?: string } }
+    const userId: string = sessionData?.user?.id ?? ''
+
+    // Create a fresh org with a tight quota (avoids the auto-created personal-org quota)
+    const quotaOrgId = nanoid()
+    await db.run(sql`
+      INSERT INTO organization (id, name, slug, created_at)
+      VALUES (${quotaOrgId}, 'Quota Org', ${nanoid()}, ${Date.now()})
+    `)
+    await db.run(sql`
+      INSERT INTO member (id, organization_id, user_id, role, created_at)
+      VALUES (${nanoid()}, ${quotaOrgId}, ${userId}, 'editor', ${Date.now()})
+    `)
+    // Insert a tight quota row for this org (only 100 bytes allowed)
+    await db.insert(orgQuotas).values({ id: nanoid(), orgId: quotaOrgId, quota: 100, used: 0 })
+
+    // The share from setup() has a matter with size 512 — well above the 100-byte quota
+    const res = await app.request(`/api/shares/${share.token}/save`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ targetOrgId: quotaOrgId }),
+    })
+
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { code?: string }
+    expect(body.code).toBe('QUOTA_EXCEEDED')
+  })
+
+  it('successfully saves a landing single-file share', async () => {
+    const { app, share, headers, personalOrgId } = await setup()
+
+    const res = await app.request(`/api/shares/${share.token}/save`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ targetOrgId: personalOrgId }),
+    })
+
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as { saved: Array<{ orgId: string }> }
+    expect(body.saved).toHaveLength(1)
+    expect(body.saved[0].orgId).toBe(personalOrgId)
+  })
+
+  it('downloads counter does NOT increment after save', async () => {
+    const { app, db, share, headers, personalOrgId } = await setup()
+
+    const downloadsBefore = share.downloads
+
+    await app.request(`/api/shares/${share.token}/save`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ targetOrgId: personalOrgId }),
+    })
+
+    const updatedShare = await getShare(db, share.id)
+    expect(updatedShare?.downloads).toBe(downloadsBefore)
+  })
+
+  it('activity_events row created with save_from_share and sourceShareId metadata', async () => {
+    const { app, db, share, headers, personalOrgId } = await setup()
+
+    await app.request(`/api/shares/${share.token}/save`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ targetOrgId: personalOrgId }),
+    })
+
+    const activities = await getActivities(db, personalOrgId)
+    expect(activities.length).toBeGreaterThan(0)
+
+    const saveActivity = activities.find((a) => a.action === 'save_from_share')
+    expect(saveActivity).toBeTruthy()
+    const metadata = JSON.parse(saveActivity?.metadata ?? '{}')
+    expect(metadata.sourceShareId).toBe(share.id)
+  })
+})

--- a/server/services/save-to-drive.ts
+++ b/server/services/save-to-drive.ts
@@ -1,0 +1,258 @@
+import { and, eq, like, or } from 'drizzle-orm'
+import { DirType } from '../../shared/constants'
+import type { Storage as S3StorageType } from '../../shared/types'
+import { matters, orgQuotas, shareRecipients, shares } from '../db/schema'
+import type { Database } from '../platform/interface'
+import { recordActivity } from './activity'
+import type { Matter } from './matter'
+import { createMatter, incrementUsageIfAllowed } from './matter'
+import { buildObjectKey } from './path-template'
+import { S3Service } from './s3'
+import type { Share, ShareRecipient } from './share'
+import { getStorage, selectStorage } from './storage'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type ShareResolution =
+  | { status: 'ok'; share: Share; matter: Matter; recipients: ShareRecipient[] }
+  | { status: 'not_found' | 'revoked' | 'matter_trashed' }
+
+export interface SaveShareInput {
+  share: Share
+  matter: Matter
+  currentUserId: string
+  targetOrgId: string
+  targetParent: string
+}
+
+export interface SaveShareResult {
+  saved: Matter[]
+  skipped: Array<{ name: string; reason: string }>
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+const s3 = new S3Service()
+
+function fileExt(name: string): string {
+  const dot = name.lastIndexOf('.')
+  return dot >= 0 ? name.slice(dot) : ''
+}
+
+function buildPath(parent: string, name: string): string {
+  return parent ? `${parent}/${name}` : name
+}
+
+async function getDirectActiveChildren(db: Database, orgId: string, folderPath: string): Promise<Matter[]> {
+  return db
+    .select()
+    .from(matters)
+    .where(and(eq(matters.orgId, orgId), eq(matters.parent, folderPath), eq(matters.status, 'active')))
+}
+
+// ─── Share resolution ─────────────────────────────────────────────────────────
+
+export async function resolveShareByToken(db: Database, token: string): Promise<ShareResolution> {
+  const rows = await db
+    .select({ share: shares, matter: matters })
+    .from(shares)
+    .innerJoin(matters, eq(shares.matterId, matters.id))
+    .where(eq(shares.token, token))
+
+  const row = rows[0]
+  if (!row) return { status: 'not_found' }
+  if (row.share.status === 'revoked') return { status: 'revoked' }
+  if (row.matter.status === 'trashed') return { status: 'matter_trashed' }
+
+  const recipientRows = await db.select().from(shareRecipients).where(eq(shareRecipients.shareId, row.share.id))
+
+  return { status: 'ok', share: row.share, matter: row.matter, recipients: recipientRows }
+}
+
+// ─── Quota helpers ────────────────────────────────────────────────────────────
+
+export async function computeSourceBytes(db: Database, matter: Matter): Promise<number> {
+  if (matter.dirtype === DirType.FILE) return matter.size ?? 0
+
+  const folderPath = buildPath(matter.parent, matter.name)
+  const rows = await db
+    .select({ size: matters.size })
+    .from(matters)
+    .where(
+      and(
+        eq(matters.orgId, matter.orgId),
+        eq(matters.status, 'active'),
+        eq(matters.dirtype, DirType.FILE),
+        or(eq(matters.parent, folderPath), like(matters.parent, `${folderPath}/%`)),
+      ),
+    )
+  return rows.reduce((acc, r) => acc + (r.size ?? 0), 0)
+}
+
+export async function isQuotaSufficient(db: Database, orgId: string, bytes: number): Promise<boolean> {
+  if (bytes <= 0) return true
+  const rows = await db
+    .select({ quota: orgQuotas.quota, used: orgQuotas.used })
+    .from(orgQuotas)
+    .where(eq(orgQuotas.orgId, orgId))
+  const row = rows[0]
+  if (!row || row.quota === 0) return true
+  return row.used + bytes <= row.quota
+}
+
+// ─── File copy ────────────────────────────────────────────────────────────────
+
+async function saveFile(
+  db: Database,
+  sourceMatter: Matter,
+  sourceStorage: S3StorageType,
+  targetStorage: S3StorageType,
+  currentUserId: string,
+  targetOrgId: string,
+  targetParent: string,
+  shareId: string,
+): Promise<Matter> {
+  const bytes = sourceMatter.size ?? 0
+
+  if (bytes > 0) {
+    const allowed = await incrementUsageIfAllowed(db, targetOrgId, targetStorage.id, bytes)
+    if (!allowed) throw new Error('QUOTA_EXCEEDED')
+  }
+
+  const dstKey = buildObjectKey({ uid: currentUserId, orgId: targetOrgId, rawExt: fileExt(sourceMatter.name) })
+
+  if (sourceStorage.id === targetStorage.id) {
+    await s3.copyObject(sourceStorage, sourceMatter.object, targetStorage, dstKey)
+  } else {
+    await s3.streamCopy(sourceStorage, sourceMatter.object, targetStorage, dstKey)
+  }
+
+  const newMatter = await createMatter(db, {
+    orgId: targetOrgId,
+    name: sourceMatter.name,
+    type: sourceMatter.type,
+    size: bytes ?? undefined,
+    dirtype: DirType.FILE,
+    parent: targetParent,
+    object: dstKey,
+    storageId: targetStorage.id,
+    status: 'active',
+    onConflict: 'rename',
+  })
+
+  await recordActivity(db, {
+    orgId: targetOrgId,
+    userId: currentUserId,
+    action: 'save_from_share',
+    targetType: 'file',
+    targetId: newMatter.id,
+    targetName: newMatter.name,
+    metadata: { sourceShareId: shareId },
+  })
+
+  return newMatter
+}
+
+// ─── Folder recursive copy ────────────────────────────────────────────────────
+
+async function saveFolderRecursive(
+  db: Database,
+  sourceFolderMatter: Matter,
+  sourceStorage: S3StorageType,
+  targetStorage: S3StorageType,
+  currentUserId: string,
+  targetOrgId: string,
+  targetParent: string,
+  shareId: string,
+): Promise<SaveShareResult> {
+  const saved: Matter[] = []
+  const skipped: Array<{ name: string; reason: string }> = []
+
+  const rootFolder = await createMatter(db, {
+    orgId: targetOrgId,
+    name: sourceFolderMatter.name,
+    type: 'folder',
+    size: 0,
+    dirtype: sourceFolderMatter.dirtype ?? undefined,
+    parent: targetParent,
+    object: '',
+    storageId: targetStorage.id,
+    status: 'active',
+    onConflict: 'rename',
+  })
+  saved.push(rootFolder)
+
+  const sourceRootPath = buildPath(sourceFolderMatter.parent, sourceFolderMatter.name)
+  const targetRootPath = buildPath(targetParent, rootFolder.name)
+
+  // BFS: pairs of (source folder path, target folder path)
+  const queue: Array<{ sourcePath: string; targetPath: string }> = [
+    { sourcePath: sourceRootPath, targetPath: targetRootPath },
+  ]
+
+  while (queue.length > 0) {
+    const { sourcePath, targetPath } = queue.shift()!
+    const children = await getDirectActiveChildren(db, sourceFolderMatter.orgId, sourcePath)
+
+    for (const child of children) {
+      if (child.dirtype === DirType.FILE) {
+        try {
+          const newFile = await saveFile(
+            db,
+            child,
+            sourceStorage,
+            targetStorage,
+            currentUserId,
+            targetOrgId,
+            targetPath,
+            shareId,
+          )
+          saved.push(newFile)
+        } catch (e) {
+          skipped.push({ name: child.name, reason: (e as Error).message })
+        }
+      } else {
+        const newFolder = await createMatter(db, {
+          orgId: targetOrgId,
+          name: child.name,
+          type: 'folder',
+          size: 0,
+          dirtype: child.dirtype ?? undefined,
+          parent: targetPath,
+          object: '',
+          storageId: targetStorage.id,
+          status: 'active',
+          onConflict: 'rename',
+        })
+        saved.push(newFolder)
+        queue.push({
+          sourcePath: buildPath(child.parent, child.name),
+          targetPath: buildPath(targetPath, newFolder.name),
+        })
+      }
+    }
+  }
+
+  return { saved, skipped }
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export async function saveShareToDrive(db: Database, input: SaveShareInput): Promise<SaveShareResult> {
+  const { share, matter: sourceMatter, currentUserId, targetOrgId, targetParent } = input
+
+  const sourceStorage = await getStorage(db, sourceMatter.storageId)
+  if (!sourceStorage) throw new Error('Source storage not found')
+
+  const targetStorage = await selectStorage(db, 'private')
+
+  const src = sourceStorage as unknown as S3StorageType
+  const dst = targetStorage as unknown as S3StorageType
+
+  if (sourceMatter.dirtype === DirType.FILE) {
+    const newMatter = await saveFile(db, sourceMatter, src, dst, currentUserId, targetOrgId, targetParent, share.id)
+    return { saved: [newMatter], skipped: [] }
+  }
+
+  return saveFolderRecursive(db, sourceMatter, src, dst, currentUserId, targetOrgId, targetParent, share.id)
+}

--- a/shared/schemas/share.ts
+++ b/shared/schemas/share.ts
@@ -27,3 +27,11 @@ export const listSharesQuerySchema = z.object({
   pageSize: z.coerce.number().int().positive().default(20),
   status: z.enum(['active', 'revoked']).optional(),
 })
+
+export const saveShareRequestSchema = z.object({
+  targetOrgId: z.string().min(1),
+  targetParent: z.string().default(''),
+  targetSubpath: z.array(z.string()).optional(),
+})
+
+export type SaveShareRequest = z.infer<typeof saveShareRequestSchema>


### PR DESCRIPTION
## Summary

- Adds `POST /api/shares/:token/save` endpoint for saving shared files/folders to the current user's workspace
- `resolveShareByToken` distinguishes `matter_trashed` (410) from `not_found`/`revoked` (404)
- Same-storage copy uses S3 `CopyObject`; cross-storage copy uses server-side `GetObject→PutObject` stream
- Pre-flight quota check (`computeSourceBytes` + `isQuotaSufficient`) returns 400 `QUOTA_EXCEEDED` if target org is over quota
- Recursive BFS folder copy with `onConflict:'rename'` for automatic name deduplication
- Activity event recorded per saved file with `action:'save_from_share'` and `sourceShareId` metadata
- Password-protected shares: recipients bypass cookie check; others require `sharetk_<token>` cookie
- Direct-kind shares (`kind:'direct'`) are rejected with 400 `DIRECT_SAVE_FORBIDDEN`
- Role gate: target org must be personal org or user must have `editor+` role

## Test plan

- [x] Integration tests (Node/SQLite): service unit tests for `resolveShareByToken`, `computeSourceBytes`, `isQuotaSufficient`, `saveShareToDrive` + HTTP route tests covering all error paths and success cases
- [x] CF Worker tests (D1): resolve, revoke, trashed, single-file save, downloads counter, recursive folder save
- [x] `npm run typecheck` — no errors
- [x] `npm run test` (integration) — 540/540 passed
- [x] `npm run test:cf` — 31/31 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)