### PR TITLE
feat: R2 binding for CF public images (write via binding, read via managed URL)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,6 +89,44 @@ jobs:
           fi
           echo "id=$DB_ID" >> "$GITHUB_OUTPUT"
 
+      - name: Ensure R2 public-images bucket exists
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          EXISTS=$(npx wrangler r2 bucket list --json 2>/dev/null | jq -r '.[] | select(.name == "zpan-public-images") | .name')
+          if [ -z "$EXISTS" ]; then
+            npx wrangler r2 bucket create zpan-public-images
+            echo "Created R2 bucket: zpan-public-images"
+          else
+            echo "Reusing R2 bucket: zpan-public-images"
+          fi
+
+      - name: Enable R2 managed public URL + capture
+        id: r2
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          # Idempotent: PUT enabled=true — CF returns the same pub-<hash>.r2.dev
+          # on every call once enabled.
+          curl -sf -X PUT \
+            "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/r2/buckets/zpan-public-images/domains/managed" \
+            -H "Authorization: Bearer $CF_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{"enabled": true}' > /dev/null
+
+          DOMAIN=$(curl -sf \
+            "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/r2/buckets/zpan-public-images/domains/managed" \
+            -H "Authorization: Bearer $CF_API_TOKEN" | jq -r '.result.domain')
+
+          if [ -z "$DOMAIN" ] || [ "$DOMAIN" = "null" ]; then
+            echo "::error::Failed to retrieve R2 managed public domain. Make sure CLOUDFLARE_API_TOKEN has 'R2 Storage: Edit' scope."
+            exit 1
+          fi
+          echo "url=https://$DOMAIN" >> "$GITHUB_OUTPUT"
+          echo "R2 public URL: https://$DOMAIN"
+
       - name: Patch wrangler.toml with D1 database ID
         run: sed -i "s/database_id = \"[^\"]*\"/database_id = \"${{ steps.d1.outputs.id }}\"/" wrangler.toml
 
@@ -127,3 +165,11 @@ jobs:
           else
             echo "BETTER_AUTH_SECRET already set, skipping"
           fi
+
+      - name: Set PUBLIC_IMAGES_URL (always upsert — R2 domain is stable)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          echo "${{ steps.r2.outputs.url }}" | npx wrangler secret put PUBLIC_IMAGES_URL
+          echo "Set PUBLIC_IMAGES_URL = ${{ steps.r2.outputs.url }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,12 +91,20 @@ jobs:
 
       - name: Ensure R2 public-images bucket exists
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          EXISTS=$(npx wrangler r2 bucket list --json 2>/dev/null | jq -r '.[] | select(.name == "zpan-public-images") | .name')
+          # Use CF REST API — `wrangler r2 bucket list` has no --json flag.
+          EXISTS=$(curl -sf \
+            "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/r2/buckets" \
+            -H "Authorization: Bearer $CF_API_TOKEN" \
+            | jq -r '.result.buckets[]? | select(.name == "zpan-public-images") | .name')
           if [ -z "$EXISTS" ]; then
