### PR TITLE
feat: v2.6 Z3 — feature gate primitives (requireFeature + ProBadge + UpgradeHint + useEntitlement + /api/licensing/status)

### DIFF
--- a/src/components/ProBadge.test.tsx
+++ b/src/components/ProBadge.test.tsx
@@ -1,0 +1,31 @@
+// Tests for src/components/ProBadge.tsx
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { ProBadge } from './ProBadge'
+
+afterEach(cleanup)
+
+describe('ProBadge', () => {
+  it('renders "Pro" text', () => {
+    const { getByText } = render(<ProBadge />)
+    expect(getByText('Pro')).toBeTruthy()
+  })
+
+  it('renders with brand color #1A73E8', () => {
+    const { getByText } = render(<ProBadge />)
+    const el = getByText('Pro')
+    expect(el.style.backgroundColor).toBe('rgb(26, 115, 232)')
+  })
+
+  it('has pro-badge slot attribute', () => {
+    const { container } = render(<ProBadge />)
+    const el = container.querySelector('[data-slot="pro-badge"]')
+    expect(el).toBeTruthy()
+  })
+
+  it('merges custom className', () => {
+    const { container } = render(<ProBadge className="extra-class" />)
+    const el = container.querySelector('[data-slot="pro-badge"]')
+    expect(el?.className).toContain('extra-class')
+  })
+})

--- a/src/components/ProBadge.tsx
+++ b/src/components/ProBadge.tsx
@@ -1,0 +1,17 @@
+import { cn } from '@/lib/utils'
+
+interface ProBadgeProps {
+  className?: string
+}
+
+export function ProBadge({ className }: ProBadgeProps) {
+  return (
+    <span
+      data-slot="pro-badge"
+      className={cn('inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold text-white', className)}
+      style={{ backgroundColor: '#1A73E8' }}
+    >
+      Pro
+    </span>
+  )
+}

