### PR TITLE
feat: avatar upload for Settings -> Profile (v2.5.0 T7)

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -14,7 +14,7 @@ import ihostConfig from './routes/ihost-config'
 import { adminInviteCodes, publicInviteCodes } from './routes/invite-codes'
 import { notifications } from './routes/notifications'
 import objects from './routes/objects'
-import profile from './routes/profile'
+import profile, { profileMe } from './routes/profile'
 import { adminQuotas, userQuotas } from './routes/quotas'
 import redirect from './routes/redirect'
 import { authedShares, publicShares } from './routes/shares'
@@ -57,6 +57,8 @@ export function createApp(platform: Platform, auth: Auth) {
   app.route('/api/auth-providers', publicAuthProviders)
 
   app.use('/api/*', authMiddleware)
+
+  app.route('/api/profile', profileMe)
 
   // Mount routes separately to avoid deep type chain accumulation.
   // Each .route() call is independent — TypeScript doesn't stack types.
@@ -105,3 +107,4 @@ export type PublicTeamsRoute = typeof publicTeams
 export type NotificationsRoute = typeof notifications
 export type IhostRoute = typeof ihost
 export type IhostConfigRoute = typeof ihostConfig
+export type ProfileMeRoute = typeof profileMe

--- a/server/routes/profile.integration.test.ts
+++ b/server/routes/profile.integration.test.ts
@@ -1,7 +1,8 @@
 import { sql } from 'drizzle-orm'
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { buildBreadcrumb } from '../services/profile.js'
-import { createTestApp } from '../test/setup.js'
+import { S3Service } from '../services/s3.js'
+import { authedHeaders, createTestApp } from '../test/setup.js'
 
 async function insertUser(
   db: Awaited<ReturnType<typeof createTestApp>>['db'],
@@ -21,6 +22,14 @@ async function insertUser(
     VALUES (${`member-${opts.id}`}, ${`org-${opts.id}`}, ${opts.id}, 'owner', ${now})
   `)
   return { orgId: `org-${opts.id}` }
+}
+
+async function insertStorage(db: Awaited<ReturnType<typeof createTestApp>>['db']) {
+  const now = Date.now()
+  await db.run(sql`
+    INSERT INTO storages (id, title, mode, bucket, endpoint, region, access_key, secret_key, file_path, custom_host, capacity, used, status, created_at, updated_at)
+    VALUES ('st-1', 'Test S3', 'public', 'test-bucket', 'https://s3.amazonaws.com', 'us-east-1', 'AKID', 'secret', '', '', 0, 0, 'active', ${now}, ${now})
+  `)
 }
 
 describe('GET /api/profiles/:username', () => {
@@ -103,5 +112,193 @@ describe('buildBreadcrumb', () => {
 
   it('returns two segments for one-level-deep path', () => {
     expect(buildBreadcrumb('Parent/Child')).toEqual(['Parent', 'Child'])
+  })
+})
+
+describe('POST /api/profile/avatar', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(S3Service.prototype, 'presignUpload').mockResolvedValue('https://presigned.example.com/upload')
+  })
+
+  it('returns 401 when not authenticated', async () => {
+    const { app } = await createTestApp()
+    const res = await app.request('/api/profile/avatar', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mime: 'image/png', size: 1024 }),
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when mime type is not allowed (gif is not accepted)', async () => {
+    const { app, db } = await createTestApp()
+    await insertStorage(db)
+    const headers = await authedHeaders(app)
+
+    const res = await app.request('/api/profile/avatar', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mime: 'image/gif', size: 1024 }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when size exceeds 2 MiB', async () => {
+    const { app, db } = await createTestApp()
+    await insertStorage(db)
+    const headers = await authedHeaders(app)
+
+    const res = await app.request('/api/profile/avatar', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mime: 'image/png', size: 3 * 1024 * 1024 }),
+    })
+    // Schema validation (zValidator) rejects sizes > MAX_AVATAR_SIZE with 400
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 503 when no public storage is configured', async () => {
+    const { app } = await createTestApp()
+    const headers = await authedHeaders(app)
+
+    const res = await app.request('/api/profile/avatar', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mime: 'image/png', size: 1024 }),
+    })
+    expect(res.status).toBe(503)
+  })
+
+  it('returns uploadUrl and key for valid png request', async () => {
+    const { app, db } = await createTestApp()
+    await insertStorage(db)
+    const headers = await authedHeaders(app)
+
+    const res = await app.request('/api/profile/avatar', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mime: 'image/png', size: 1024 }),
+    })
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as { uploadUrl: string; key: string }
+    expect(body.uploadUrl).toBe('https://presigned.example.com/upload')
+    expect(body.key).toMatch(/^_system\/avatars\/.+\.png$/)
+  })
+
+  it('returns key with jpg extension for jpeg mime', async () => {
+    const { app, db } = await createTestApp()
+    await insertStorage(db)
+    const headers = await authedHeaders(app)
+
+    const res = await app.request('/api/profile/avatar', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mime: 'image/jpeg', size: 2048 }),
+    })
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as { uploadUrl: string; key: string }
+    expect(body.key).toMatch(/\.jpg$/)
+  })
+})
+
+describe('POST /api/profile/avatar/commit', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(S3Service.prototype, 'headObject').mockResolvedValue({ size: 1024, contentType: 'image/png' })
+  })
+
+  it('returns 401 when not authenticated', async () => {
+    const { app } = await createTestApp()
+    const res = await app.request('/api/profile/avatar/commit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mime: 'image/png' }),
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when avatar object does not exist in S3', async () => {
+    vi.restoreAllMocks()
+    vi.spyOn(S3Service.prototype, 'headObject').mockRejectedValue(new Error('Not Found'))
+
+    const { app, db } = await createTestApp()
+    await insertStorage(db)
+    const headers = await authedHeaders(app)
+
+    const res = await app.request('/api/profile/avatar/commit', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mime: 'image/png' }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('persists user.image and returns image URL', async () => {
+    const { app, db } = await createTestApp()
+    await insertStorage(db)
+    const headers = await authedHeaders(app)
+
+    const res = await app.request('/api/profile/avatar/commit', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mime: 'image/jpeg' }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { image: string }
+    expect(body.image).toContain('_system/avatars/')
+    expect(body.image).toContain('.jpg')
+
+    const rows = await db.all<{ image: string | null }>(sql`SELECT image FROM user LIMIT 1`)
+    expect(rows[0]?.image).toBe(body.image)
+  })
+})
+
+describe('DELETE /api/profile/avatar', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(S3Service.prototype, 'headObject').mockResolvedValue({ size: 1024, contentType: 'image/png' })
+    vi.spyOn(S3Service.prototype, 'deleteObject').mockResolvedValue(undefined)
+  })
+
+  it('returns 401 when not authenticated', async () => {
+    const { app } = await createTestApp()
+    const res = await app.request('/api/profile/avatar', { method: 'DELETE' })
+    expect(res.status).toBe(401)
+  })
+
+  it('clears user.image and removes S3 object', async () => {
+    const { app, db } = await createTestApp()
+    await insertStorage(db)
+    const headers = await authedHeaders(app)
+
+    await db.run(sql`UPDATE user SET image = 'https://example.com/avatar.png'`)
+
+    const res = await app.request('/api/profile/avatar', {
+      method: 'DELETE',
+      headers,
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { ok: boolean }
+    expect(body.ok).toBe(true)
+
+    const rows = await db.all<{ image: string | null }>(sql`SELECT image FROM user LIMIT 1`)
+    expect(rows[0]?.image).toBeNull()
+    expect(S3Service.prototype.deleteObject).toHaveBeenCalled()
+  })
+
+  it('succeeds even when S3 object does not exist', async () => {
+    vi.restoreAllMocks()
+    vi.spyOn(S3Service.prototype, 'headObject').mockRejectedValue(new Error('Not Found'))
+
+    const { app, db } = await createTestApp()
+    await insertStorage(db)
+    const headers = await authedHeaders(app)
+
+    const res = await app.request('/api/profile/avatar', {
+      method: 'DELETE',
+      headers,
+    })
+    expect(res.status).toBe(200)
   })
 })

--- a/server/routes/profile.ts
+++ b/server/routes/profile.ts
@@ -1,6 +1,26 @@
+import { zValidator } from '@hono/zod-validator'
+import { eq } from 'drizzle-orm'
 import { Hono } from 'hono'
+import { AVATAR_MIMES, commitAvatarSchema, requestAvatarUploadSchema } from '../../shared/schemas'
+import type { Storage as S3Storage } from '../../shared/types'
+import { user } from '../db/auth-schema'
+import { requireAuth } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
 import { getUserByUsername } from '../services/profile'
+import { S3Service } from '../services/s3'
+import { selectStorage } from '../services/storage'
+
+const s3 = new S3Service()
+
+const MIME_TO_EXT: Record<(typeof AVATAR_MIMES)[number], string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/webp': 'webp',
+}
+
+function avatarKey(userId: string, mime: (typeof AVATAR_MIMES)[number]): string {
+  return `_system/avatars/${userId}.${MIME_TO_EXT[mime]}`
+}
 
 const app = new Hono<Env>()
   .get('/:username', async (c) => {
@@ -19,3 +39,74 @@ const app = new Hono<Env>()
   })
 
 export default app
+
+// ── Authenticated profile endpoints ──────────────────────────────────────────
+// Avatars must be publicly viewable — select public-mode storage whose bucket
+// is expected to allow unauthenticated GET (public-read ACL or equivalent).
+
+export const profileMe = new Hono<Env>()
+  .post('/avatar', requireAuth, zValidator('json', requestAvatarUploadSchema), async (c) => {
+    const userId = c.get('userId') as string
+    const { mime, size: _size } = c.req.valid('json')
+    // size is validated by schema (≤ MAX_AVATAR_SIZE); no manual check needed.
+
+    const db = c.get('platform').db
+    let storage: S3Storage
+    try {
+      storage = (await selectStorage(db, 'public')) as unknown as S3Storage
+    } catch (err) {
+      console.warn('[profile/avatar] no public storage available:', err)
+      return c.json({ error: 'No public storage configured for avatars' }, 503)
+    }
+
+    const key = avatarKey(userId, mime)
+    const uploadUrl = await s3.presignUpload(storage, key, mime)
+
+    return c.json({ uploadUrl, key }, 201)
+  })
+  .post('/avatar/commit', requireAuth, zValidator('json', commitAvatarSchema), async (c) => {
+    const userId = c.get('userId') as string
+    const { mime } = c.req.valid('json')
+
+    const db = c.get('platform').db
+    let storage: S3Storage
+    try {
+      storage = (await selectStorage(db, 'public')) as unknown as S3Storage
+    } catch (err) {
+      console.warn('[profile/avatar/commit] no public storage available:', err)
+      return c.json({ error: 'No public storage configured for avatars' }, 503)
+    }
+
+    const key = avatarKey(userId, mime)
+    try {
+      await s3.headObject(storage, key)
+    } catch {
+      return c.json({ error: 'Avatar object not found. Upload the file first.' }, 400)
+    }
+
+    // getPublicUrl assumes the bucket has public-read access (public-mode storage).
+    const imageUrl = s3.getPublicUrl(storage, key)
+    await db.update(user).set({ image: imageUrl }).where(eq(user.id, userId))
+
+    return c.json({ image: imageUrl })
+  })
+  .delete('/avatar', requireAuth, async (c) => {
+    const userId = c.get('userId') as string
+    const db = c.get('platform').db
+
+    // Clear the DB reference first — this is the authoritative action.
+    // S3 cleanup below is best-effort; orphaned objects are acceptable.
+    await db.update(user).set({ image: null }).where(eq(user.id, userId))
+
+    try {
+      const storage = (await selectStorage(db, 'public')) as unknown as S3Storage
+      // Delete all possible extension variants to avoid orphaned objects when
+      // the user has previously changed their avatar MIME type.
+      await Promise.allSettled(AVATAR_MIMES.map((mime) => s3.deleteObject(storage, avatarKey(userId, mime))))
+    } catch (err) {
+      // No storage or unreachable — ignore; DB is already cleared.
+      console.warn('[profile/avatar delete] S3 cleanup skipped:', err)
+    }
+
+    return c.json({ ok: true })
+  })

--- a/shared/schemas/index.ts
+++ b/shared/schemas/index.ts
@@ -150,3 +150,20 @@ export const listIhostImagesSchema = z.object({
   cursor: z.string().optional(),
   limit: z.coerce.number().int().min(1).max(200).default(50),
 })
+
+// ─── Avatar Upload ────────────────────────────────────────────────────────────
+
+export const AVATAR_MIMES = ['image/png', 'image/jpeg', 'image/webp'] as const
+export type AvatarMime = (typeof AVATAR_MIMES)[number]
+export const MAX_AVATAR_SIZE = 2 * 1024 * 1024 // 2 MiB
+
+export const requestAvatarUploadSchema = z.object({
+  mime: z.enum(AVATAR_MIMES),
+  size: z.number().int().positive().max(MAX_AVATAR_SIZE),
+})
+
+export type RequestAvatarUploadInput = z.infer<typeof requestAvatarUploadSchema>
+
+export const commitAvatarSchema = z.object({
+  mime: z.enum(AVATAR_MIMES),
+})

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -17,7 +17,7 @@ import {
   Video,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import {
   DropdownMenu,
@@ -67,7 +67,7 @@ export function AppSidebar() {
   const { data: session } = useSession()
   const { data: activeOrg } = useActiveOrganization()
   const { siteName } = useSiteOptions()
-  const user = session?.user as { name: string; username?: string; role?: string } | undefined
+  const user = session?.user as { name: string; username?: string; role?: string; image?: string | null } | undefined
   const isAdmin = user?.role === 'admin'
   const { data: quota } = useQuery({
     queryKey: ['user', 'quota'],
@@ -221,6 +221,7 @@ export function AppSidebar() {
                 <DropdownMenuTrigger asChild>
                   <SidebarMenuButton className="flex-1 data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground">
                     <Avatar size="sm">
+                      {user?.image && <AvatarImage src={user.image} alt={user.name || user.username || ''} />}
                       <AvatarFallback className="bg-sidebar-primary text-sidebar-primary-foreground text-xs font-semibold">
                         {user ? getInitials(user.name || user.username || '?') : '?'}
                       </AvatarFallback>

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -5,6 +5,7 @@ import {
   batchMoveObjects,
   batchTrashObjects,
   buildShareObjectUrl,
+  commitAvatar,
   confirmIhostImage,
   confirmUpload,
   copyObject,
@@ -13,6 +14,7 @@ import {
   createObject,
   createShare,
   createStorage,
+  deleteAvatar,
   deleteIhostConfig,
   deleteIhostImage,
   deleteObject,
@@ -43,6 +45,7 @@ import {
   listUsers,
   markAllNotificationsRead,
   markNotificationRead,
+  requestAvatarUpload,
   restoreObject,
   revokeIhostApiKey,
   saveShareToDrive,
@@ -1678,6 +1681,88 @@ describe('api', () => {
       vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Not found' }, false, 404))
 
       await expect(deleteIhostImage('bad-id')).rejects.toThrow()
+    })
+  })
+
+  describe('requestAvatarUpload', () => {
+    it('calls POST /api/profile/avatar with mime and size', async () => {
+      const draft = { uploadUrl: 'https://s3/presigned', key: '_system/avatars/user-1.png' }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(draft, true, 201))
+
+      await requestAvatarUpload({ mime: 'image/png', size: 1024 })
+
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toContain('/api/profile/avatar')
+      expect(init.method).toBe('POST')
+      const body = typeof init.body === 'string' ? JSON.parse(init.body) : null
+      expect(body?.mime).toBe('image/png')
+      expect(body?.size).toBe(1024)
+    })
+
+    it('resolves with uploadUrl and key', async () => {
+      const draft = { uploadUrl: 'https://s3/presigned', key: '_system/avatars/user-1.png' }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(draft, true, 201))
+
+      const result = await requestAvatarUpload({ mime: 'image/png', size: 1024 })
+
+      expect(result).toEqual(draft)
+    })
+
+    it('throws ApiError on failure', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'File too large' }, false, 400))
+
+      await expect(requestAvatarUpload({ mime: 'image/png', size: 999 })).rejects.toThrow('File too large')
+    })
+  })
+
+  describe('commitAvatar', () => {
+    it('calls POST /api/profile/avatar/commit with mime', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ image: 'https://example.com/avatar.jpg' }))
+
+      await commitAvatar({ mime: 'image/jpeg' })
+
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toContain('/api/profile/avatar/commit')
+      expect(init.method).toBe('POST')
+      const body = typeof init.body === 'string' ? JSON.parse(init.body) : null
+      expect(body?.mime).toBe('image/jpeg')
+    })
+
+    it('resolves with image URL', async () => {
+      const payload = { image: 'https://example.com/avatar.jpg' }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
+
+      const result = await commitAvatar({ mime: 'image/jpeg' })
+
+      expect(result).toEqual(payload)
+    })
+
+    it('throws ApiError on failure', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Object not found' }, false, 400))
+
+      await expect(commitAvatar({ mime: 'image/png' })).rejects.toThrow('Object not found')
+    })
+  })
+
+  describe('deleteAvatar', () => {
+    it('calls DELETE /api/profile/avatar', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true }),
+      } as unknown as Response)
+
+      await deleteAvatar()
+
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toContain('/api/profile/avatar')
+      expect(init.method).toBe('DELETE')
+    })
+
+    it('throws ApiError on failure', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Unauthorized' }, false, 401))
+
+      await expect(deleteAvatar()).rejects.toThrow()
     })
   })
 })

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,7 @@
 import type { OAuthProviderConfig } from '@shared/oauth-providers'
 import type {
   AllowedImageMime,
+  AvatarMime,
   ConflictStrategy,
   CreateShareRequest,
   CreateStorageInput,
@@ -29,6 +30,7 @@ import {
   inviteCodes,
   notificationsApi,
   objects,
+  profileMeApi,
   profiles,
   publicSharesApi,
   storages,
@@ -596,6 +598,29 @@ export function confirmIhostImage(id: string) {
 
 export async function deleteIhostImage(id: string) {
   const res = await ihostApi.images[':id'].$delete({ param: { id } })
+  if (!res.ok) {
+    const parsed = (await res.json().catch(() => ({}))) as ApiErrorBody
+    throw new ApiError(res.status, { ...parsed, error: parsed.error ?? res.statusText })
+  }
+}
+
+// Avatar Upload API
+
+export interface AvatarUploadDraft {
+  uploadUrl: string
+  key: string
+}
+
+export function requestAvatarUpload(data: { mime: AvatarMime; size: number }) {
+  return unwrap<AvatarUploadDraft>(profileMeApi.avatar.$post({ json: data }))
+}
+
+export function commitAvatar(data: { mime: AvatarMime }) {
+  return unwrap<{ image: string }>(profileMeApi.avatar.commit.$post({ json: data }))
+}
+
+export async function deleteAvatar() {
+  const res = await profileMeApi.avatar.$delete()
   if (!res.ok) {
     const parsed = (await res.json().catch(() => ({}))) as ApiErrorBody
     throw new ApiError(res.status, { ...parsed, error: parsed.error ?? res.statusText })

--- a/src/lib/rpc.ts
+++ b/src/lib/rpc.ts
@@ -9,6 +9,7 @@ import type {
   IhostRoute,
   NotificationsRoute,
   ObjectsRoute,
+  ProfileMeRoute,
   ProfileRoute,
   PublicSharesRoute,
   PublicTeamsRoute,
@@ -35,6 +36,7 @@ export const adminAuthProviders = hc<AdminAuthProvidersRoute>('/api/admin/auth-p
 export const inviteCodes = hc<AdminInviteCodesRoute>('/api/admin/invite-codes', opts)
 export const emailConfig = hc<EmailConfigRoute>('/api/admin/email-config', opts)
 export const profiles = hc<ProfileRoute>('/api/profiles')
+export const profileMeApi = hc<ProfileMeRoute>('/api/profile', opts)
 export const teamsApi = hc<TeamsRoute>('/api/teams', opts)
 export const publicTeamsApi = hc<PublicTeamsRoute>('/api/teams')
 export const notificationsApi = hc<NotificationsRoute>('/api/notifications', opts)

--- a/src/routes/_authenticated/settings/profile.tsx
+++ b/src/routes/_authenticated/settings/profile.tsx
@@ -1,15 +1,19 @@
 import { zodResolver } from '@hookform/resolvers/zod'
+import type { AvatarMime } from '@shared/schemas'
+import { AVATAR_MIMES, MAX_AVATAR_SIZE } from '@shared/schemas'
 import { useMutation } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { z } from 'zod'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { commitAvatar, deleteAvatar, requestAvatarUpload, uploadToS3 } from '@/lib/api'
 import { authClient, useSession } from '@/lib/auth-client'
 
 export const Route = createFileRoute('/_authenticated/settings/profile')({
@@ -21,6 +25,113 @@ const profileSchema = z.object({
 })
 
 type ProfileFormValues = z.infer<typeof profileSchema>
+
+function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2)
+}
+
+// refreshSession forces the auth client to re-fetch the session from the server
+// so that useSession() reflects DB changes made outside better-auth's updateUser.
+async function refreshSession() {
+  await authClient.getSession()
+}
+
+export function AvatarSection() {
+  const { t } = useTranslation()
+  const { data: session } = useSession()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const user = session?.user
+
+  const uploadMutation = useMutation({
+    mutationFn: async (file: File) => {
+      if (!AVATAR_MIMES.includes(file.type as AvatarMime)) {
+        throw new Error(t('settings.profile.avatar.invalidMime'))
+      }
+      if (file.size > MAX_AVATAR_SIZE) {
+        throw new Error(t('settings.profile.avatar.tooLarge'))
+      }
+      const draft = await requestAvatarUpload({ mime: file.type as AvatarMime, size: file.size })
+      await uploadToS3(draft.uploadUrl, file)
+      await commitAvatar({ mime: file.type as AvatarMime })
+      await refreshSession()
+    },
+    onSuccess: () => toast.success(t('settings.profile.avatar.uploaded')),
+    onError: (err) => toast.error(err instanceof Error ? err.message : String(err)),
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: async () => {
+      await deleteAvatar()
+      await refreshSession()
+    },
+    onSuccess: () => toast.success(t('settings.profile.avatar.removed')),
+    onError: (err) => toast.error(err instanceof Error ? err.message : String(err)),
+  })
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (file) uploadMutation.mutate(file)
+    e.target.value = ''
+  }
+
+  function handleDragOver(e: React.DragEvent) {
+    e.preventDefault()
+  }
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault()
+    const file = e.dataTransfer.files?.[0]
+    if (file) uploadMutation.mutate(file)
+  }
+
+  const isPending = uploadMutation.isPending || deleteMutation.isPending
+  const displayName = user?.name || (user as { username?: string })?.username || '?'
+
+  return (
+    <section
+      className="flex items-center gap-6"
+      aria-label={t('settings.profile.avatar.dropZone')}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+    >
+      <div className="relative">
+        <Avatar size="lg" className="size-16">
+          {user?.image && <AvatarImage src={user.image} alt={displayName} />}
+          <AvatarFallback className="text-lg font-semibold">{getInitials(displayName)}</AvatarFallback>
+        </Avatar>
+        {isPending && (
+          <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/40">
+            <span className="text-xs text-white">{t('common.loading')}</span>
+          </div>
+        )}
+      </div>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={AVATAR_MIMES.join(',')}
+        className="hidden"
+        onChange={handleFileChange}
+      />
+      <div className="flex flex-col gap-2">
+        <Button variant="outline" size="sm" disabled={isPending} onClick={() => fileInputRef.current?.click()}>
+          {t('settings.profile.avatar.upload')}
+        </Button>
+        {user?.image && (
+          <Button variant="ghost" size="sm" disabled={isPending} onClick={() => deleteMutation.mutate()}>
+            {t('settings.profile.avatar.remove')}
+          </Button>
+        )}
+        <p className="text-xs text-muted-foreground">{t('settings.profile.avatar.hint')}</p>
+      </div>
+    </section>
+  )
+}
 
 export function ProfileForm() {
   const { t } = useTranslation()
@@ -78,7 +189,11 @@ function ProfilePage() {
   const { t } = useTranslation()
 
   return (
-    <div className="max-w-lg">
+    <div className="max-w-lg space-y-4">
+      <Card className="gap-4 p-4 shadow-none">
+        <h3 className="text-sm font-medium text-muted-foreground">{t('settings.profile.avatar.section')}</h3>
+        <AvatarSection />
+      </Card>
       <Card className="gap-4 p-4 shadow-none">
         <h3 className="text-sm font-medium text-muted-foreground">{t('settings.profile.section')}</h3>
         <ProfileForm />


### PR DESCRIPTION
## Summary

- **Backend**: Three new authenticated endpoints under `/api/profile/avatar` — presign (POST), commit (POST), delete (DELETE) — with mime/size validation, S3 presigned PUT URL generation, headObject verification on commit, and best-effort parallel S3 cleanup on delete
- **Shared schemas**: `AVATAR_MIMES`, `MAX_AVATAR_SIZE`, `requestAvatarUploadSchema` (with `.max()` enforcement), `commitAvatarSchema` — all from `@shared/schemas`
- **Frontend**: `AvatarSection` component in Settings → Profile with file picker, drag-drop zone (`<section>`), avatar preview (falls back to initials), upload and remove buttons; uses `uploadToS3` + `commitAvatar` presign flow and `authClient.getSession()` for session refresh
- **App sidebar**: Updated to render `AvatarImage` when `user.image` is present, falling back to initials
- **Tests**: 11 integration tests (auth, mime/size validation, presign, commit persistence, delete cleanup) + 7 API unit tests

## Design decisions

- Uses **public-mode storage** (bucket expected to have public-read access) so avatars are served at stable direct URLs without presigning on every request
- Key path: `_system/avatars/<userId>.<ext>` — deterministic, overwritten on re-upload
- Delete uses `Promise.allSettled` across all possible MIME extension variants to avoid orphaned objects when users change avatar format
- Session refresh uses `authClient.getSession()` (no dual DB write via `updateUser`)

## Test plan

- [ ] POST `/api/profile/avatar` with valid image mime → returns `{ uploadUrl, key }` and echoes object path
- [ ] POST with wrong mime (gif) → 400; with size > 2 MiB → 400
- [ ] POST `/api/profile/avatar/commit` persists `user.image`
- [ ] DELETE `/api/profile/avatar` clears `user.image` and removes S3 object
- [ ] Settings → Profile page shows avatar section with upload button, drag-drop, preview, remove button
- [ ] After upload, header avatar updates (session refetched)
- [ ] All existing Avatar component sites render correctly; initials fallback still works
- [ ] Unauthenticated requests → 401
- [ ] `src/lib/api.ts` new wrappers have matching tests in `src/lib/api.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)