-            npx wrangler r2 bucket create zpan-public-images
+            curl -sf -X POST \
+              "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/r2/buckets" \
+              -H "Authorization: Bearer $CF_API_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d '{"name": "zpan-public-images"}' > /dev/null
             echo "Created R2 bucket: zpan-public-images"
           else
             echo "Reusing R2 bucket: zpan-public-images"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Deploy via GitHub Actions with zero server management. Free tier covers personal
 1. **Fork** this repository
 2. In your fork, go to **Settings → Secrets and variables → Actions** and add:
    - `CLOUDFLARE_ACCOUNT_ID` — found on the [Cloudflare dashboard](https://dash.cloudflare.com/) sidebar
-   - `CLOUDFLARE_API_TOKEN` — create one [here](https://dash.cloudflare.com/profile/api-tokens) with **Workers Scripts:Edit** and **D1:Edit** permissions
+   - `CLOUDFLARE_API_TOKEN` — create one [here](https://dash.cloudflare.com/profile/api-tokens) with **Workers Scripts:Edit**, **D1:Edit**, and **R2 Storage:Edit** permissions (R2 scope is needed to auto-provision the avatar/logo bucket)
 3. Go to the **Actions** tab, select **Deploy to Cloudflare Workers**, and click **Run workflow**
 
 After initial setup, the workflow runs automatically every time you sync your fork with the latest release.

--- a/server/platform/cloudflare.ts
+++ b/server/platform/cloudflare.ts
@@ -14,7 +14,12 @@ export function createCloudflarePlatform(env: CloudflareEnv): Platform {
   return {
     db,
     getEnv(key: string) {
-      return env[key] as string | undefined
+      const v = env[key]
+      return typeof v === 'string' ? v : undefined
+    },
+    getBinding<T = unknown>(key: string): T | undefined {
+      const v = env[key]
+      return typeof v === 'object' && v !== null ? (v as T) : undefined
     },
   }
 }

--- a/server/platform/interface.ts
+++ b/server/platform/interface.ts
@@ -11,4 +11,8 @@ export type Database = BaseSQLiteDatabase<any, any, FullSchema>
 export interface Platform {
   db: Database
   getEnv(key: string): string | undefined
+  // Access platform-native bindings (e.g. CF R2 bucket, D1 database).
+  // Returns `undefined` on platforms without that binding, so callers branch
+  // on the return value to pick a runtime-appropriate code path.
+  getBinding<T = unknown>(key: string): T | undefined
 }

--- a/server/platform/libsql.ts
+++ b/server/platform/libsql.ts
@@ -28,5 +28,8 @@ export async function createLibsqlPlatform(env: LibsqlEnv): Promise<Platform> {
     getEnv(key: string) {
       return envRecord[key] ?? process.env[key]
     },
+    getBinding<T = unknown>(_key: string): T | undefined {
+      return undefined
+    },
   }
 }

--- a/server/platform/node.ts
+++ b/server/platform/node.ts
@@ -20,5 +20,10 @@ export function createNodePlatform(): Platform {
     getEnv(key: string) {
       return process.env[key]
     },
+    // Node has no platform-native bindings — callers always fall back to
+    // whatever the non-binding path does (e.g. DB-configured S3 storage).
+    getBinding<T = unknown>(_key: string): T | undefined {
+      return undefined
+    },
   }
 }

--- a/server/routes/me.ts
+++ b/server/routes/me.ts
@@ -13,7 +13,7 @@ const AVATAR_PREFIX = '_system/avatars'
 export const me = new Hono<Env>()
   .use(requireAuth)
   .put('/avatar', async (c) => {
-    const db = c.get('platform').db
+    const platform = c.get('platform')
     const userId = c.get('userId') as string
 
     const form = await c.req.formData().catch(() => null)
@@ -22,18 +22,18 @@ export const me = new Hono<Env>()
     const file = form.get('file')
     if (!(file instanceof File)) return c.json({ error: 'file field is required' }, 400)
 
-    const result = await uploadPublicImage(db, AVATAR_PREFIX, userId, file)
+    const result = await uploadPublicImage(platform, AVATAR_PREFIX, userId, file)
     if (!result.ok) return c.json({ error: result.error }, result.status)
 
-    await db.update(user).set({ image: result.url }).where(eq(user.id, userId))
+    await platform.db.update(user).set({ image: result.url }).where(eq(user.id, userId))
     return c.json({ url: result.url })
   })
   .delete('/avatar', async (c) => {
-    const db = c.get('platform').db
+    const platform = c.get('platform')
     const userId = c.get('userId') as string
 
-    // Clear DB first (authoritative); S3 cleanup below is best-effort.
-    await db.update(user).set({ image: null }).where(eq(user.id, userId))
-    await deletePublicImageVariants(db, AVATAR_PREFIX, userId)
+    // Clear DB first (authoritative); storage cleanup below is best-effort.
+    await platform.db.update(user).set({ image: null }).where(eq(user.id, userId))
+    await deletePublicImageVariants(platform, AVATAR_PREFIX, userId)
     return c.json({ ok: true })
   })

--- a/server/routes/teams.ts
+++ b/server/routes/teams.ts
@@ -93,11 +93,11 @@ export const teams = new Hono<Env>()
   })
   // ── Org logo (public-bucket image) ───────────────────────────────────────────
   .put('/:teamId/logo', async (c) => {
-    const db = c.get('platform').db
+    const platform = c.get('platform')
     const userId = c.get('userId') as string
     const { teamId } = c.req.param()
 
-    const role = await getMemberRole(db, teamId, userId)
+    const role = await getMemberRole(platform.db, teamId, userId)
     if (role !== 'owner' && role !== 'admin') return c.json({ error: 'Forbidden' }, 403)
 
     const form = await c.req.formData().catch(() => null)
@@ -105,21 +105,21 @@ export const teams = new Hono<Env>()
     const file = form.get('file')
     if (!(file instanceof File)) return c.json({ error: 'file field is required' }, 400)
 
-    const result = await uploadPublicImage(db, LOGO_PREFIX, teamId, file)
+    const result = await uploadPublicImage(platform, LOGO_PREFIX, teamId, file)
     if (!result.ok) return c.json({ error: result.error }, result.status)
 
-    await db.update(organization).set({ logo: result.url }).where(eq(organization.id, teamId))
+    await platform.db.update(organization).set({ logo: result.url }).where(eq(organization.id, teamId))
     return c.json({ url: result.url })
   })
   .delete('/:teamId/logo', async (c) => {
-    const db = c.get('platform').db
+    const platform = c.get('platform')
     const userId = c.get('userId') as string
     const { teamId } = c.req.param()
 
-    const role = await getMemberRole(db, teamId, userId)
+    const role = await getMemberRole(platform.db, teamId, userId)
     if (role !== 'owner' && role !== 'admin') return c.json({ error: 'Forbidden' }, 403)
 
-    await db.update(organization).set({ logo: null }).where(eq(organization.id, teamId))
-    await deletePublicImageVariants(db, LOGO_PREFIX, teamId)
+    await platform.db.update(organization).set({ logo: null }).where(eq(organization.id, teamId))
+    await deletePublicImageVariants(platform, LOGO_PREFIX, teamId)
     return c.json({ ok: true })
   })