--- a/src/components/UpgradeHint.test.tsx
+++ b/src/components/UpgradeHint.test.tsx
@@ -1,0 +1,109 @@
+// Tests for src/components/UpgradeHint.tsx
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { UpgradeHint } from './UpgradeHint'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/hooks/useEntitlement', () => ({
+  useEntitlement: vi.fn(),
+}))
+
+vi.mock('./ui/button', () => ({
+  Button: ({
+    children,
+    asChild,
+    ...props
+  }: {
+    children: React.ReactNode
+    asChild?: boolean
+    [key: string]: unknown
+  }) =>
+    asChild ? (
+      children
+    ) : (
+      <button type="button" {...props}>
+        {children}
+      </button>
+    ),
+}))
+
+vi.mock('./ui/card', () => ({
+  Card: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) => (
+    <div {...props}>{children}</div>
+  ),
+  CardHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+import { useEntitlement } from '@/hooks/useEntitlement'
+
+function setupEntitlement(bound: boolean) {
+  vi.mocked(useEntitlement).mockReturnValue({
+    bound,
+    plan: bound ? 'community' : null,
+    features: [],
+    hasFeature: () => false,
+    isLoading: false,
+    isError: false,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+afterEach(cleanup)
+
+describe('UpgradeHint — unbound state', () => {
+  beforeEach(() => setupEntitlement(false))
+
+  it('renders headline "Unlock with ZPan Pro"', () => {
+    const { getByText } = render(<UpgradeHint feature="white_label" />)
+    expect(getByText('Unlock with ZPan Pro')).toBeTruthy()
+  })
+
+  it('renders CTA "Connect to Cloud" when not bound', () => {
+    const { getByText } = render(<UpgradeHint feature="teams_unlimited" />)
+    expect(getByText('Connect to Cloud')).toBeTruthy()
+  })
+
+  it('links CTA to /settings/billing', () => {
+    const { getByRole } = render(<UpgradeHint feature="white_label" />)
+    const link = getByRole('link')
+    expect(link.getAttribute('href')).toBe('/settings/billing')
+  })
+
+  it('mentions the feature in the description', () => {
+    const { getByText } = render(<UpgradeHint feature="white_label" />)
+    expect(getByText(/white-label/i)).toBeTruthy()
+  })
+})
+
+describe('UpgradeHint — bound state', () => {
+  beforeEach(() => setupEntitlement(true))
+
+  it('renders CTA "Manage on Cloud" when bound', () => {
+    const { getByText } = render(<UpgradeHint feature="team_quotas" />)
+    expect(getByText('Manage on Cloud')).toBeTruthy()
+  })
+
+  it('does not render "Connect to Cloud" when bound', () => {
+    const { queryByText } = render(<UpgradeHint feature="team_quotas" />)
+    expect(queryByText('Connect to Cloud')).toBeNull()
+  })
+})
+
+describe('UpgradeHint — data-slot', () => {
+  beforeEach(() => setupEntitlement(false))
+
+  it('renders with upgrade-hint slot attribute', () => {
+    const { container } = render(<UpgradeHint feature="open_registration" />)
+    const el = container.querySelector('[data-slot="upgrade-hint"]')
+    expect(el).toBeTruthy()
+  })
+})

--- a/src/components/UpgradeHint.tsx
+++ b/src/components/UpgradeHint.tsx
@@ -1,0 +1,39 @@
+import type { ProFeature } from '@shared/types'
+import { useEntitlement } from '@/hooks/useEntitlement'
+import { Button } from './ui/button'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from './ui/card'
+
+const FEATURE_LABELS: Record<ProFeature, string> = {
+  white_label: 'white-label branding',
+  open_registration: 'open registration',
+  teams_unlimited: 'unlimited teams',
+  team_quotas: 'per-team storage quotas',
+}
+
+interface UpgradeHintProps {
+  feature: ProFeature
+}
+
+export function UpgradeHint({ feature }: UpgradeHintProps) {
+  const { bound } = useEntitlement()
+  const featureLabel = FEATURE_LABELS[feature] ?? feature
+
+  return (
+    <Card data-slot="upgrade-hint">
+      <CardHeader>
+        <CardTitle>Unlock with ZPan Pro</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground">
+          {featureLabel.charAt(0).toUpperCase() + featureLabel.slice(1)} is a Pro feature. Upgrade your plan to access
+          it.
+        </p>
+      </CardContent>
+      <CardFooter>
+        <Button asChild>
+          <a href="/settings/billing">{bound ? 'Manage on Cloud' : 'Connect to Cloud'}</a>
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/src/hooks/useEntitlement.ts
+++ b/src/hooks/useEntitlement.ts
@@ -1,0 +1,29 @@
+import type { ProFeature } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+import { getLicensingStatus } from '@/lib/api'
+
+export const entitlementQueryKey = ['licensing', 'status'] as const
+
+export function useEntitlement() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: entitlementQueryKey,
+    queryFn: getLicensingStatus,
+    staleTime: 60 * 1000,
+    refetchInterval: 60 * 1000,
+  })
+
+  function hasFeature(name: ProFeature): boolean {
+    if (!data?.bound || !data.features) return false
+    if (data.expires_at != null && Date.now() > data.expires_at * 1000) return false
+    return data.features.includes(name)
+  }
+
+  return {
+    bound: data?.bound ?? false,
+    plan: data?.plan ?? null,
+    features: data?.features ?? [],
+    hasFeature,
+    isLoading,
+    isError,
+  }
+}


### PR DESCRIPTION
## Summary

- **`server/licensing/has-feature.ts`** — `loadBindingState(db)` reads `license_binding` table and builds `BindingState`; `hasFeature(feature, state)` is a pure sync check (no DB hit, no expiry bypass)
- **`server/middleware/require-feature.ts`** — `requireFeature(name)` Hono middleware; loads binding state then returns `402 Payment Required` + `{ error: 'feature_not_available', feature, upgrade_url: '/settings/billing' }` when feature is missing or entitlement expired
- **`server/routes/licensing.ts`** — public `GET /api/licensing/status`; returns `{ bound: false }` when unbound, full `BindingState` (no `refresh_token`) when bound; mounted before `authMiddleware`
- **`src/lib/rpc.ts` + `src/lib/api.ts`** — `getLicensingStatus()` wrapper + `LicensingRoute` type export
- **`src/hooks/useEntitlement.ts`** — React Query hook with `['licensing','status']` key, 60 s refetch, returns `{ bound, plan, features, hasFeature(name), isLoading, isError }`
- **`src/components/ProBadge.tsx`** — small "Pro" pill with brand color `#1A73E8`
- **`src/components/UpgradeHint.tsx`** — block upsell card with headline "Unlock with ZPan Pro"; CTA is "Connect to Cloud" (unbound) or "Manage on Cloud" (bound, feature missing), always links to `/settings/billing`

## Test plan

- [ ] `src/lib/api.test.ts` — 4 new tests: correct URL, unbound payload, full bound payload, error throw
- [ ] `src/components/ProBadge.test.tsx` — renders "Pro" text, brand color `#1A73E8`, slot attribute, className merge
- [ ] `src/components/UpgradeHint.test.tsx` — headline, CTA text per bound state, link target, feature label in body
- [ ] All 86 test files pass (`npm test`)
- [ ] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)