### PR TITLE
feat: v2.5.0 T6 — Google Cloud Run deployment (service.yaml + workflow + docs)

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -32,9 +32,9 @@ jobs:
           HAS_TURSO_URL: ${{ secrets.TURSO_DATABASE_URL != '' }}
         run: |
           missing=()
-          [ "$HAS_GCP_KEY" != "true" ]     && missing+=(GCP_SERVICE_ACCOUNT_KEY)
-          [ "$HAS_GCP_PROJECT" != "true" ]  && missing+=(GCP_PROJECT_ID)
-          [ "$HAS_TURSO_URL" != "true" ]    && missing+=(TURSO_DATABASE_URL)
+          [ "$HAS_GCP_KEY" != "true" ]    && missing+=(GCP_SERVICE_ACCOUNT_KEY)
+          [ "$HAS_GCP_PROJECT" != "true" ] && missing+=(GCP_PROJECT_ID)
+          [ "$HAS_TURSO_URL" != "true" ]   && missing+=(TURSO_DATABASE_URL)
           if [ ${#missing[@]} -gt 0 ]; then
             echo "::error::Missing required secrets: ${missing[*]}. Go to Settings → Secrets and variables → Actions."
             exit 1
@@ -85,7 +85,27 @@ jobs:
           npm ci
           npm run db:migrate
 
-      - name: Ensure BETTER_AUTH_SECRET exists in Secret Manager
+      - name: Store required secrets in Secret Manager
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          TURSO_DATABASE_URL: ${{ secrets.TURSO_DATABASE_URL }}
+        run: |
+          upsert_secret() {
+            local name="$1" value="$2"
+            EXISTS=$(gcloud secrets describe "$name" \
+              --project "$GCP_PROJECT_ID" \
+              --format="value(name)" 2>/dev/null || true)
+            if [ -z "$EXISTS" ]; then
+              printf '%s' "$value" | gcloud secrets create "$name" \
+                --project "$GCP_PROJECT_ID" --data-file=-
+            else
+              printf '%s' "$value" | gcloud secrets versions add "$name" \
+                --project "$GCP_PROJECT_ID" --data-file=-
+            fi
+          }
+          upsert_secret turso-database-url "$TURSO_DATABASE_URL"
+
+      - name: Ensure BETTER_AUTH_SECRET in Secret Manager
         id: auth_secret
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
@@ -96,73 +116,103 @@ jobs:
             --format="value(name)" 2>/dev/null || true)
           if [ -n "$USER_SECRET" ]; then
             if [ -z "$EXISTS" ]; then
-              echo "$USER_SECRET" | gcloud secrets create better-auth-secret \
-                --project "$GCP_PROJECT_ID" \
-                --data-file=-
+              printf '%s' "$USER_SECRET" | gcloud secrets create better-auth-secret \
+                --project "$GCP_PROJECT_ID" --data-file=-
             else
-              echo "$USER_SECRET" | gcloud secrets versions add better-auth-secret \
-                --project "$GCP_PROJECT_ID" \
-                --data-file=-
+              printf '%s' "$USER_SECRET" | gcloud secrets versions add better-auth-secret \
+                --project "$GCP_PROJECT_ID" --data-file=-
             fi
             echo "Set BETTER_AUTH_SECRET from GitHub secret."
           elif [ -z "$EXISTS" ]; then
             openssl rand -base64 32 | gcloud secrets create better-auth-secret \
-              --project "$GCP_PROJECT_ID" \
-              --data-file=-
+              --project "$GCP_PROJECT_ID" --data-file=-
             echo "auto_generated=true" >> "$GITHUB_OUTPUT"
             echo "Auto-generated BETTER_AUTH_SECRET and stored in Secret Manager."
           else
             echo "BETTER_AUTH_SECRET already exists in Secret Manager, skipping."
           fi
 
-      - name: Store runtime secrets in Secret Manager
+      - name: Build container image
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-          TURSO_DATABASE_URL: ${{ secrets.TURSO_DATABASE_URL }}
-          TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
-          BETTER_AUTH_URL: ${{ secrets.BETTER_AUTH_URL }}
+          VERSION: ${{ steps.release.outputs.version }}
         run: |
-          store_secret() {
-            local name="$1"
-            local value="$2"
-            [ -z "$value" ] && return
-            EXISTS=$(gcloud secrets describe "$name" \
-              --project "$GCP_PROJECT_ID" \
-              --format="value(name)" 2>/dev/null || true)
-            if [ -z "$EXISTS" ]; then
-              echo "$value" | gcloud secrets create "$name" \
-                --project "$GCP_PROJECT_ID" \
-                --data-file=-
-            else
-              echo "$value" | gcloud secrets versions add "$name" \
-                --project "$GCP_PROJECT_ID" \
-                --data-file=-
-            fi
-          }
-          store_secret turso-database-url "$TURSO_DATABASE_URL"
-          store_secret turso-auth-token   "$TURSO_AUTH_TOKEN"
-          store_secret better-auth-url    "$BETTER_AUTH_URL"
+          gcloud builds submit \
+            --tag "gcr.io/$GCP_PROJECT_ID/zpan:$VERSION" \
+            --project "$GCP_PROJECT_ID" \
+            .
 
-      - name: Deploy to Cloud Run
+      - name: Deploy service from manifest
         id: deploy
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           REGION: ${{ inputs.region || 'us-central1' }}
+          VERSION: ${{ steps.release.outputs.version }}
         run: |
-          SERVICE_URL=$(gcloud run deploy zpan \
-            --source . \
+          # Substitute PROJECT_ID placeholder and pin the image tag
+          sed -i \
+            -e "s|PROJECT_ID|$GCP_PROJECT_ID|g" \
+            -e "s|zpan:latest|zpan:$VERSION|g" \
+            deploy/cloud-run/service.yaml
+
+          # Create or update the service from the manifest
+          gcloud run services replace deploy/cloud-run/service.yaml \
+            --region "$REGION" \
+            --project "$GCP_PROJECT_ID"
+
+          # Allow public unauthenticated access
+          gcloud run services add-iam-policy-binding zpan \
             --region "$REGION" \
             --project "$GCP_PROJECT_ID" \
-            --allow-unauthenticated \
-            --port 8222 \
-            --set-secrets="TURSO_DATABASE_URL=turso-database-url:latest,TURSO_AUTH_TOKEN=turso-auth-token:latest,BETTER_AUTH_SECRET=better-auth-secret:latest,BETTER_AUTH_URL=better-auth-url:latest" \
-            --min-instances 0 \
-            --max-instances 10 \
-            --memory 512Mi \
-            --cpu 1 \
-            --format="value(status.url)" \
-            --quiet)
+            --member=allUsers \
+            --role=roles/run.invoker
+
+          # Capture the service URL for the post-deploy step
+          SERVICE_URL=$(gcloud run services describe zpan \
+            --region "$REGION" \
+            --project "$GCP_PROJECT_ID" \
+            --format="value(status.url)")
           echo "url=$SERVICE_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Wire BETTER_AUTH_URL and optional secrets
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          REGION: ${{ inputs.region || 'us-central1' }}
+          TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
+          BETTER_AUTH_URL: ${{ secrets.BETTER_AUTH_URL }}
+          SERVICE_URL: ${{ steps.deploy.outputs.url }}
+        run: |
+          upsert_secret() {
+            local name="$1" value="$2"
+            EXISTS=$(gcloud secrets describe "$name" \
+              --project "$GCP_PROJECT_ID" \
+              --format="value(name)" 2>/dev/null || true)
+            if [ -z "$EXISTS" ]; then
+              printf '%s' "$value" | gcloud secrets create "$name" \
+                --project "$GCP_PROJECT_ID" --data-file=-
+            else
+              printf '%s' "$value" | gcloud secrets versions add "$name" \
+                --project "$GCP_PROJECT_ID" --data-file=-
+            fi
+          }
+
+          # BETTER_AUTH_URL: user-supplied custom domain takes priority; fall back to the
+          # service URL assigned by Cloud Run on first deploy.
+          EFFECTIVE_URL="${BETTER_AUTH_URL:-$SERVICE_URL}"
+          upsert_secret better-auth-url "$EFFECTIVE_URL"
+          UPDATE_SECRETS="BETTER_AUTH_URL=better-auth-url:latest"
+
+          # TURSO_AUTH_TOKEN is optional (omit for file:// local Turso URLs).
+          if [ -n "$TURSO_AUTH_TOKEN" ]; then
+            upsert_secret turso-auth-token "$TURSO_AUTH_TOKEN"
+            UPDATE_SECRETS="$UPDATE_SECRETS,TURSO_AUTH_TOKEN=turso-auth-token:latest"
+          fi
+
+          gcloud run services update zpan \
+            --region "$REGION" \
+            --project "$GCP_PROJECT_ID" \
+            --update-secrets="$UPDATE_SECRETS"
+
           echo "**Deployed to:** $SERVICE_URL" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ steps.auth_secret.outputs.auto_generated }}" = "true" ]; then
             echo "" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -1,0 +1,170 @@