--- a/server/services/image-upload.test.ts
+++ b/server/services/image-upload.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Platform } from '../platform/interface'
+import { deletePublicImageVariants, isImageMime, uploadPublicImage } from './image-upload'
+
+// biome-ignore lint/suspicious/noExplicitAny: test stub intentionally opaque
+type Any = any
+
+function mockR2Bucket() {
+  return {
+    put: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function mockPlatform(
+  opts: { r2?: ReturnType<typeof mockR2Bucket>; publicUrl?: string; dbStorage?: Any; dbStorageThrows?: boolean } = {},
+): Platform {
+  return {
+    db: {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            orderBy: () => ({
+              limit: async () =>
+                opts.dbStorageThrows
+                  ? (() => {
+                      throw new Error('no storage')
+                    })()
+                  : opts.dbStorage
+                    ? [opts.dbStorage]
+                    : [],
+            }),
+          }),
+        }),
+      }),
+    } as Any,
+    getEnv: (key) => (key === 'PUBLIC_IMAGES_URL' ? opts.publicUrl : undefined),
+    getBinding: <T>(key: string) => (key === 'PUBLIC_IMAGES' && opts.r2 ? (opts.r2 as unknown as T) : undefined),
+  }
+}
+
+function makeFile(type: string, bytes = 16): File {
+  return new File([new Uint8Array(bytes)], `f.${type.split('/')[1]}`, { type })
+}
+
+describe('isImageMime', () => {
+  it('accepts png/jpeg/webp', () => {
+    expect(isImageMime('image/png')).toBe(true)
+    expect(isImageMime('image/jpeg')).toBe(true)
+    expect(isImageMime('image/webp')).toBe(true)
+  })
+
+  it('rejects other mimes', () => {
+    expect(isImageMime('image/gif')).toBe(false)
+    expect(isImageMime('application/pdf')).toBe(false)
+    expect(isImageMime('')).toBe(false)
+    expect(isImageMime(undefined)).toBe(false)
+    expect(isImageMime(42)).toBe(false)
+  })
+})
+
+describe('uploadPublicImage — R2 binding path', () => {
+  it('uses R2 binding when PUBLIC_IMAGES + PUBLIC_IMAGES_URL both set', async () => {
+    const r2 = mockR2Bucket()
+    const platform = mockPlatform({ r2, publicUrl: 'https://pub-abc.r2.dev' })
+
+    const result = await uploadPublicImage(platform, '_system/avatars', 'u1', makeFile('image/png'))
+
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.url).toBe('https://pub-abc.r2.dev/_system/avatars/u1.png')
+    expect(r2.put).toHaveBeenCalledOnce()
+    expect(r2.put.mock.calls[0]?.[0]).toBe('_system/avatars/u1.png')
+    expect(r2.put.mock.calls[0]?.[2]).toEqual({ httpMetadata: { contentType: 'image/png' } })
+  })
+
+  it('maps mime to correct file extension (jpeg → jpg)', async () => {
+    const r2 = mockR2Bucket()
+    const platform = mockPlatform({ r2, publicUrl: 'https://pub-abc.r2.dev' })
+
+    const result = await uploadPublicImage(platform, '_system/avatars', 'u1', makeFile('image/jpeg'))
+
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.url).toMatch(/\.jpg$/)
+  })
+
+  it('trims a trailing slash in PUBLIC_IMAGES_URL', async () => {
+    const r2 = mockR2Bucket()
+    const platform = mockPlatform({ r2, publicUrl: 'https://pub-abc.r2.dev/' })
+
+    const result = await uploadPublicImage(platform, '_system/avatars', 'u1', makeFile('image/png'))
+
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.url).toBe('https://pub-abc.r2.dev/_system/avatars/u1.png')
+  })
+
+  it('rejects invalid mime (gif) before touching R2', async () => {
+    const r2 = mockR2Bucket()
+    const platform = mockPlatform({ r2, publicUrl: 'https://pub-abc.r2.dev' })
+
+    const result = await uploadPublicImage(platform, '_system/avatars', 'u1', makeFile('image/gif'))
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.status).toBe(400)
+    expect(r2.put).not.toHaveBeenCalled()
+  })
+
+  it('rejects file > 2 MiB before touching R2', async () => {
+    const r2 = mockR2Bucket()
+    const platform = mockPlatform({ r2, publicUrl: 'https://pub-abc.r2.dev' })
+
+    const result = await uploadPublicImage(platform, '_system/avatars', 'u1', makeFile('image/png', 3 * 1024 * 1024))
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.status).toBe(413)
+    expect(r2.put).not.toHaveBeenCalled()
+  })
+
+  it('falls back to S3 path when binding is missing (PUBLIC_IMAGES_URL alone ignored)', async () => {
+    const platform = mockPlatform({ publicUrl: 'https://pub-abc.r2.dev', dbStorageThrows: true })
+
+    const result = await uploadPublicImage(platform, '_system/avatars', 'u1', makeFile('image/png'))
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.status).toBe(503)
+  })
+
+  it('falls back to S3 path when PUBLIC_IMAGES_URL is missing (binding alone ignored)', async () => {
+    const r2 = mockR2Bucket()
+    const platform = mockPlatform({ r2, dbStorageThrows: true })
+
+    const result = await uploadPublicImage(platform, '_system/avatars', 'u1', makeFile('image/png'))
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.status).toBe(503)
+    expect(r2.put).not.toHaveBeenCalled()
+  })
+
+  it('returns 503 when neither binding nor DB storage is available', async () => {
+    const platform = mockPlatform({ dbStorageThrows: true })
+
+    const result = await uploadPublicImage(platform, '_system/avatars', 'u1', makeFile('image/png'))
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.status).toBe(503)
+  })
+})
+
+describe('deletePublicImageVariants — R2 binding path', () => {
+  it('deletes all 3 mime variants via R2 binding', async () => {
+    const r2 = mockR2Bucket()
+    const platform = mockPlatform({ r2, publicUrl: 'https://pub-abc.r2.dev' })
+
+    await deletePublicImageVariants(platform, '_system/avatars', 'u1')
+
+    expect(r2.delete).toHaveBeenCalledTimes(3)
+    const keys = r2.delete.mock.calls.map((c) => c[0] as string)
+    expect(keys).toContain('_system/avatars/u1.png')
+    expect(keys).toContain('_system/avatars/u1.jpg')
+    expect(keys).toContain('_system/avatars/u1.webp')
+  })
+
+  it('is a no-op when no backend is configured', async () => {
+    const platform = mockPlatform({ dbStorageThrows: true })
+    await expect(deletePublicImageVariants(platform, '_system/avatars', 'u1')).resolves.toBeUndefined()
+  })
+})

