### PR TITLE
feat(licensing): add cloud.zpan.space production public key

### DIFF
--- a/server/licensing/public-keys.ts
+++ b/server/licensing/public-keys.ts
@@ -1,0 +1,14 @@
+// Cloud public keys for verifying PASETO v4 entitlement certificates.
+//
+// ZPan verifies every entitlement certificate against this list.
+// Multiple keys are supported to allow zero-downtime key rotation:
+//   1. Add the new key here and deploy ZPan.
+//   2. Update the cloud Worker secret (LICENSE_SIGNING_KEY) to the new key and deploy.
+//   3. After 24 h (old certs expired), remove the old key here and deploy ZPan again.
+//
+// Keys are PASERK k4.public.* strings (Ed25519, 32 raw bytes, base64url-encoded).
+
+export const CLOUD_PUBLIC_KEYS: string[] = [
+  // cloud.zpan.space production key — provisioned 2026-04-23
+  'k4.public.sphdaogcyIh2_6_yZnO4_xQsi2m52HH9j2CPHcKlGGw',
+]


### PR DESCRIPTION
## Summary

- Creates `server/licensing/public-keys.ts` with the Ed25519 public key for verifying PASETO v4 entitlement certificates issued by `cloud.zpan.space`
- Key was provisioned 2026-04-23 using `scripts/gen-keypair.ts` in `zpan-cloud`; private key is stored as a CF Worker secret (`LICENSE_SIGNING_KEY`)

## Key details

```
Format:   PASERK k4.public.* (Ed25519, 32 bytes, base64url)
Value:    k4.public.sphdaogcyIh2_6_yZnO4_xQsi2m52HH9j2CPHcKlGGw
Added:    2026-04-23
```

## Rotation procedure (documented in zpan-cloud README)

1. Generate a new keypair in zpan-cloud: `npx tsx scripts/gen-keypair.ts`
2. Add the new `k4.public.*` entry to the array in this file and deploy ZPan
3. Update the Worker secret in zpan-cloud: `wrangler secret put LICENSE_SIGNING_KEY`
4. After 24 h (old certificates have expired), remove the old key entry and deploy ZPan again

## Related

- zpan-cloud C5 task — implements `POST /api/entitlements` and the PASETO v4 signer
- Do NOT merge before the cloud Worker is deployed with the matching `LICENSE_SIGNING_KEY` secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)