+name: Deploy to Google Cloud Run
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release tag to deploy (e.g. v2.5.0). Leave empty for latest.'
+        required: false
+      region:
+        description: 'GCP region (e.g. us-central1).'
+        required: false
+        default: us-central1
+
+# Prevent overlapping deployments.
+concurrency:
+  group: deploy-cloud-run
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    # Only run on forks — the upstream repo does not deploy itself.
+    if: github.repository != 'saltbo/zpan'
+    steps:
+      - name: Check required secrets
+        env:
+          HAS_GCP_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY != '' }}
+          HAS_GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID != '' }}
+          HAS_TURSO_URL: ${{ secrets.TURSO_DATABASE_URL != '' }}
+        run: |
+          missing=()
+          [ "$HAS_GCP_KEY" != "true" ]     && missing+=(GCP_SERVICE_ACCOUNT_KEY)
+          [ "$HAS_GCP_PROJECT" != "true" ]  && missing+=(GCP_PROJECT_ID)
+          [ "$HAS_TURSO_URL" != "true" ]    && missing+=(TURSO_DATABASE_URL)
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing required secrets: ${missing[*]}. Go to Settings → Secrets and variables → Actions."
+            exit 1
+          fi
+
+      - name: Resolve release tag
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "$INPUT_VERSION" ]; then
+            TAG="$INPUT_VERSION"
+          else
+            TAG=$(gh api repos/saltbo/zpan/releases/latest --jq '.tag_name')
+          fi
+          if [ -z "$TAG" ]; then
+            echo "::error::No release found in saltbo/zpan"
+            exit 1
+          fi
+          echo "version=$TAG" >> "$GITHUB_OUTPUT"
+          echo "### 🚀 Deploying $TAG to Cloud Run" >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/checkout@v4
+        with:
+          repository: saltbo/zpan
+          ref: ${{ steps.release.outputs.version }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Apply Turso migrations
+        env:
+          TURSO_DATABASE_URL: ${{ secrets.TURSO_DATABASE_URL }}
+          TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
+        run: |
+          npm ci
+          npm run db:migrate
+
+      - name: Ensure BETTER_AUTH_SECRET exists in Secret Manager
+        id: auth_secret
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          USER_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+        run: |
+          EXISTS=$(gcloud secrets describe better-auth-secret \
+            --project "$GCP_PROJECT_ID" \
+            --format="value(name)" 2>/dev/null || true)
+          if [ -n "$USER_SECRET" ]; then
+            if [ -z "$EXISTS" ]; then
+              echo "$USER_SECRET" | gcloud secrets create better-auth-secret \
+                --project "$GCP_PROJECT_ID" \
+                --data-file=-
+            else
+              echo "$USER_SECRET" | gcloud secrets versions add better-auth-secret \
+                --project "$GCP_PROJECT_ID" \
+                --data-file=-
+            fi
+            echo "Set BETTER_AUTH_SECRET from GitHub secret."
+          elif [ -z "$EXISTS" ]; then
+            openssl rand -base64 32 | gcloud secrets create better-auth-secret \
+              --project "$GCP_PROJECT_ID" \
+              --data-file=-
+            echo "auto_generated=true" >> "$GITHUB_OUTPUT"
+            echo "Auto-generated BETTER_AUTH_SECRET and stored in Secret Manager."
+          else
+            echo "BETTER_AUTH_SECRET already exists in Secret Manager, skipping."
+          fi
+
+      - name: Store runtime secrets in Secret Manager
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          TURSO_DATABASE_URL: ${{ secrets.TURSO_DATABASE_URL }}
+          TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
+          BETTER_AUTH_URL: ${{ secrets.BETTER_AUTH_URL }}
+        run: |
+          store_secret() {
+            local name="$1"
+            local value="$2"
+            [ -z "$value" ] && return
+            EXISTS=$(gcloud secrets describe "$name" \
+              --project "$GCP_PROJECT_ID" \
+              --format="value(name)" 2>/dev/null || true)
+            if [ -z "$EXISTS" ]; then
+              echo "$value" | gcloud secrets create "$name" \
+                --project "$GCP_PROJECT_ID" \
+                --data-file=-
+            else
+              echo "$value" | gcloud secrets versions add "$name" \
+                --project "$GCP_PROJECT_ID" \
+                --data-file=-
+            fi
+          }
+          store_secret turso-database-url "$TURSO_DATABASE_URL"
+          store_secret turso-auth-token   "$TURSO_AUTH_TOKEN"
+          store_secret better-auth-url    "$BETTER_AUTH_URL"
+
+      - name: Deploy to Cloud Run
+        id: deploy
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          REGION: ${{ inputs.region || 'us-central1' }}
+        run: |
+          SERVICE_URL=$(gcloud run deploy zpan \
+            --source . \
+            --region "$REGION" \
+            --project "$GCP_PROJECT_ID" \
+            --allow-unauthenticated \
+            --port 8222 \
+            --set-secrets="TURSO_DATABASE_URL=turso-database-url:latest,TURSO_AUTH_TOKEN=turso-auth-token:latest,BETTER_AUTH_SECRET=better-auth-secret:latest,BETTER_AUTH_URL=better-auth-url:latest" \
+            --min-instances 0 \
+            --max-instances 10 \
+            --memory 512Mi \
+            --cpu 1 \
+            --format="value(status.url)" \
+            --quiet)
+          echo "url=$SERVICE_URL" >> "$GITHUB_OUTPUT"
+          echo "**Deployed to:** $SERVICE_URL" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.auth_secret.outputs.auto_generated }}" = "true" ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> ⚠️ **BETTER_AUTH_SECRET was auto-generated** and stored in Secret Manager. Back it up from the GCP console before rotating." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/deploy/cloud-run/service.yaml
+++ b/deploy/cloud-run/service.yaml
@@ -28,20 +28,10 @@ spec:
                 secretKeyRef:
                   name: turso-database-url
                   key: latest
