### PR TITLE
Fix: 解决了多个BUG

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,13 +75,26 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          DB_ID=$(npx wrangler d1 list --json | jq -r '.[] | select(.name == "zpan-db") | .uuid')
+          # 直接调用 Cloudflare REST API 查询 D1 数据库列表
+          RESPONSE=$(curl -s -X GET \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/d1/database" \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            -H "Content-Type: application/json")
+          
+          DB_ID=$(echo "$RESPONSE" | jq -r '.result[] | select(.name == "zpan-db") | .uuid')
+          
           if [ -z "$DB_ID" ]; then
-            DB_ID=$(npx wrangler d1 create zpan-db --json | jq -r '.uuid')
+            CREATE=$(curl -s -X POST \
+              "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/d1/database" \
+              -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+              -H "Content-Type: application/json" \
+              --data '{"name":"zpan-db"}')
+            DB_ID=$(echo "$CREATE" | jq -r '.result.uuid')
             echo "Created D1 database: $DB_ID"
           else
             echo "Reusing D1 database: $DB_ID"
           fi
+          
           echo "id=$DB_ID" >> "$GITHUB_OUTPUT"
 
       - name: Patch wrangler.toml with D1 database ID

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,7 +113,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx wrangler deploy --assets dist
+        run: npx wrangler deploy --assets dist/client
 
       - name: Set BETTER_AUTH_SECRET (first deploy only)
         env:


### PR DESCRIPTION
在该 PR 中解决了如下问题：
- 修复了Cloudflare Workers部署报错
- 修复了通过 Cloudflare Workers 部署后访问时 404 错误

在原来的版本中使用 Cloudflare Workers 部署时会报如下错误：
<img width="2120" height="613" alt="image" src="https://github.com/user-attachments/assets/3086fa2c-a48a-424a-9838-49d3c04b1eaf" />
为了能正常部署，我临时采用直接调用 Cloudflare REST API 查询 D1 数据库列表的方法。
该问题与 wrangler 的版本有关，在旧版本中没有 json 参数，但是新版本已经加入了该参数，我搞不懂为什么他还在使用旧版本的wrangler（我对 github actions 这方面不太了解）。