--- a/server/services/image-upload.ts
+++ b/server/services/image-upload.ts
@@ -1,5 +1,5 @@
 import type { Storage as S3Storage } from '../../shared/types'
-import type { Database } from '../platform/interface'
+import type { Platform } from '../platform/interface'
 import { S3Service } from './s3'
 import { selectStorage } from './storage'
 
@@ -25,17 +25,49 @@ export function imageKey(prefix: string, id: string, mime: ImageMime): string {
 
 export type ImageUploadResult = { ok: true; url: string } | { ok: false; status: 400 | 413 | 503; error: string }
 
+// Minimal R2Bucket interface we actually call — typed locally so we don't
+// depend on @cloudflare/workers-types on non-CF builds.
+interface R2BucketLike {
+  put(
+    key: string,
+    value: ArrayBuffer | ArrayBufferView | ReadableStream | Blob,
+    options?: { httpMetadata?: { contentType?: string } },
+  ): Promise<unknown>
+  delete(key: string): Promise<void>
+}
+
+type Backend =
+  | { kind: 'r2'; bucket: R2BucketLike; publicUrlBase: string }
+  | { kind: 's3'; storage: S3Storage }
+  | { kind: 'none' }
+
+// CF deployment with `PUBLIC_IMAGES` binding + `PUBLIC_IMAGES_URL` env var →
+// writes via R2 binding (zero-auth, zero-egress), reads via R2's public
+// domain (direct browser fetch, no Worker round-trip per image).
+// Everything else → falls back to the user-configured `mode='public'` S3
+// storage in the `storages` table.
+async function getBackend(platform: Platform): Promise<Backend> {
+  const r2 = platform.getBinding<R2BucketLike>('PUBLIC_IMAGES')
+  const publicUrl = platform.getEnv('PUBLIC_IMAGES_URL')
+  if (r2 && publicUrl) {
+    return { kind: 'r2', bucket: r2, publicUrlBase: publicUrl.replace(/\/$/, '') }
+  }
+  try {
+    const storage = (await selectStorage(platform.db, 'public')) as unknown as S3Storage
+    return { kind: 's3', storage }
+  } catch {
+    return { kind: 'none' }
+  }
+}
+
 /**
- * Stream-proxy a File to the workspace's public-mode bucket and return the
+ * Stream-proxy a File to the workspace's public image backend and return the
  * permanent public URL. Shared by /api/me/avatar and /api/teams/:id/logo —
- * validates mime + size, selects public storage, constructs the S3 key as
- * `<prefix>/<id>.<ext>`, PUTs, returns URL.
- *
- * Caller is responsible for auth + writing the returned URL to the right
- * DB column (user.image / organization.logo).
+ * validates mime + size, selects backend (R2 binding on CF / S3 fallback),
+ * constructs the key as `<prefix>/<id>.<ext>`, PUTs, returns URL.
  */
 export async function uploadPublicImage(
-  db: Database,
+  platform: Platform,
   prefix: string,
   id: string,
   file: File,
@@ -47,27 +79,38 @@ export async function uploadPublicImage(
     return { ok: false, status: 413, error: 'File too large. Max 2 MiB.' }
   }
 
-  let storage: S3Storage
-  try {
-    storage = (await selectStorage(db, 'public')) as unknown as S3Storage
-  } catch {
+  const backend = await getBackend(platform)
+  if (backend.kind === 'none') {
     return { ok: false, status: 503, error: 'No public storage configured' }
   }
 
   const key = imageKey(prefix, id, file.type)
   const bytes = new Uint8Array(await file.arrayBuffer())
-  await s3.putObject(storage, key, bytes, file.type)
-  return { ok: true, url: s3.getPublicUrl(storage, key) }
+
+  if (backend.kind === 'r2') {
+    await backend.bucket.put(key, bytes, { httpMetadata: { contentType: file.type } })
+    return { ok: true, url: `${backend.publicUrlBase}/${key}` }
+  }
+
+  await s3.putObject(backend.storage, key, bytes, file.type)
+  return { ok: true, url: s3.getPublicUrl(backend.storage, key) }
 }
 
 /**
- * Best-effort delete of every mime variant of a public image. DB clearing
- * is the caller's responsibility — this only touches S3.
+ * Best-effort delete of every mime variant of a public image. DB clearing is
+ * the caller's responsibility — this only touches the backend object store.
  */
-export async function deletePublicImageVariants(db: Database, prefix: string, id: string): Promise<void> {
+export async function deletePublicImageVariants(platform: Platform, prefix: string, id: string): Promise<void> {
+  const backend = await getBackend(platform)
+  if (backend.kind === 'none') return
+
+  if (backend.kind === 'r2') {
+    await Promise.allSettled(IMAGE_MIMES.map((mime) => backend.bucket.delete(imageKey(prefix, id, mime))))
+    return
+  }
+
   try {
-    const storage = (await selectStorage(db, 'public')) as unknown as S3Storage
-    await Promise.allSettled(IMAGE_MIMES.map((mime) => s3.deleteObject(storage, imageKey(prefix, id, mime))))
+    await Promise.allSettled(IMAGE_MIMES.map((mime) => s3.deleteObject(backend.storage, imageKey(prefix, id, mime))))
   } catch (err) {
     console.warn('[image-upload] S3 cleanup skipped:', err)
   }

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -273,6 +273,7 @@ export async function createTestApp(envOverrides: Record<string, string> = {}) {
   const platform: Platform = {
     db,
     getEnv: (key: string) => envOverrides[key],
+    getBinding: () => undefined,
   }
   const auth = await createAuth(db, 'test-secret', 'http://localhost:3000')
   const app = createApp(platform, auth)

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -14,6 +14,13 @@ database_name = "zpan-db"
 database_id = "5bd64957-fa49-4da0-8b7b-6e0ad84037e7"
 migrations_dir = "./migrations"
 
+# Public-bucket for avatars / org logos / future system-level public assets.
+# The deploy workflow provisions this bucket on first run, enables its managed
+# public URL, and writes PUBLIC_IMAGES_URL to the Worker's secret store.
+[[r2_buckets]]
+binding = "PUBLIC_IMAGES"
+bucket_name = "zpan-public-images"
+
 [observability]
 enabled = true
 
@@ -30,3 +37,7 @@ binding = "DB"
 database_name = "zpan-db-staging"
 database_id = "a9197d7a-6524-42f0-b646-e714dcb30b3b"
 migrations_dir = "./migrations"
+
+[[env.staging.r2_buckets]]
+binding = "PUBLIC_IMAGES"
+bucket_name = "zpan-public-images-staging"


### PR DESCRIPTION
> Reopens the work from #337 (which auto-closed when its base branch \`refactor/unified-image-upload\` was merged via #336). Rebased onto master; all 4 commits preserved.

## Why

After #336 (just merged), avatar/logo uploads all go through \`uploadPublicImage\` → \`selectStorage(db, 'public')\` → \`S3Service\`. On Cloudflare Workers this works but isn't native — writes sign requests through R2's S3-compatible endpoint, reads rely on a user-configured public storage added via Admin UI.

This PR makes CF deployments use R2 natively:

- **Write path** → \`env.PUBLIC_IMAGES.put()\` (R2 binding): zero auth, zero egress, no AWS SDK in the hot path
- **Read path** → R2's managed public domain (\`pub-xxxxxx.r2.dev/<key>\`): browser direct-fetch, CDN-cached, no Worker round-trip per image load

Forks deploying zpan to CF now get avatar/logo out of the box. **Zero manual storage config in Admin UI.**

## What changed

### Code

- \`server/platform/interface.ts\` — new \`getBinding<T>(key)\` method alongside \`getEnv\`. CF impl returns \`env[key]\` for object values; Node/Docker/libSQL return \`undefined\`.
- \`server/services/image-upload.ts\` — \`getBackend(platform)\` picks R2 if \`getBinding('PUBLIC_IMAGES')\` + \`getEnv('PUBLIC_IMAGES_URL')\` are both set, else falls back to \`selectStorage(db, 'public')\`. Same \`uploadPublicImage\` / \`deletePublicImageVariants\` signature from #336, but takes \`platform\` now.
- \`server/routes/me.ts\` / \`server/routes/teams.ts\` — pass \`platform\` instead of \`db\`.

The \`R2Bucket\` type is declared locally as a minimal structural shape (\`put\` + \`delete\`) — no \`@cloudflare/workers-types\` dependency on non-CF builds.

### Infrastructure

\`.github/workflows/deploy.yml\` gains three steps that make fork deployments fully zero-touch for avatars/logos:

1. **Ensure R2 bucket** — check-then-create via CF REST API (idempotent). Uses REST instead of \`wrangler r2 bucket list\` because that command has no \`--json\` flag.
2. **Enable R2 managed public URL** — \`PUT /r2/buckets/.../domains/managed {enabled:true}\` (idempotent) + GET to capture the assigned \`pub-xxxxxxxx.r2.dev\`.
3. **Set \`PUBLIC_IMAGES_URL\` Worker secret** — upserted after deploy.

\`wrangler.toml\`: new \`[[r2_buckets]] binding = "PUBLIC_IMAGES"\` for production + staging counterpart.

README: \`CLOUDFLARE_API_TOKEN\` now needs \`R2 Storage: Edit\` scope (3rd scope alongside Workers Scripts + D1).

## Tests

- New \`server/services/image-upload.test.ts\` — 12 unit cases:
  - mime validator
  - R2 path: happy + jpeg→jpg ext + trailing-slash URL normalization + invalid-mime reject + oversize reject
  - Fallback matrix: binding-only / URL-only / neither → 503
  - Delete-all-variants via binding + no-op when no backend
- Existing 54 integration cases (me + teams) untouched; they run via the S3 fallback path since \`createTestApp\`'s platform has no binding. This validates fallback parity with pre-PR behavior.

**Final: 84 test files, 2599 tests green locally. Typecheck clean.**

## Upstream gap (one-time manual)

CF Workers Builds (upstream's git-integrated deploy) auto-created the \`zpan-public-images\` bucket on preview, but doesn't enable the managed public URL or set the \`PUBLIC_IMAGES_URL\` secret — those steps only live in \`deploy.yml\` which runs on forks only.

For upstream (\`saltbo/zpan\`) to use the R2 path (not S3 fallback), one-time setup:

1. Dashboard → R2 → \`zpan-public-images\` → Settings → "Allow Access" → copy \`pub-xxxxxx.r2.dev\`
2. \`echo "https://pub-xxxxxx.r2.dev" | wrangler secret put PUBLIC_IMAGES_URL\`

Secret persists across Workers Builds deploys. One-time cost.

**Forks**: no manual step — \`deploy.yml\` handles everything.
**Non-CF (Docker/Node/Lambda/Vercel/etc.)**: unchanged — S3 fallback via admin-configured public storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)