-            - name: TURSO_AUTH_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: turso-auth-token
-                  key: latest
             - name: BETTER_AUTH_SECRET
               valueFrom:
                 secretKeyRef:
                   name: better-auth-secret
-                  key: latest
-            - name: BETTER_AUTH_URL
-              valueFrom:
-                secretKeyRef:
-                  name: better-auth-url
                   key: latest
           resources:
             limits:

--- a/deploy/cloud-run/service.yaml
+++ b/deploy/cloud-run/service.yaml
@@ -1,0 +1,49 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: zpan
+  annotations:
+    run.googleapis.com/ingress: all
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "0"
+        autoscaling.knative.dev/maxScale: "10"
+    spec:
+      containerConcurrency: 80
+      timeoutSeconds: 300
+      containers:
+        - image: gcr.io/PROJECT_ID/zpan:latest
+          ports:
+            - name: http1
+              containerPort: 8222
+          env:
+            - name: PORT
+              value: "8222"
+            - name: NODE_ENV
+              value: production
+            - name: TURSO_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: turso-database-url
+                  key: latest
+            - name: TURSO_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: turso-auth-token
+                  key: latest
+            - name: BETTER_AUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: better-auth-secret
+                  key: latest
+            - name: BETTER_AUTH_URL
+              valueFrom:
+                secretKeyRef:
+                  name: better-auth-url
+                  key: latest
+          resources:
+            limits:
+              cpu: "1"
+              memory: 512Mi

--- a/docs/deploy/cloud-run.md
+++ b/docs/deploy/cloud-run.md
@@ -1,0 +1,135 @@
+# Google Cloud Run Deployment
+
+ZPan supports Google Cloud Run as a first-class deploy target. It reuses the existing root `Dockerfile` — no separate entry file is needed. [Turso](https://turso.tech) provides the database, and any S3-compatible bucket (Cloudflare R2 recommended) handles file storage.
+
+> **GCS is not adapted as a storage driver.** Google Cloud Storage is not S3-compatible at the API level. Bring an external S3-compatible bucket (R2, AWS S3, Tigris, B2, etc.).
+
+## Prerequisites
+
+| Tool / Account | Purpose |
+|---------------|---------|
+| [Google Cloud account](https://cloud.google.com) | Hosts the Cloud Run service |
+| GCP project with billing enabled | Cloud Run, Cloud Build, Secret Manager, and Artifact Registry are used |
+| [Turso database](https://turso.tech) | libSQL-compatible remote database |
+| S3-compatible storage | File storage (Cloudflare R2 recommended — free egress) |
+
+## Required Secrets
+
+Set these in your fork's GitHub repository under **Settings → Secrets and variables → Actions**:
+
+| Secret | Description |
+|--------|-------------|
+| `GCP_SERVICE_ACCOUNT_KEY` | JSON key for a GCP service account with roles: `roles/run.admin`, `roles/cloudbuild.builds.editor`, `roles/secretmanager.admin`, `roles/iam.serviceAccountUser`, `roles/artifactregistry.writer` |
+| `GCP_PROJECT_ID` | Your GCP project ID (e.g. `my-zpan-project`) |
+| `TURSO_DATABASE_URL` | Turso database URL, e.g. `libsql://your-db.turso.io` |
+| `BETTER_AUTH_URL` | Your Cloud Run service URL, e.g. `https://zpan-abc123-uc.a.run.app` |
+
+### Optional Secrets
+
+| Secret | Description |
+|--------|-------------|
+| `TURSO_AUTH_TOKEN` | Turso auth token. Create with `turso db tokens create your-db`. Required for remote Turso URLs; omit for `file://` local databases. |
+| `BETTER_AUTH_SECRET` | Signing secret for auth sessions. If not provided, the workflow auto-generates one on first deploy and stores it in Secret Manager. Back it up from the GCP console before rotating. To bring your own: `openssl rand -base64 32`. |
+
+## Quick Start (Fork + Deploy)
+
+1. **Fork** the `saltbo/zpan` repository.
+
+2. **Create a GCP project** and enable the required APIs:
+   ```sh
+   gcloud projects create my-zpan-project --name="ZPan"
+   gcloud config set project my-zpan-project
+   gcloud services enable \
+     run.googleapis.com \
+     cloudbuild.googleapis.com \
+     secretmanager.googleapis.com \
+     artifactregistry.googleapis.com
+   ```
+
+3. **Create a service account** and download its key:
+   ```sh
+   gcloud iam service-accounts create zpan-deployer \
+     --display-name="ZPan Deployer"
+
+   for role in roles/run.admin roles/cloudbuild.builds.editor \
+               roles/secretmanager.admin roles/iam.serviceAccountUser \
+               roles/artifactregistry.writer; do
+     gcloud projects add-iam-policy-binding my-zpan-project \
+       --member="serviceAccount:zpan-deployer@my-zpan-project.iam.gserviceaccount.com" \
+       --role="$role"
+   done
+
+   gcloud iam service-accounts keys create gcp-key.json \
+     --iam-account="zpan-deployer@my-zpan-project.iam.gserviceaccount.com"
+   ```
+   Use the contents of `gcp-key.json` as the `GCP_SERVICE_ACCOUNT_KEY` secret. Delete the local file afterward.
+
+4. **Create a Turso database:**
+   ```sh
+   turso db create zpan-db
+   turso db show zpan-db --url     # → TURSO_DATABASE_URL
+   turso db tokens create zpan-db  # → TURSO_AUTH_TOKEN
+   ```
+
+5. **Add the required secrets** to your fork (see table above). `BETTER_AUTH_URL` can be added after the first deploy once you know the Cloud Run service URL. `BETTER_AUTH_SECRET` is optional — the workflow auto-generates one on first deploy.
+
+6. **Push to `master`** — the `deploy-cloud-run.yml` workflow runs automatically. Cloud Build builds the image from the root `Dockerfile`, applies Turso migrations, and deploys the Cloud Run service.
+
+## Workflow Steps
+
+The workflow follows the standard 8-step deployment contract:
+
+1. Guard: skips on the upstream `saltbo/zpan` repo.
+2. Check required secrets — fails early with an actionable error if any are missing.
+3. Resolve the latest release tag from `saltbo/zpan` (override via `workflow_dispatch` input).
+4. Checkout upstream code at the resolved tag.
+5. Authenticate to Google Cloud using the service account key.
+6. Apply Turso migrations (`npm run db:migrate`).
+7. Ensure `BETTER_AUTH_SECRET` exists in Secret Manager (auto-generates on first deploy).
+8. Deploy via `gcloud run deploy zpan --source .` — Cloud Build builds the image; the service is created or updated.
+
+## Region
+
+The default region is `us-central1`. To deploy to a different region, use the `workflow_dispatch` trigger and set the `region` input:
+
+```
+Actions → Deploy to Google Cloud Run → Run workflow → region: europe-west1
+```
+
+## Cold-Start Expectations
+
+`min-instances` is set to **0** to qualify for the free tier. With zero minimum instances, the first request after a period of inactivity will experience a cold start — typically **1–3 seconds** for the ZPan Node.js container.
+
+To eliminate cold starts at the cost of always-on billing, set `min-instances` to `1` in the workflow's `gcloud run deploy` flags or in `deploy/cloud-run/service.yaml`.
+
+## Service Manifest
+
+`deploy/cloud-run/service.yaml` is a Knative service manifest for reference and manual apply:
+
+```sh
+# Replace PROJECT_ID with your GCP project ID first
+sed "s/PROJECT_ID/my-zpan-project/g" deploy/cloud-run/service.yaml | \
+  gcloud run services replace - --region us-central1
+
+# Dry-run validation
+sed "s/PROJECT_ID/my-zpan-project/g" deploy/cloud-run/service.yaml | \
+  gcloud run services replace - --region us-central1 --dry-run
+```
+
+The workflow uses `--source .` (Cloud Build) rather than this manifest for automated deployments, so the manifest is not required for normal operation.
+
+## Storage Configuration
+
+Cloud Run deployments require an **external S3-compatible bucket**. Configure it via the ZPan admin dashboard after your first login. Cloudflare R2 is recommended — it has zero egress fees, and there are no bandwidth charges between Cloud Run and R2.
+
+GCS (Google Cloud Storage) is **not supported** as a storage backend — it uses a different API protocol.
+
+## Pricing Notes
+
+- **Cloud Run** — free tier: 2 million requests/month, 360,000 GB-seconds compute, 180,000 vCPU-seconds. With `min-instances=0`, idle deployments cost $0.
+- **Cloud Build** — free tier: 120 build-minutes/day. Each deployment triggers one Cloud Build run.
+- **Secret Manager** — free tier: 6 active secret versions, 10,000 access operations/month.
+- **Turso** — free tier: 500 databases, 9 GB total storage, 1B row reads / 25M row writes per month.
+- **Cloudflare R2** — 10 GB storage free, zero egress fees.
+
+A personal ZPan instance with light usage fits entirely within free tiers across all services.

--- a/docs/deploy/cloud-run.md
+++ b/docs/deploy/cloud-run.md
@@ -9,7 +9,7 @@ ZPan supports Google Cloud Run as a first-class deploy target. It reuses the exi
 | Tool / Account | Purpose |
 |---------------|---------|
 | [Google Cloud account](https://cloud.google.com) | Hosts the Cloud Run service |
-| GCP project with billing enabled | Cloud Run, Cloud Build, Secret Manager, and Artifact Registry are used |
+| GCP project with billing enabled | Cloud Run, Cloud Build, Secret Manager, and Container Registry are used |
 | [Turso database](https://turso.tech) | libSQL-compatible remote database |
 | S3-compatible storage | File storage (Cloudflare R2 recommended — free egress) |
 
@@ -19,10 +19,9 @@ Set these in your fork's GitHub repository under **Settings → Secrets and vari
 
 | Secret | Description |
 |--------|-------------|
-| `GCP_SERVICE_ACCOUNT_KEY` | JSON key for a GCP service account with roles: `roles/run.admin`, `roles/cloudbuild.builds.editor`, `roles/secretmanager.admin`, `roles/iam.serviceAccountUser`, `roles/artifactregistry.writer` |
+| `GCP_SERVICE_ACCOUNT_KEY` | JSON key for a GCP service account with roles: `roles/run.admin`, `roles/cloudbuild.builds.editor`, `roles/secretmanager.admin`, `roles/iam.serviceAccountUser`, `roles/storage.admin` |
 | `GCP_PROJECT_ID` | Your GCP project ID (e.g. `my-zpan-project`) |
 | `TURSO_DATABASE_URL` | Turso database URL, e.g. `libsql://your-db.turso.io` |
-| `BETTER_AUTH_URL` | Your Cloud Run service URL, e.g. `https://zpan-abc123-uc.a.run.app` |
 
 ### Optional Secrets
 
@@ -30,6 +29,7 @@ Set these in your fork's GitHub repository under **Settings → Secrets and vari
 |--------|-------------|
 | `TURSO_AUTH_TOKEN` | Turso auth token. Create with `turso db tokens create your-db`. Required for remote Turso URLs; omit for `file://` local databases. |
 | `BETTER_AUTH_SECRET` | Signing secret for auth sessions. If not provided, the workflow auto-generates one on first deploy and stores it in Secret Manager. Back it up from the GCP console before rotating. To bring your own: `openssl rand -base64 32`. |
+| `BETTER_AUTH_URL` | Custom domain for auth callbacks, e.g. `https://zpan.example.com`. If omitted, the workflow automatically uses the Cloud Run service URL assigned on first deploy. Only needed if you configure a custom domain after the initial deploy. |
 
 ## Quick Start (Fork + Deploy)
 
@@ -43,7 +43,7 @@ Set these in your fork's GitHub repository under **Settings → Secrets and vari
      run.googleapis.com \
      cloudbuild.googleapis.com \
      secretmanager.googleapis.com \
-     artifactregistry.googleapis.com
+     containerregistry.googleapis.com
    ```
 
 3. **Create a service account** and download its key:
@@ -53,7 +53,7 @@ Set these in your fork's GitHub repository under **Settings → Secrets and vari
 
    for role in roles/run.admin roles/cloudbuild.builds.editor \
                roles/secretmanager.admin roles/iam.serviceAccountUser \
-               roles/artifactregistry.writer; do
+               roles/storage.admin; do
      gcloud projects add-iam-policy-binding my-zpan-project \
        --member="serviceAccount:zpan-deployer@my-zpan-project.iam.gserviceaccount.com" \
        --role="$role"
@@ -68,25 +68,35 @@ Set these in your fork's GitHub repository under **Settings → Secrets and vari
    ```sh
    turso db create zpan-db
    turso db show zpan-db --url     # → TURSO_DATABASE_URL
-   turso db tokens create zpan-db  # → TURSO_AUTH_TOKEN
+   turso db tokens create zpan-db  # → TURSO_AUTH_TOKEN (optional but recommended)
    ```
 
-5. **Add the required secrets** to your fork (see table above). `BETTER_AUTH_URL` can be added after the first deploy once you know the Cloud Run service URL. `BETTER_AUTH_SECRET` is optional — the workflow auto-generates one on first deploy.
+5. **Add the required secrets** to your fork (see table above). `BETTER_AUTH_URL` and `BETTER_AUTH_SECRET` are both optional — the workflow handles them automatically on first deploy.
 
-6. **Push to `master`** — the `deploy-cloud-run.yml` workflow runs automatically. Cloud Build builds the image from the root `Dockerfile`, applies Turso migrations, and deploys the Cloud Run service.
+6. **Push to `master`** — the `deploy-cloud-run.yml` workflow runs automatically. Cloud Build builds the image, Turso migrations run, `service.yaml` drives the Cloud Run deploy, and `BETTER_AUTH_URL` is auto-wired from the assigned service URL.
 
 ## Workflow Steps
 
 The workflow follows the standard 8-step deployment contract:
 
-1. Guard: skips on the upstream `saltbo/zpan` repo.
-2. Check required secrets — fails early with an actionable error if any are missing.
-3. Resolve the latest release tag from `saltbo/zpan` (override via `workflow_dispatch` input).
-4. Checkout upstream code at the resolved tag.
-5. Authenticate to Google Cloud using the service account key.
-6. Apply Turso migrations (`npm run db:migrate`).
-7. Ensure `BETTER_AUTH_SECRET` exists in Secret Manager (auto-generates on first deploy).
-8. Deploy via `gcloud run deploy zpan --source .` — Cloud Build builds the image; the service is created or updated.
+1. **Guard** — skips on the upstream `saltbo/zpan` repo.
+2. **Check required secrets** — fails early with an actionable error if any are missing.
+3. **Resolve release tag** — defaults to the latest `saltbo/zpan` release; override via `workflow_dispatch` input.
+4. **Checkout** upstream code at the resolved tag.
+5. **Authenticate** to Google Cloud using the service account key.
+6. **Apply Turso migrations** (`npm run db:migrate`).
+7. **Store required secrets** in Secret Manager (`turso-database-url`, `better-auth-secret`).
+8. **Build + deploy** — Cloud Build builds the image; `gcloud run services replace deploy/cloud-run/service.yaml` creates or updates the service; a post-deploy step wires `BETTER_AUTH_URL` (from the real service URL) and `TURSO_AUTH_TOKEN` (if provided) into the running service via `gcloud run services update --update-secrets`.
+
+### BETTER_AUTH_URL — first-deploy behaviour
+
+`BETTER_AUTH_URL` is not known until after Cloud Run assigns the service URL. The workflow resolves this automatically:
+
+1. The initial `gcloud run services replace` deploys without `BETTER_AUTH_URL`.
+2. After deploy, the service URL is captured and stored as the `better-auth-url` Secret Manager entry.
+3. `gcloud run services update --update-secrets` wires it into the running service in-place.
+
+No manual intervention is required on first deploy. If you later configure a custom domain, set `BETTER_AUTH_URL` as a GitHub secret and re-run the workflow — it will update the secret and redeploy.
 
 ## Region
 
@@ -100,23 +110,21 @@ Actions → Deploy to Google Cloud Run → Run workflow → region: europe-west1
 
 `min-instances` is set to **0** to qualify for the free tier. With zero minimum instances, the first request after a period of inactivity will experience a cold start — typically **1–3 seconds** for the ZPan Node.js container.
 
-To eliminate cold starts at the cost of always-on billing, set `min-instances` to `1` in the workflow's `gcloud run deploy` flags or in `deploy/cloud-run/service.yaml`.
+To eliminate cold starts at the cost of always-on billing, set `min-instances` to `1` in `deploy/cloud-run/service.yaml` before deploying.
 
 ## Service Manifest
 
-`deploy/cloud-run/service.yaml` is a Knative service manifest for reference and manual apply:
+`deploy/cloud-run/service.yaml` is the Knative service manifest that drives automated deployments. The workflow substitutes the `PROJECT_ID` placeholder and pins the image tag before calling `gcloud run services replace`.
+
+To validate the manifest manually before deploying:
 
 ```sh
-# Replace PROJECT_ID with your GCP project ID first
-sed "s/PROJECT_ID/my-zpan-project/g" deploy/cloud-run/service.yaml | \
-  gcloud run services replace - --region us-central1
-
-# Dry-run validation
+# Substitute PROJECT_ID and validate (dry-run)
 sed "s/PROJECT_ID/my-zpan-project/g" deploy/cloud-run/service.yaml | \
   gcloud run services replace - --region us-central1 --dry-run
 ```
 
-The workflow uses `--source .` (Cloud Build) rather than this manifest for automated deployments, so the manifest is not required for normal operation.
+`TURSO_AUTH_TOKEN` and `BETTER_AUTH_URL` are not in the base manifest because they are optional or not known at initial deploy time. The workflow adds them post-deploy via `gcloud run services update --update-secrets`.
 
 ## Storage Configuration
 


### PR DESCRIPTION
## Summary

- Adds `deploy/cloud-run/service.yaml` — Knative service manifest with `min-instances=0`, Secret Manager-backed env vars, and configurable autoscaling
- Adds `.github/workflows/deploy-cloud-run.yml` — 8-step workflow contract: secret validation, release resolution, GCloud auth, Turso migrations, Secret Manager upsert, `gcloud run deploy --source .` (Cloud Build)
- Adds `docs/deploy/cloud-run.md` — 5-section doc covering prerequisites, required secrets, quick-start, cold-start expectations, and free-tier pricing notes

Reuses the existing root `Dockerfile` — no new entry file. Follows the same pattern as `deploy-vercel.yml`.

## Test plan

- [ ] `docker build .` succeeds with existing Dockerfile (no regressions)
- [ ] `gcloud run services replace deploy/cloud-run/service.yaml --dry-run` validates manifest (after substituting `PROJECT_ID`)
- [ ] Workflow runs end-to-end: Cloud Build builds image, Cloud Run service created/updated
- [ ] Service URL returns `/health` 200 and SPA hydrates
- [ ] Re-running workflow redeploys without orphaning Cloud Build artifacts
- [ ] `docs/deploy/cloud-run.md` lists all required secrets and cost notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)