### PR TITLE
feat(licensing): cloud client + binding API (pair, poll, refresh, disconnect)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "nanoid": "^5.1.0",
         "next-themes": "^0.4.6",
         "nodemailer": "^8.0.5",
+        "paseto-ts": "^2.0.6",
         "pdfjs-dist": "^5.6.205",
         "radix-ui": "^1.4.3",
         "react": "^19.0.0",
@@ -8783,6 +8784,97 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@stablelib/binary": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-2.0.1.tgz",
+      "integrity": "sha512-U9iAO8lXgEDONsA0zPPSgcf3HUBNAqHiJmSHgZz62OvC3Hi2Bhc5kTnQ3S1/L+sthDTHtCMhcEiklmIly6uQ3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/int": "^2.0.1"
+      }
+    },
+    "node_modules/@stablelib/blake2b": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/blake2b/-/blake2b-2.0.1.tgz",
+      "integrity": "sha512-kBN4i9FHpkTEVrHwKtb1ZjI6QwyoK8emY9TaLcHHFSZkw2FN9Td8Js9mU2U10q+EZ3Mp6z78QgdPDwJXbc3Dtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/binary": "^2.0.1",
+        "@stablelib/hash": "^2.0.0",
+        "@stablelib/wipe": "^2.0.1"
+      }
+    },
+    "node_modules/@stablelib/chacha": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/chacha/-/chacha-2.0.1.tgz",
+      "integrity": "sha512-lS1FqtNqofxe2vLkRsLli2m3x/XanUyAYRphLhdHumKeIsLbjbCXdCq3Pf/eWiO7G3QlSG5ViqnoVjktzfLWMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/binary": "^2.0.1",
+        "@stablelib/wipe": "^2.0.1"
+      }
+    },
+    "node_modules/@stablelib/ed25519": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-2.1.0.tgz",
+      "integrity": "sha512-8GLWoJur9nJiErABKHs5MjceSiYJJ2n8QP9k8Q5x6GWU2y5oAQ6qzPh8kCgQy5aHlUxcmRA1frQ5Gu2bHoIDPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/random": "^2.0.1",
+        "@stablelib/sha512": "^2.0.1",
+        "@stablelib/wipe": "^2.0.1"
+      }
+    },
+    "node_modules/@stablelib/hash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-2.0.0.tgz",
+      "integrity": "sha512-u3WPSqGido8lwJuMcrBgM5K54LrPGhkWAdtsyccf7dGsLixAZUds77zOAbu7bvKPwQlmoByH0txBi5rTmEKuHg==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/int": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-2.0.1.tgz",
+      "integrity": "sha512-Ht63fQp3wz/F8U4AlXEPb7hfJOIILs8Lq55jgtD7KueWtyjhVuzcsGLSTAWtZs3XJDZYdF1WcSKn+kBtbzupww==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/random": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-2.0.1.tgz",
+      "integrity": "sha512-W6GAtXEEs7r+dSbuBsvoFmlyL3gLxle41tQkjKu17dDWtDdjhVUbtRfRCQcCUeczwkgjQxMPopgwYEvxXtHXGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/binary": "^2.0.1",
+        "@stablelib/wipe": "^2.0.1"
+      }
+    },
+    "node_modules/@stablelib/sha512": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/sha512/-/sha512-2.0.1.tgz",
+      "integrity": "sha512-DUNe5cbnoH3sSIN+MG04RvTCLXtkbyy/SnQxiNO+GgF/KSXkkUSlF6mUVvCUdZBZ2X3NgogR+tAvaRSn8wxnLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/binary": "^2.0.1",
+        "@stablelib/hash": "^2.0.0",
+        "@stablelib/wipe": "^2.0.1"
+      }
+    },
+    "node_modules/@stablelib/wipe": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-2.0.1.tgz",
+      "integrity": "sha512-1eU2K9EgOcV4qc9jcP6G72xxZxEm5PfeI5H55l08W95b4oRJaqhmlWRc4xZAm6IVSKhVNxMi66V67hCzzuMTAg==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/xchacha20": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/xchacha20/-/xchacha20-2.0.1.tgz",
+      "integrity": "sha512-k55pNv7gIM4mUPU00+nJYTxKiUVNwAtsgrridC0aIU5cVbw9u6qP99x8ENu5eiwOEhZUNg+p3tTOLooCeAOJQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/binary": "^2.0.1",
+        "@stablelib/chacha": "^2.0.1",
+        "@stablelib/wipe": "^2.0.1"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -14432,6 +14524,17 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/paseto-ts": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/paseto-ts/-/paseto-ts-2.0.6.tgz",
+      "integrity": "sha512-Ul3AzoCcS4uA6jF+GW2zYUxZY78xsqCbfxdv2Khk/30hDxAzcvsWQjp4uW1XcbkrO9zNrPbdBv4HiXgJigWLVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/blake2b": "^2.0.1",
+        "@stablelib/ed25519": "^2.1.0",
+        "@stablelib/xchacha20": "^2.0.1"
       }
     },
     "node_modules/path-expression-matcher": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "nanoid": "^5.1.0",
     "next-themes": "^0.4.6",
     "nodemailer": "^8.0.5",
+    "paseto-ts": "^2.0.6",
     "pdfjs-dist": "^5.6.205",
     "radix-ui": "^1.4.3",
     "react": "^19.0.0",

--- a/server/app.ts
+++ b/server/app.ts
@@ -12,6 +12,8 @@ import emailConfig from './routes/email-config'
 import ihost from './routes/ihost'
 import ihostConfig from './routes/ihost-config'
 import { adminInviteCodes, publicInviteCodes } from './routes/invite-codes'
+import licensing from './routes/licensing'
+import licensingAdmin from './routes/licensing-admin'
 import { me } from './routes/me'
 import { notifications } from './routes/notifications'
 import objects from './routes/objects'
@@ -56,6 +58,7 @@ export function createApp(platform: Platform, auth: Auth) {
   app.route('/api/profiles', profile)
   app.route('/api/teams', publicTeams)
   app.route('/api/auth-providers', publicAuthProviders)
+  app.route('/api/licensing', licensing)
 
   app.use('/api/*', authMiddleware)
 
@@ -79,6 +82,7 @@ export function createApp(platform: Platform, auth: Auth) {
   app.route('/api/notifications', notifications)
   app.route('/api/ihost', ihost)
   app.route('/api/ihost/config', ihostConfig)
+  app.route('/api/licensing', licensingAdmin)
 
   app.get('/api/health', (c) => c.json({ status: 'ok' }))
 
@@ -109,3 +113,5 @@ export type NotificationsRoute = typeof notifications
 export type IhostRoute = typeof ihost
 export type IhostConfigRoute = typeof ihostConfig
 export type MeRoute = typeof me
+export type LicensingRoute = typeof licensing
+export type LicensingAdminRoute = typeof licensingAdmin

--- a/server/licensing/entitlement.test.ts
+++ b/server/licensing/entitlement.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment node
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { sign } from 'paseto-ts/v4'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import * as authSchema from '../db/auth-schema'
+import * as appSchema from '../db/schema'
+import { invalidateEntitlementCache, loadEntitlement } from './entitlement'
+
+const SCHEMA_SQL = `
+  CREATE TABLE IF NOT EXISTS license_binding (
+    id INTEGER PRIMARY KEY,
+    instance_id TEXT NOT NULL,
+    cloud_account_id TEXT,
+    cloud_account_email TEXT,
+    refresh_token TEXT NOT NULL,
+    cached_cert TEXT,
+    cached_expires_at INTEGER,
+    last_refresh_at INTEGER,
+    last_refresh_error TEXT,
+    bound_at INTEGER
+  );
+  CREATE TABLE IF NOT EXISTS system_options (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL DEFAULT '',
+    public INTEGER DEFAULT 0
+  );
+`
+
+const DEV_SECRET = 'k4.secret.K_XrtRH8ozh6oM38rkCz7oHxU_GbKIuExCg2jmBl9_VgfF29_7kGkFAnXvII1bHUBy2Yjw04DRdC4kmbuSND2Q'
+
+function makeDb() {
+  const sqlite = new Database(':memory:')
+  sqlite.exec(SCHEMA_SQL)
+  return drizzle(sqlite, { schema: { ...appSchema, ...authSchema } })
+}
+
+describe('loadEntitlement', () => {
+  beforeEach(() => {
+    invalidateEntitlementCache()
+  })
+
+  afterEach(() => {
+    invalidateEntitlementCache()
+  })
+
+  it('returns null when no binding row exists', async () => {
+    const db = makeDb()
+    const result = await loadEntitlement(db)
+    expect(result).toBeNull()
+  })
+
+  it('returns null when binding has no cachedCert', async () => {
+    const db = makeDb()
+    await db.insert(appSchema.licenseBinding).values({
+      id: 1,
+      instanceId: 'inst-1',
+      refreshToken: 'token',
+      cachedCert: null,
+      cachedExpiresAt: null,
+      lastRefreshAt: null,
+      lastRefreshError: null,
+      boundAt: null,
+    })
+
+    const result = await loadEntitlement(db)
+    expect(result).toBeNull()
+  })
+
+  it('returns entitlement summary for a valid PASETO cert', async () => {
+    const db = makeDb()
+
+    const cert = sign(DEV_SECRET, {
+      account_id: 'acct-1',
+      instance_id: 'inst-1',
+      plan: 'pro',
+      features: ['white_label'],
+      issued_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+    })
+
+    await db.insert(appSchema.licenseBinding).values({
+      id: 1,
+      instanceId: 'inst-1',
+      refreshToken: 'token',
+      cachedCert: cert,
+      cachedExpiresAt: null,
+      lastRefreshAt: null,
+      lastRefreshError: null,
+      boundAt: null,
+    })
+
+    const result = await loadEntitlement(db)
+    expect(result).not.toBeNull()
+    expect(result?.plan).toBe('pro')
+    expect(result?.features).toEqual(['white_label'])
+  })
+
+  it('returns null for an invalid/expired PASETO cert', async () => {
+    const db = makeDb()
+
+    const cert = sign(DEV_SECRET, {
+      account_id: 'acct-1',
+      instance_id: 'inst-1',
+      plan: 'pro',
+      features: ['white_label'],
+      issued_at: new Date(Date.now() - 100000).toISOString(),
+      expires_at: new Date(Date.now() - 1000).toISOString(), // expired
+    })
+
+    await db.insert(appSchema.licenseBinding).values({
+      id: 1,
+      instanceId: 'inst-1',
+      refreshToken: 'token',
+      cachedCert: cert,
+      cachedExpiresAt: null,
+      lastRefreshAt: null,
+      lastRefreshError: null,
+      boundAt: null,
+    })
+
+    const result = await loadEntitlement(db)
+    expect(result).toBeNull()
+  })
+})
+
+describe('invalidateEntitlementCache', () => {
+  it('clears cached state so next call re-reads from DB', async () => {
+    const db = makeDb()
+
+    // Load once — result is null, cached
+    await loadEntitlement(db)
+
+    // Now insert a binding
+    const cert = sign(DEV_SECRET, {
+      account_id: 'acct-1',
+      instance_id: 'inst-1',
+      plan: 'pro',
+      features: ['team_quotas'],
+      issued_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+    })
+
+    await db.insert(appSchema.licenseBinding).values({
+      id: 1,
+      instanceId: 'inst-1',
+      refreshToken: 'token',
+      cachedCert: cert,
+      cachedExpiresAt: null,
+      lastRefreshAt: null,
+      lastRefreshError: null,
+      boundAt: null,
+    })
+
+    // Without invalidation, the cached null would be returned
+    invalidateEntitlementCache()
+
+    const result = await loadEntitlement(db)
+    expect(result?.plan).toBe('pro')
+  })
+})

--- a/server/licensing/entitlement.ts
+++ b/server/licensing/entitlement.ts
@@ -1,0 +1,50 @@
+import type { ProFeature } from '@shared/types'
+import { eq } from 'drizzle-orm'
+import { licenseBinding } from '../db/schema'
+import type { Database } from '../platform/interface'
+import { verifyCertificate } from './verify'
+
+export interface EntitlementSummary {
+  plan: 'community' | 'pro'
+  features: ProFeature[]
+}
+
+const CACHE_TTL_MS = 60_000
+
+let cachedSummary: EntitlementSummary | null = null
+let cachedAt = 0
+
+// Load and verify the cached license cert from the database.
+// Result is memoized in-process for 60 seconds — feature checks never block on DB.
+// Cache is automatically invalidated on restart or after TTL.
+export async function loadEntitlement(db: Database): Promise<EntitlementSummary | null> {
+  const now = Date.now()
+  if (cachedAt > 0 && now - cachedAt < CACHE_TTL_MS) {
+    return cachedSummary
+  }
+
+  const rows = await db
+    .select({ instanceId: licenseBinding.instanceId, cachedCert: licenseBinding.cachedCert })
+    .from(licenseBinding)
+    .where(eq(licenseBinding.id, 1))
+    .limit(1)
+
+  const row = rows[0]
+  if (!row?.cachedCert) {
+    cachedSummary = null
+    cachedAt = now
+    return null
+  }
+
+  const entitlement = verifyCertificate(row.cachedCert, row.instanceId)
+  cachedSummary = entitlement ? { plan: entitlement.plan, features: entitlement.features } : null
+  cachedAt = now
+  return cachedSummary
+}
+
+// Invalidate the in-process cache — call after a cert refresh so the next
+// feature check picks up the new entitlement without waiting for TTL.
+export function invalidateEntitlementCache(): void {
+  cachedAt = 0
+  cachedSummary = null
+}

--- a/server/licensing/has-feature.test.ts
+++ b/server/licensing/has-feature.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import type { BindingState } from '../../shared/types'
+import { hasFeature } from './has-feature'
+
+describe('hasFeature', () => {
+  it('returns false when state is null', () => {
+    expect(hasFeature('white_label', null)).toBe(false)
+  })
+
+  it('returns false when state is unbound', () => {
+    const state: BindingState = { bound: false }
+    expect(hasFeature('white_label', state)).toBe(false)
+  })
+
+  it('returns false when bound but features list is empty', () => {
+    const state: BindingState = { bound: true, plan: 'community', features: [] }
+    expect(hasFeature('white_label', state)).toBe(false)
+  })
+
+  it('returns true when feature is in features list', () => {
+    const state: BindingState = {
+      bound: true,
+      plan: 'pro',
+      features: ['white_label', 'teams_unlimited'],
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+    }
+    expect(hasFeature('white_label', state)).toBe(true)
+  })
+
+  it('returns false when feature is not in features list', () => {
+    const state: BindingState = {
+      bound: true,
+      plan: 'pro',
+      features: ['white_label'],
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+    }
+    expect(hasFeature('teams_unlimited', state)).toBe(false)
+  })
+
+  it('returns false when entitlement has expired', () => {
+    const state: BindingState = {
+      bound: true,
+      plan: 'pro',
+      features: ['white_label'],
+      expires_at: Math.floor(Date.now() / 1000) - 1, // 1 second in the past
+    }
+    expect(hasFeature('white_label', state)).toBe(false)
+  })
+
+  it('returns true when expires_at is in the future', () => {
+    const state: BindingState = {
+      bound: true,
+      plan: 'pro',
+      features: ['team_quotas'],
+      expires_at: Math.floor(Date.now() / 1000) + 86400,
+    }
+    expect(hasFeature('team_quotas', state)).toBe(true)
+  })
+
+  it('returns true when expires_at is undefined (no expiry)', () => {
+    const state: BindingState = {
+      bound: true,
+      plan: 'pro',
+      features: ['open_registration'],
+    }
+    expect(hasFeature('open_registration', state)).toBe(true)
+  })
+})

--- a/server/licensing/has-feature.ts
+++ b/server/licensing/has-feature.ts
@@ -1,0 +1,37 @@
+import type { BindingState, LicenseEntitlement, ProFeature } from '../../shared/types'
+import { licenseBinding } from '../db/schema'
+import type { Database } from '../platform/interface'
+
+export async function loadBindingState(db: Database): Promise<BindingState> {
+  const rows = await db.select().from(licenseBinding).limit(1)
+  if (rows.length === 0) return { bound: false }
+
+  const row = rows[0]
+  const state: BindingState = {
+    bound: true,
+    account_email: row.cloudAccountEmail ?? undefined,
+    last_refresh_at: row.lastRefreshAt ?? undefined,
+    last_refresh_error: row.lastRefreshError ?? undefined,
+  }
+
+  if (row.cachedCert) {
+    try {
+      const entitlement = JSON.parse(row.cachedCert) as LicenseEntitlement
+      state.plan = entitlement.plan
+      state.features = entitlement.features
+      state.expires_at = entitlement.expires_at
+        ? Math.floor(new Date(entitlement.expires_at).getTime() / 1000)
+        : undefined
+    } catch {
+      // malformed cached cert — treat as unentitled
+    }
+  }
+
+  return state
+}
+
+export function hasFeature(feature: ProFeature, state: BindingState | null): boolean {
+  if (!state?.bound || !state.features) return false
+  if (state.expires_at != null && Date.now() > state.expires_at * 1000) return false
+  return state.features.includes(feature)
+}

--- a/server/licensing/instance-id.ts
+++ b/server/licensing/instance-id.ts
@@ -1,0 +1,26 @@
+import { eq } from 'drizzle-orm'
+import { nanoid } from 'nanoid'
+import { systemOptions } from '../db/schema'
+import type { Database } from '../platform/interface'
+
+const INSTANCE_ID_KEY = 'instance_id'
+
+// Returns the instance UUID, creating and persisting one if it does not exist.
+// The ID is stored in systemOptions under key 'instance_id'.
+export async function getOrCreateInstanceId(db: Database): Promise<string> {
+  const rows = await db
+    .select({ value: systemOptions.value })
+    .from(systemOptions)
+    .where(eq(systemOptions.key, INSTANCE_ID_KEY))
+    .limit(1)
+
+  if (rows[0]?.value) return rows[0].value
+
+  const id = nanoid(21)
+  await db
+    .insert(systemOptions)
+    .values({ key: INSTANCE_ID_KEY, value: id, public: false })
+    .onConflictDoUpdate({ target: systemOptions.key, set: { value: id } })
+
+  return id
+}

--- a/server/licensing/public-keys.test.ts
+++ b/server/licensing/public-keys.test.ts
@@ -1,0 +1,16 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { PUBLIC_KEYS } from './public-keys'
+
+describe('PUBLIC_KEYS', () => {
+  it('exports a non-empty array', () => {
+    expect(PUBLIC_KEYS).toBeInstanceOf(Array)
+    expect(PUBLIC_KEYS.length).toBeGreaterThan(0)
+  })
+
+  it('each entry is a PASERK v4 public key', () => {
+    for (const key of PUBLIC_KEYS) {
+      expect(key).toMatch(/^k4\.public\./)
+    }
+  })
+})

--- a/server/licensing/public-keys.ts
+++ b/server/licensing/public-keys.ts
@@ -1,0 +1,10 @@
+// Replace DEV key with production key from cloud.zpan.space before Z11
+//
+// Rotation: add new key to the array; old certs signed by any key in the list
+// will continue to verify. Remove a key only after all certs signed by it have
+// expired or been re-issued.
+//
+// DEV placeholder keypair (throwaway — real production key lands via a
+// cross-repo PR from cloud's C5 task):
+//   secret: k4.secret.K_XrtRH8ozh6oM38rkCz7oHxU_GbKIuExCg2jmBl9_VgfF29_7kGkFAnXvII1bHUBy2Yjw04DRdC4kmbuSND2Q
+export const PUBLIC_KEYS: string[] = ['k4.public.YHxdvf-5BpBQJ17yCNWx1ActmI8NOA0XQuJJm7kjQ9k']

--- a/server/licensing/refresh.test.ts
+++ b/server/licensing/refresh.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment node
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { sign } from 'paseto-ts/v4'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as authSchema from '../db/auth-schema'
+import * as appSchema from '../db/schema'
+import { invalidateEntitlementCache } from './entitlement'
+import { performRefresh } from './refresh'
+
+const SCHEMA_SQL = `
+  CREATE TABLE IF NOT EXISTS license_binding (
+    id INTEGER PRIMARY KEY,
+    instance_id TEXT NOT NULL,
+    cloud_account_id TEXT,
+    cloud_account_email TEXT,
+    refresh_token TEXT NOT NULL,
+    cached_cert TEXT,
+    cached_expires_at INTEGER,
+    last_refresh_at INTEGER,
+    last_refresh_error TEXT,
+    bound_at INTEGER
+  );
+  CREATE TABLE IF NOT EXISTS system_options (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL DEFAULT '',
+    public INTEGER DEFAULT 0
+  );
+`
+
+const DEV_SECRET = 'k4.secret.K_XrtRH8ozh6oM38rkCz7oHxU_GbKIuExCg2jmBl9_VgfF29_7kGkFAnXvII1bHUBy2Yjw04DRdC4kmbuSND2Q'
+
+function futureIso(offsetMs: number): string {
+  return new Date(Date.now() + offsetMs).toISOString()
+}
+
+function makeDb() {
+  const sqlite = new Database(':memory:')
+  sqlite.exec(SCHEMA_SQL)
+  return drizzle(sqlite, { schema: { ...appSchema, ...authSchema } })
+}
+
+type DB = ReturnType<typeof makeDb>
+
+async function seedBinding(db: DB, overrides: Partial<typeof appSchema.licenseBinding.$inferInsert> = {}) {
+  await db.insert(appSchema.licenseBinding).values({
+    id: 1,
+    instanceId: 'inst-abc',
+    refreshToken: 'old-rt',
+    cachedCert: null,
+    cachedExpiresAt: null,
+    lastRefreshAt: null,
+    lastRefreshError: null,
+    boundAt: null,
+    ...overrides,
+  })
+}
+
+describe('performRefresh', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+    invalidateEntitlementCache()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('is a no-op when no binding exists', async () => {
+    const db = makeDb()
+    // No binding row — should return without error
+    await expect(performRefresh(db, 'https://cloud.zpan.space')).resolves.toBeUndefined()
+  })
+
+  it('rotates refresh_token and stores plain object entitlement (pre-C5)', async () => {
+    const db = makeDb()
+    await seedBinding(db)
+
+    const cloudPayload = {
+      refresh_token: 'new-rt',
+      entitlement: {
+        account_id: 'acct-1',
+        instance_id: 'inst-abc',
+        plan: 'pro',
+        features: ['white_label'],
+        issued_at: new Date().toISOString(),
+        expires_at: futureIso(86400000),
+      },
+    }
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => cloudPayload,
+      text: async () => '',
+    } as unknown as Response)
+
+    await performRefresh(db, 'https://cloud.zpan.space')
+
+    const rows = await db.select().from(appSchema.licenseBinding).limit(1)
+    expect(rows[0].refreshToken).toBe('new-rt')
+    expect(rows[0].cachedCert).toBeTruthy()
+    expect(rows[0].lastRefreshAt).toBeTruthy()
+    expect(rows[0].lastRefreshError).toBeNull()
+  })
+
+  it('rotates refresh_token and stores PASETO string entitlement', async () => {
+    const db = makeDb()
+    await seedBinding(db)
+
+    const cert = sign(DEV_SECRET, {
+      account_id: 'acct-1',
+      instance_id: 'inst-abc',
+      plan: 'pro',
+      features: ['white_label'],
+      issued_at: new Date().toISOString(),
+      expires_at: futureIso(3_600_000),
+    })
+
+    const cloudPayload = { refresh_token: 'new-rt-paseto', entitlement: cert }
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => cloudPayload,
+      text: async () => '',
+    } as unknown as Response)
+
+    await performRefresh(db, 'https://cloud.zpan.space')
+
+    const rows = await db.select().from(appSchema.licenseBinding).limit(1)
+    expect(rows[0].refreshToken).toBe('new-rt-paseto')
+    expect(rows[0].cachedCert).toBe(cert)
+  })
+
+  it('clears binding row on CloudUnboundError (401)', async () => {
+    const db = makeDb()
+    await seedBinding(db)
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+      text: async () => '',
+    } as unknown as Response)
+
+    await performRefresh(db, 'https://cloud.zpan.space')
+
+    const rows = await db.select().from(appSchema.licenseBinding).limit(1)
+    expect(rows.length).toBe(0)
+  })
+
+  it('updates last_refresh_error on network error, keeps binding', async () => {
+    const db = makeDb()
+    await seedBinding(db)
+
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('Connection timeout'))
+
+    await performRefresh(db, 'https://cloud.zpan.space')
+
+    const rows = await db.select().from(appSchema.licenseBinding).limit(1)
+    expect(rows[0].refreshToken).toBe('old-rt') // unchanged
+    expect(rows[0].lastRefreshError).toBe('Connection timeout')
+  })
+})

--- a/server/licensing/refresh.ts
+++ b/server/licensing/refresh.ts
@@ -1,0 +1,79 @@
+import type { LicenseEntitlement } from '@shared/types'
+import { eq } from 'drizzle-orm'
+import { licenseBinding } from '../db/schema'
+import type { Database } from '../platform/interface'
+import { CloudNetworkError, CloudUnboundError, refreshEntitlement } from '../services/licensing-cloud'
+import { invalidateEntitlementCache } from './entitlement'
+import { verifyCertificate } from './verify'
+
+// Normalise the entitlement from cloud into a stored JSON string.
+// Cloud C5 will always return a PASETO-signed string; before C5 it may be an
+// object. In the pre-C5 path we store the raw JSON. In the PASETO path we verify
+// the cert and store the raw token so it can be re-verified on subsequent reads.
+function normaliseCert(raw: string | object, instanceId: string): { cert: string; entitlement: LicenseEntitlement | null } {
+  if (typeof raw === 'string') {
+    // PASETO string — verify and cache the raw token
+    const entitlement = verifyCertificate(raw, instanceId)
+    return { cert: raw, entitlement }
+  }
+
+  // Pre-C5 plain object — store as JSON; treat as trusted (no sig check yet)
+  // TODO: assert PASETO string once C5 lands; remove this branch
+  const cert = JSON.stringify(raw)
+  const typed = raw as LicenseEntitlement
+  return { cert, entitlement: typed }
+}
+
+// Performs an entitlement refresh against cloud using the stored refresh_token.
+//
+// On success: rotates refresh_token + cached_cert, updates last_refresh_at, clears last_refresh_error.
+// On CloudUnboundError (401): clears the licenseBinding row entirely (instance unbound from cloud).
+// On network error: updates last_refresh_error only — keeps existing cached cert intact.
+export async function performRefresh(db: Database, baseUrl: string): Promise<void> {
+  const rows = await db
+    .select({
+      instanceId: licenseBinding.instanceId,
+      refreshToken: licenseBinding.refreshToken,
+    })
+    .from(licenseBinding)
+    .where(eq(licenseBinding.id, 1))
+    .limit(1)
+
+  const row = rows[0]
+  if (!row) return // no binding — nothing to refresh
+
+  try {
+    const data = await refreshEntitlement(baseUrl, row.refreshToken)
+    const { cert, entitlement } = normaliseCert(data.entitlement, row.instanceId)
+
+    await db
+      .update(licenseBinding)
+      .set({
+        refreshToken: data.refresh_token,
+        cachedCert: cert,
+        cachedExpiresAt: entitlement ? Math.floor(new Date(entitlement.expires_at).getTime() / 1000) : null,
+        lastRefreshAt: Math.floor(Date.now() / 1000),
+        lastRefreshError: null,
+      })
+      .where(eq(licenseBinding.id, 1))
+
+    invalidateEntitlementCache()
+  } catch (err) {
+    if (err instanceof CloudUnboundError) {
+      await db.delete(licenseBinding).where(eq(licenseBinding.id, 1))
+      invalidateEntitlementCache()
+      return
+    }
+
+    if (err instanceof CloudNetworkError || err instanceof Error) {
+      await db
+        .update(licenseBinding)
+        .set({ lastRefreshError: err.message })
+        .where(eq(licenseBinding.id, 1))
+      // Keep cached cert — it remains valid until its own expires_at
+      return
+    }
+
+    throw err
+  }
+}

--- a/server/licensing/refresh.ts
+++ b/server/licensing/refresh.ts
@@ -10,7 +10,10 @@ import { verifyCertificate } from './verify'
 // Cloud C5 will always return a PASETO-signed string; before C5 it may be an
 // object. In the pre-C5 path we store the raw JSON. In the PASETO path we verify
 // the cert and store the raw token so it can be re-verified on subsequent reads.
-function normaliseCert(raw: string | object, instanceId: string): { cert: string; entitlement: LicenseEntitlement | null } {
+function normaliseCert(
+  raw: string | object,
+  instanceId: string,
+): { cert: string; entitlement: LicenseEntitlement | null } {
   if (typeof raw === 'string') {
     // PASETO string — verify and cache the raw token
     const entitlement = verifyCertificate(raw, instanceId)
@@ -66,10 +69,7 @@ export async function performRefresh(db: Database, baseUrl: string): Promise<voi
     }
 
     if (err instanceof CloudNetworkError || err instanceof Error) {
-      await db
-        .update(licenseBinding)
-        .set({ lastRefreshError: err.message })
-        .where(eq(licenseBinding.id, 1))
+      await db.update(licenseBinding).set({ lastRefreshError: err.message }).where(eq(licenseBinding.id, 1))
       // Keep cached cert — it remains valid until its own expires_at
       return
     }

--- a/server/licensing/verify.test.ts
+++ b/server/licensing/verify.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+import { generateKeys, sign } from 'paseto-ts/v4'
+import { describe, expect, it } from 'vitest'
+import { verifyCertificate } from './verify'
+
+// DEV keypair matching PUBLIC_KEYS[0] — used to sign test certs
+const DEV_SECRET = 'k4.secret.K_XrtRH8ozh6oM38rkCz7oHxU_GbKIuExCg2jmBl9_VgfF29_7kGkFAnXvII1bHUBy2Yjw04DRdC4kmbuSND2Q'
+
+function futureIso(offsetMs: number): string {
+  return new Date(Date.now() + offsetMs).toISOString()
+}
+
+function pastIso(offsetMs: number): string {
+  return new Date(Date.now() - offsetMs).toISOString()
+}
+
+function signCert(overrides: Record<string, unknown> = {}, key = DEV_SECRET): string {
+  return sign(key, {
+    account_id: 'acct-1',
+    instance_id: 'inst-abc',
+    plan: 'pro',
+    features: ['white_label'],
+    issued_at: new Date().toISOString(),
+    expires_at: futureIso(3_600_000), // 1 hour from now
+    ...overrides,
+  })
+}
+
+describe('verifyCertificate', () => {
+  it('returns entitlement for a valid cert signed by PUBLIC_KEYS[0]', () => {
+    const cert = signCert()
+    const result = verifyCertificate(cert, 'inst-abc')
+
+    expect(result).not.toBeNull()
+    expect(result?.plan).toBe('pro')
+    expect(result?.features).toEqual(['white_label'])
+    expect(result?.instance_id).toBe('inst-abc')
+    expect(result?.account_id).toBe('acct-1')
+  })
+
+  it('returns null for a cert with an invalid signature', () => {
+    const cert = signCert()
+    // Corrupt the cert by altering a character in the payload segment
+    const corrupted = `${cert.slice(0, -5)}XXXXX`
+    expect(verifyCertificate(corrupted, 'inst-abc')).toBeNull()
+  })
+
+  it('returns null for an expired cert', () => {
+    const cert = signCert({ expires_at: pastIso(1000) })
+    expect(verifyCertificate(cert, 'inst-abc')).toBeNull()
+  })
+
+  it('returns null when instance_id does not match', () => {
+    const cert = signCert({ instance_id: 'inst-abc' })
+    expect(verifyCertificate(cert, 'inst-DIFFERENT')).toBeNull()
+  })
+
+  it('verifies a cert signed by a second key when two keys are in PUBLIC_KEYS', async () => {
+    const { secretKey: altSecret, publicKey: altPublic } = generateKeys('public')
+
+    // Temporarily inject the alt key into PUBLIC_KEYS for this test
+    const { PUBLIC_KEYS } = await import('./public-keys')
+    const original = [...PUBLIC_KEYS]
+    PUBLIC_KEYS.push(altPublic)
+
+    try {
+      const cert = signCert({ instance_id: 'inst-xyz' }, altSecret)
+      const result = verifyCertificate(cert, 'inst-xyz')
+      expect(result).not.toBeNull()
+      expect(result?.plan).toBe('pro')
+    } finally {
+      PUBLIC_KEYS.length = 0
+      for (const k of original) PUBLIC_KEYS.push(k)
+    }
+  })
+
+  it('returns null when the cert is not a valid PASETO token at all', () => {
+    expect(verifyCertificate('not-a-token', 'inst-abc')).toBeNull()
+  })
+})

--- a/server/licensing/verify.ts
+++ b/server/licensing/verify.ts
@@ -1,0 +1,44 @@
+import type { LicenseEntitlement } from '@shared/types'
+import { verify } from 'paseto-ts/v4'
+import { PUBLIC_KEYS } from './public-keys'
+
+// Attempt to verify a PASETO v4.public cert against each known public key.
+// Returns the parsed entitlement only when ALL of the following hold:
+//   1. Signature is valid for one of the PUBLIC_KEYS
+//   2. expires_at has not passed
+//   3. instance_id matches the provided instanceId
+// Returns null (never throws) for any invalid cert so feature gates silently lock.
+export function verifyCertificate(cert: string, instanceId: string): LicenseEntitlement | null {
+  for (const key of PUBLIC_KEYS) {
+    const entitlement = tryVerify(cert, key, instanceId)
+    if (entitlement !== null) {
+      return entitlement
+    }
+  }
+  return null
+}
+
+function tryVerify(cert: string, publicKey: string, instanceId: string): LicenseEntitlement | null {
+  try {
+    const { payload } = verify<LicenseEntitlement>(publicKey, cert, { validatePayload: false })
+
+    if (new Date(payload.expires_at) <= new Date()) {
+      return null
+    }
+
+    if (payload.instance_id !== instanceId) {
+      return null
+    }
+
+    return {
+      account_id: payload.account_id,
+      instance_id: payload.instance_id,
+      plan: payload.plan,
+      features: payload.features,
+      issued_at: payload.issued_at,
+      expires_at: payload.expires_at,
+    }
+  } catch {
+    return null
+  }
+}

--- a/server/middleware/require-feature.ts
+++ b/server/middleware/require-feature.ts
@@ -8,10 +8,7 @@ export function requireFeature(name: ProFeature) {
     const db = c.get('platform').db
     const state = await loadBindingState(db)
     if (!hasFeature(name, state)) {
-      return c.json(
-        { error: 'feature_not_available', feature: name, upgrade_url: '/settings/billing' },
-        402,
-      )
+      return c.json({ error: 'feature_not_available', feature: name, upgrade_url: '/settings/billing' }, 402)
     }
     await next()
   })

--- a/server/middleware/require-feature.ts
+++ b/server/middleware/require-feature.ts
@@ -1,0 +1,18 @@
+import type { ProFeature } from '@shared/types'
+import { createMiddleware } from 'hono/factory'
+import { hasFeature, loadBindingState } from '../licensing/has-feature'
+import type { Env } from './platform'
+
+export function requireFeature(name: ProFeature) {
+  return createMiddleware<Env>(async (c, next) => {
+    const db = c.get('platform').db
+    const state = await loadBindingState(db)
+    if (!hasFeature(name, state)) {
+      return c.json(
+        { error: 'feature_not_available', feature: name, upgrade_url: '/settings/billing' },
+        402,
+      )
+    }
+    await next()
+  })
+}

--- a/server/routes/licensing-admin.integration.test.ts
+++ b/server/routes/licensing-admin.integration.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as schema from '../db/schema.js'
+import { adminHeaders, authedHeaders, createTestApp } from '../test/setup.js'
+
+function makeCloudResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response
+}
+
+describe('Licensing Admin API — auth guards', () => {
+  it('POST /api/licensing/pair returns 401 without auth', async () => {
+    const { app } = await createTestApp()
+    const res = await app.request('/api/licensing/pair', { method: 'POST' })
+    expect(res.status).toBe(401)
+  })
+
+  it('GET /api/licensing/pair/:code/poll returns 401 without auth', async () => {
+    const { app } = await createTestApp()
+    const res = await app.request('/api/licensing/pair/ABC-123/poll')
+    expect(res.status).toBe(401)
+  })
+
+  it('POST /api/licensing/refresh returns 401 without auth', async () => {
+    const { app } = await createTestApp()
+    const res = await app.request('/api/licensing/refresh', { method: 'POST' })
+    expect(res.status).toBe(401)
+  })
+
+  it('DELETE /api/licensing/binding returns 401 without auth', async () => {
+    const { app } = await createTestApp()
+    const res = await app.request('/api/licensing/binding', { method: 'DELETE' })
+    expect(res.status).toBe(401)
+  })
+
+  it('POST /api/licensing/pair returns 403 for non-admin', async () => {
+    const { app } = await createTestApp()
+    await authedHeaders(app, 'admin@example.com')
+    await authedHeaders(app, 'regular@example.com')
+    const signInRes = await app.request('/api/auth/sign-in/email', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'regular@example.com', password: 'password123456' }),
+    })
+    const headers = { Cookie: signInRes.headers.getSetCookie().join('; ') }
+    const res = await app.request('/api/licensing/pair', { method: 'POST', headers })
+    expect(res.status).toBe(403)
+  })
+})
+
+describe('POST /api/licensing/pair', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('calls cloud and returns pairing info', async () => {
+    const { app } = await createTestApp()
+    const headers = await adminHeaders(app)
+
+    const cloudPayload = {
+      code: 'ABC-123',
+      pairing_url: 'https://cloud.zpan.space/pair',
+      expires_at: '2026-01-01T00:00:00Z',
+    }
+    vi.mocked(fetch).mockResolvedValueOnce(makeCloudResponse(cloudPayload))
+
+    const res = await app.request('/api/licensing/pair', {
+      method: 'POST',
+      headers,
+    })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.code).toBe('ABC-123')
+    expect(body.pairing_url).toBe('https://cloud.zpan.space/pair')
+  })
+})
+
+describe('GET /api/licensing/pair/:code/poll', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns pending status when cloud returns pending', async () => {
+    const { app } = await createTestApp()
+    const headers = await adminHeaders(app)
+
+    vi.mocked(fetch).mockResolvedValueOnce(makeCloudResponse({ status: 'pending' }))
+
+    const res = await app.request('/api/licensing/pair/ABC-123/poll', { headers })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.status).toBe('pending')
+  })
+
+  it('stores binding on approved and returns approved status', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+
+    vi.mocked(fetch).mockResolvedValueOnce(
+      makeCloudResponse({
+        status: 'approved',
+        refresh_token: 'rt-secret',
+        entitlement: { plan: 'pro', features: ['white_label'], expires_at: '2026-12-31T00:00:00Z' },
+      }),
+    )
+
+    const res = await app.request('/api/licensing/pair/CODE-1/poll', { headers })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.status).toBe('approved')
+
+    // Check that binding was persisted
+    const rows = await db.select().from(schema.licenseBinding).limit(1)
+    expect(rows.length).toBe(1)
+    expect(rows[0].refreshToken).toBe('rt-secret')
+  })
+})
+
+describe('POST /api/licensing/refresh', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns success when binding exists and cloud responds OK', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+
+    await db.insert(schema.licenseBinding).values({
+      id: 1,
+      instanceId: 'inst-1',
+      refreshToken: 'old-token',
+      cachedCert: null,
+      cachedExpiresAt: null,
+      lastRefreshAt: null,
+      lastRefreshError: null,
+      boundAt: null,
+    })
+
+    vi.mocked(fetch).mockResolvedValueOnce(
+      makeCloudResponse({ refresh_token: 'new-token', entitlement: { plan: 'pro', features: [] } }),
+    )
+
+    const res = await app.request('/api/licensing/refresh', { method: 'POST', headers })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.success).toBe(true)
+  })
+
+  it('returns success:true with null last_refresh_at when no binding exists', async () => {
+    const { app } = await createTestApp()
+    const headers = await adminHeaders(app)
+
+    // No binding exists — performRefresh is a no-op
+    const res = await app.request('/api/licensing/refresh', { method: 'POST', headers })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.success).toBe(true)
+    expect(body.last_refresh_at).toBeNull()
+  })
+})
+
+describe('DELETE /api/licensing/binding', () => {
+  it('deletes binding row and returns deleted: true', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+
+    await db.insert(schema.licenseBinding).values({
+      id: 1,
+      instanceId: 'inst-1',
+      refreshToken: 'some-token',
+      cachedCert: null,
+      cachedExpiresAt: null,
+      lastRefreshAt: null,
+      lastRefreshError: null,
+      boundAt: null,
+    })
+
+    const res = await app.request('/api/licensing/binding', { method: 'DELETE', headers })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.deleted).toBe(true)
+
+    // Confirm row is gone
+    const rows = await db.select().from(schema.licenseBinding).limit(1)
+    expect(rows.length).toBe(0)
+  })
+
+  it('returns deleted: true even when no binding exists', async () => {
+    const { app } = await createTestApp()
+    const headers = await adminHeaders(app)
+
+    const res = await app.request('/api/licensing/binding', { method: 'DELETE', headers })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.deleted).toBe(true)
+  })
+})

--- a/server/routes/licensing-admin.ts
+++ b/server/routes/licensing-admin.ts
@@ -1,0 +1,144 @@
+import { Hono } from 'hono'
+import { eq } from 'drizzle-orm'
+import { licenseBinding, systemOptions } from '../db/schema'
+import { getOrCreateInstanceId } from '../licensing/instance-id'
+import { performRefresh } from '../licensing/refresh'
+import { verifyCertificate } from '../licensing/verify'
+import { invalidateEntitlementCache } from '../licensing/entitlement'
+import { requireAdmin } from '../middleware/auth'
+import type { Env } from '../middleware/platform'
+import {
+  CloudNetworkError,
+  CloudUnboundError,
+  createPairing,
+  pollPairing,
+} from '../services/licensing-cloud'
+
+const CLOUD_BASE_URL_DEFAULT = 'https://cloud.zpan.space'
+
+function getCloudBaseUrl(c: { get(key: 'platform'): { getEnv(k: string): string | undefined } }): string {
+  return c.get('platform').getEnv('ZPAN_CLOUD_URL') ?? CLOUD_BASE_URL_DEFAULT
+}
+
+const app = new Hono<Env>()
+  .use(requireAdmin)
+
+  // POST /api/licensing/pair — initiate device-code pairing with cloud
+  .post('/pair', async (c) => {
+    const db = c.get('platform').db
+    const baseUrl = getCloudBaseUrl(c)
+
+    const instanceId = await getOrCreateInstanceId(db)
+
+    // Read site_title for instance_name; fall back to host header
+    const titleRows = await db
+      .select({ value: systemOptions.value })
+      .from(systemOptions)
+      .where(eq(systemOptions.key, 'site_title'))
+      .limit(1)
+
+    const instanceName = titleRows[0]?.value ?? 'ZPan'
+    const instanceHost = c.req.header('host') ?? new URL(c.req.url).host
+
+    const pairing = await createPairing(baseUrl, instanceId, instanceName, instanceHost)
+    return c.json(pairing)
+  })
+
+  // GET /api/licensing/pair/:code/poll — proxy poll to cloud
+  .get('/pair/:code/poll', async (c) => {
+    const { code } = c.req.param()
+    const db = c.get('platform').db
+    const baseUrl = getCloudBaseUrl(c)
+
+    const result = await pollPairing(baseUrl, code)
+
+    if (result.status === 'approved' && result.refresh_token && result.entitlement != null) {
+      const instanceId = await getOrCreateInstanceId(db)
+
+      let cert: string
+      let expiresAt: number | null = null
+
+      if (typeof result.entitlement === 'string') {
+        cert = result.entitlement
+        const entitlement = verifyCertificate(cert, instanceId)
+        if (entitlement) {
+          expiresAt = Math.floor(new Date(entitlement.expires_at).getTime() / 1000)
+        }
+      } else {
+        // Pre-C5 plain object — store as JSON
+        // TODO: assert PASETO string once C5 lands; remove this branch
+        cert = JSON.stringify(result.entitlement)
+      }
+
+      await db
+        .insert(licenseBinding)
+        .values({
+          id: 1,
+          instanceId,
+          refreshToken: result.refresh_token,
+          cachedCert: cert,
+          cachedExpiresAt: expiresAt,
+          lastRefreshAt: Math.floor(Date.now() / 1000),
+          boundAt: Math.floor(Date.now() / 1000),
+        })
+        .onConflictDoUpdate({
+          target: licenseBinding.id,
+          set: {
+            refreshToken: result.refresh_token,
+            cachedCert: cert,
+            cachedExpiresAt: expiresAt,
+            lastRefreshAt: Math.floor(Date.now() / 1000),
+            boundAt: Math.floor(Date.now() / 1000),
+          },
+        })
+
+      invalidateEntitlementCache()
+
+      const stateRows = await db.select().from(licenseBinding).where(eq(licenseBinding.id, 1)).limit(1)
+      const row = stateRows[0]
+
+      return c.json({
+        status: 'approved' as const,
+        plan: row?.cachedCert ? getPlanFromCert(row.cachedCert) : undefined,
+      })
+    }
+
+    return c.json({ status: result.status })
+  })
+
+  // POST /api/licensing/refresh — force an entitlement refresh
+  .post('/refresh', async (c) => {
+    const db = c.get('platform').db
+    const baseUrl = getCloudBaseUrl(c)
+
+    await performRefresh(db, baseUrl)
+
+    const rows = await db.select({ lastRefreshAt: licenseBinding.lastRefreshAt }).from(licenseBinding).limit(1)
+    const lastRefreshAt = rows[0]?.lastRefreshAt ?? null
+
+    return c.json({ success: true, last_refresh_at: lastRefreshAt })
+  })
+
+  // DELETE /api/licensing/binding — local unbind (does NOT call cloud)
+  .delete('/binding', async (c) => {
+    const db = c.get('platform').db
+
+    await db.delete(licenseBinding).where(eq(licenseBinding.id, 1))
+    invalidateEntitlementCache()
+
+    return c.json({ deleted: true })
+  })
+
+function getPlanFromCert(cert: string): string | undefined {
+  // PASETO token — can't parse without verify; return undefined for now
+  if (cert.startsWith('v4.public.')) return undefined
+
+  try {
+    const parsed = JSON.parse(cert) as { plan?: string }
+    return parsed.plan
+  } catch {
+    return undefined
+  }
+}
+
+export default app

--- a/server/routes/licensing-admin.ts
+++ b/server/routes/licensing-admin.ts
@@ -1,18 +1,13 @@
-import { Hono } from 'hono'
 import { eq } from 'drizzle-orm'
+import { Hono } from 'hono'
 import { licenseBinding, systemOptions } from '../db/schema'
+import { invalidateEntitlementCache } from '../licensing/entitlement'
 import { getOrCreateInstanceId } from '../licensing/instance-id'
 import { performRefresh } from '../licensing/refresh'
 import { verifyCertificate } from '../licensing/verify'
-import { invalidateEntitlementCache } from '../licensing/entitlement'
 import { requireAdmin } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
-import {
-  CloudNetworkError,
-  CloudUnboundError,
-  createPairing,
-  pollPairing,
-} from '../services/licensing-cloud'
+import { createPairing, pollPairing } from '../services/licensing-cloud'
 
 const CLOUD_BASE_URL_DEFAULT = 'https://cloud.zpan.space'
 

--- a/server/routes/licensing.integration.test.ts
+++ b/server/routes/licensing.integration.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import * as schema from '../db/schema.js'
+import { createTestApp } from '../test/setup.js'
+
+describe('GET /api/licensing/status', () => {
+  it('returns { bound: false } when no binding row exists', async () => {
+    const { app } = await createTestApp()
+
+    const res = await app.request('/api/licensing/status')
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({ bound: false })
+  })
+
+  it('returns bound state with plan and features when binding row exists with cert', async () => {
+    const { app, db } = await createTestApp()
+
+    const entitlement = {
+      account_id: 'acc-1',
+      instance_id: 'inst-1',
+      plan: 'pro',
+      features: ['white_label', 'teams_unlimited'],
+      issued_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 86400000).toISOString(),
+    }
+
+    await db.insert(schema.licenseBinding).values({
+      id: 1,
+      instanceId: 'inst-1',
+      cloudAccountId: 'acc-1',
+      cloudAccountEmail: 'user@example.com',
+      refreshToken: 'secret-refresh-token',
+      cachedCert: JSON.stringify(entitlement),
+      cachedExpiresAt: Math.floor(Date.now() / 1000) + 86400,
+      lastRefreshAt: Math.floor(Date.now() / 1000),
+      lastRefreshError: null,
+      boundAt: Math.floor(Date.now() / 1000),
+    })
+
+    const res = await app.request('/api/licensing/status')
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.bound).toBe(true)
+    expect(body.account_email).toBe('user@example.com')
+    expect(body.plan).toBe('pro')
+    expect(body.features).toEqual(['white_label', 'teams_unlimited'])
+    // refresh_token must never appear in the response
+    expect(body.refresh_token).toBeUndefined()
+    expect(body.refreshToken).toBeUndefined()
+  })
+
+  it('returns bound:true with no plan/features when cachedCert is null', async () => {
+    const { app, db } = await createTestApp()
+
+    await db.insert(schema.licenseBinding).values({
+      id: 1,
+      instanceId: 'inst-1',
+      cloudAccountId: null,
+      cloudAccountEmail: null,
+      refreshToken: 'secret',
+      cachedCert: null,
+      cachedExpiresAt: null,
+      lastRefreshAt: null,
+      lastRefreshError: null,
+      boundAt: null,
+    })
+
+    const res = await app.request('/api/licensing/status')
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.bound).toBe(true)
+    expect(body.plan).toBeUndefined()
+    expect(body.features).toBeUndefined()
+  })
+
+  it('is accessible without authentication', async () => {
+    const { app } = await createTestApp()
+    const res = await app.request('/api/licensing/status')
+    expect(res.status).toBe(200)
+  })
+})

--- a/server/routes/licensing.ts
+++ b/server/routes/licensing.ts
@@ -1,0 +1,12 @@
+import { Hono } from 'hono'
+import type { BindingState } from '../../shared/types'
+import { loadBindingState } from '../licensing/has-feature'
+import type { Env } from '../middleware/platform'
+
+const app = new Hono<Env>().get('/status', async (c) => {
+  const db = c.get('platform').db
+  const state = await loadBindingState(db)
+  return c.json(state satisfies BindingState)
+})
+
+export default app

--- a/server/services/licensing-cloud.test.ts
+++ b/server/services/licensing-cloud.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { CloudNetworkError, CloudUnboundError, createPairing, pollPairing, refreshEntitlement } from './licensing-cloud'
+
+const BASE_URL = 'https://cloud.zpan.space'
+
+function makeResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response
+}
+
+describe('licensing-cloud', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('createPairing', () => {
+    it('sends POST to /api/pairings with instance info', async () => {
+      const payload = {
+        code: 'ABC-123',
+        pairing_url: 'https://cloud.zpan.space/pair',
+        expires_at: '2026-01-01T00:00:00Z',
+      }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
+
+      const result = await createPairing(BASE_URL, 'inst-1', 'My ZPan', 'zpan.example.com')
+
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toBe('https://cloud.zpan.space/api/pairings')
+      expect(init.method).toBe('POST')
+      const body = JSON.parse(init.body as string)
+      expect(body.instance_id).toBe('inst-1')
+      expect(body.instance_name).toBe('My ZPan')
+      expect(body.instance_host).toBe('zpan.example.com')
+      expect(result).toEqual(payload)
+    })
+
+    it('throws on non-OK response', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Bad Request' }, 400))
+
+      await expect(createPairing(BASE_URL, 'inst-1', 'ZPan', 'host')).rejects.toThrow('Cloud pairing failed')
+    })
+
+    it('throws CloudNetworkError on fetch failure', async () => {
+      vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'))
+
+      await expect(createPairing(BASE_URL, 'inst-1', 'ZPan', 'host')).rejects.toThrow(CloudNetworkError)
+    })
+  })
+
+  describe('pollPairing', () => {
+    it('sends GET to /api/pairings/:code', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ status: 'pending' }))
+
+      await pollPairing(BASE_URL, 'ABC-123')
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toBe('https://cloud.zpan.space/api/pairings/ABC-123')
+    })
+
+    it('returns pending status', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ status: 'pending' }))
+
+      const result = await pollPairing(BASE_URL, 'CODE-1')
+      expect(result.status).toBe('pending')
+    })
+
+    it('returns approved status with refresh_token and entitlement', async () => {
+      const payload = {
+        status: 'approved',
+        refresh_token: 'rt-token',
+        entitlement: 'v4.public.token',
+      }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
+
+      const result = await pollPairing(BASE_URL, 'CODE-2')
+      expect(result.status).toBe('approved')
+      expect(result.refresh_token).toBe('rt-token')
+    })
+
+    it('throws on non-OK response', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Not Found' }, 404))
+
+      await expect(pollPairing(BASE_URL, 'BAD')).rejects.toThrow('Cloud poll failed')
+    })
+
+    it('throws CloudNetworkError on fetch failure', async () => {
+      vi.mocked(fetch).mockRejectedValueOnce(new Error('Timeout'))
+
+      await expect(pollPairing(BASE_URL, 'CODE')).rejects.toThrow(CloudNetworkError)
+    })
+  })
+
+  describe('refreshEntitlement', () => {
+    it('sends POST to /api/entitlements with refresh_token', async () => {
+      const payload = { refresh_token: 'new-rt', entitlement: 'v4.public.newtoken' }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
+
+      const result = await refreshEntitlement(BASE_URL, 'old-rt')
+
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toBe('https://cloud.zpan.space/api/entitlements')
+      expect(init.method).toBe('POST')
+      const body = JSON.parse(init.body as string)
+      expect(body.refresh_token).toBe('old-rt')
+      expect(result.refresh_token).toBe('new-rt')
+    })
+
+    it('throws CloudUnboundError on 401', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Unbound' }, 401))
+
+      await expect(refreshEntitlement(BASE_URL, 'old-rt')).rejects.toThrow(CloudUnboundError)
+    })
+
+    it('throws on other non-OK response', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Server Error' }, 500))
+
+      await expect(refreshEntitlement(BASE_URL, 'old-rt')).rejects.toThrow('Cloud refresh failed')
+    })
+
+    it('throws CloudNetworkError on fetch failure', async () => {
+      vi.mocked(fetch).mockRejectedValueOnce(new Error('Connection refused'))
+
+      await expect(refreshEntitlement(BASE_URL, 'old-rt')).rejects.toThrow(CloudNetworkError)
+    })
+  })
+})

--- a/server/services/licensing-cloud.ts
+++ b/server/services/licensing-cloud.ts
@@ -1,0 +1,110 @@
+// HTTP client for cloud.zpan.space — pairing and entitlement refresh.
+// All requests have a 10s timeout. Cloud API uses snake_case JSON payloads.
+
+const CLOUD_REQUEST_TIMEOUT_MS = 10_000
+
+export interface PairingResponse {
+  code: string
+  pairing_url: string
+  expires_at: string
+}
+
+export interface PairingPollResponse {
+  status: 'pending' | 'approved' | 'denied' | 'expired'
+  refresh_token?: string
+  // TODO: assert PASETO string once C5 lands; for now may be string (PASETO) or object (pre-C5)
+  entitlement?: string | object
+}
+
+export interface EntitlementRefreshResponse {
+  refresh_token: string
+  // TODO: assert PASETO string once C5 lands; for now may be string (PASETO) or object (pre-C5)
+  entitlement: string | object
+}
+
+export class CloudUnboundError extends Error {
+  constructor() {
+    super('Instance unbound from cloud')
+    this.name = 'CloudUnboundError'
+  }
+}
+
+export class CloudNetworkError extends Error {
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : 'Cloud network error')
+    this.name = 'CloudNetworkError'
+  }
+}
+
+function withTimeout(ms: number): AbortSignal {
+  return AbortSignal.timeout(ms)
+}
+
+async function cloudFetch(baseUrl: string, path: string, init: RequestInit): Promise<Response> {
+  try {
+    return await fetch(`${baseUrl}${path}`, {
+      ...init,
+      signal: withTimeout(CLOUD_REQUEST_TIMEOUT_MS),
+    })
+  } catch (err) {
+    throw new CloudNetworkError(err)
+  }
+}
+
+export async function createPairing(
+  baseUrl: string,
+  instanceId: string,
+  instanceName: string,
+  instanceHost: string,
+): Promise<PairingResponse> {
+  const res = await cloudFetch(baseUrl, '/api/pairings', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ instance_id: instanceId, instance_name: instanceName, instance_host: instanceHost }),
+  })
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Cloud pairing failed: ${res.status} ${text}`)
+  }
+
+  return res.json() as Promise<PairingResponse>
+}
+
+export async function pollPairing(baseUrl: string, code: string): Promise<PairingPollResponse> {
+  const res = await cloudFetch(baseUrl, `/api/pairings/${encodeURIComponent(code)}`, {
+    method: 'GET',
+  })
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Cloud poll failed: ${res.status} ${text}`)
+  }
+
+  return res.json() as Promise<PairingPollResponse>
+}
+
+// Calls POST /api/entitlements with the stored refresh_token.
+// Throws CloudUnboundError on 401 (instance was unbound from cloud side).
+// Throws CloudNetworkError on network failure.
+export async function refreshEntitlement(
+  baseUrl: string,
+  refreshToken: string,
+): Promise<EntitlementRefreshResponse> {
+  const res = await cloudFetch(baseUrl, '/api/entitlements', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refresh_token: refreshToken }),
+  })
+
+  if (res.status === 401) {
+    throw new CloudUnboundError()
+  }
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Cloud refresh failed: ${res.status} ${text}`)
+  }
+
+  return res.json() as Promise<EntitlementRefreshResponse>
+}

--- a/server/services/licensing-cloud.ts
+++ b/server/services/licensing-cloud.ts
@@ -87,10 +87,7 @@ export async function pollPairing(baseUrl: string, code: string): Promise<Pairin
 // Calls POST /api/entitlements with the stored refresh_token.
 // Throws CloudUnboundError on 401 (instance was unbound from cloud side).
 // Throws CloudNetworkError on network failure.
-export async function refreshEntitlement(
-  baseUrl: string,
-  refreshToken: string,
-): Promise<EntitlementRefreshResponse> {
+export async function refreshEntitlement(baseUrl: string, refreshToken: string): Promise<EntitlementRefreshResponse> {
   const res = await cloudFetch(baseUrl, '/api/entitlements', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -262,6 +262,18 @@ const APP_SCHEMA_SQL = `
   CREATE INDEX IF NOT EXISTS apikey_config_id_idx ON apikey(config_id);
   CREATE INDEX IF NOT EXISTS apikey_reference_id_idx ON apikey(reference_id);
   CREATE INDEX IF NOT EXISTS apikey_key_idx ON apikey(key);
+  CREATE TABLE IF NOT EXISTS license_binding (
+    id INTEGER PRIMARY KEY,
+    instance_id TEXT NOT NULL,
+    cloud_account_id TEXT,
+    cloud_account_email TEXT,
+    refresh_token TEXT NOT NULL,
+    cached_cert TEXT,
+    cached_expires_at INTEGER,
+    last_refresh_at INTEGER,
+    last_refresh_error TEXT,
+    bound_at INTEGER
+  );
 `
 
 export async function createTestApp(envOverrides: Record<string, string> = {}) {

--- a/shared/types/licensing.ts
+++ b/shared/types/licensing.ts
@@ -5,8 +5,8 @@ export interface LicenseEntitlement {
   instance_id: string
   plan: 'community' | 'pro'
   features: ProFeature[]
-  issued_at: number
-  expires_at: number
+  issued_at: string
+  expires_at: string
 }
 
 export interface BindingState {

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1827,7 +1827,11 @@ describe('api', () => {
 
   describe('connectCloud', () => {
     it('calls the correct endpoint with POST', async () => {
-      const payload = { code: 'ABC-123', pairing_url: 'https://cloud.zpan.space/pair', expires_at: '2026-01-01T00:00:00Z' }
+      const payload = {
+        code: 'ABC-123',
+        pairing_url: 'https://cloud.zpan.space/pair',
+        expires_at: '2026-01-01T00:00:00Z',
+      }
       vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
 
       await connectCloud()
@@ -1838,7 +1842,11 @@ describe('api', () => {
     })
 
     it('returns pairing info', async () => {
-      const payload = { code: 'XYZ-789', pairing_url: 'https://cloud.zpan.space/pair', expires_at: '2026-01-01T00:00:00Z' }
+      const payload = {
+        code: 'XYZ-789',
+        pairing_url: 'https://cloud.zpan.space/pair',
+        expires_at: '2026-01-01T00:00:00Z',
+      }
       vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
 
       const result = await connectCloud()

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -7,6 +7,7 @@ import {
   buildShareObjectUrl,
   confirmIhostImage,
   confirmUpload,
+  connectCloud,
   copyObject,
   createIhostApiKey,
   createIhostImagePresign,
@@ -21,9 +22,11 @@ import {
   deleteStorage,
   deleteTeamLogo,
   deleteUser,
+  disconnectCloud,
   emptyTrash,
   enableIhostFeature,
   getIhostConfig,
+  getLicensingStatus,
   getObject,
   getProfile,
   getSession,
@@ -45,6 +48,8 @@ import {
   listUsers,
   markAllNotificationsRead,
   markNotificationRead,
+  pollPairing,
+  refreshLicense,
   restoreObject,
   revokeIhostApiKey,
   saveShareToDrive,
@@ -1776,6 +1781,162 @@ describe('api', () => {
     it('throws ApiError on failure', async () => {
       vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Forbidden' }, false, 403))
       await expect(deleteTeamLogo('org-1')).rejects.toThrow()
+    })
+  })
+
+  describe('getLicensingStatus', () => {
+    it('calls the correct endpoint', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ bound: false }))
+
+      await getLicensingStatus()
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toContain('/api/licensing/status')
+    })
+
+    it('returns unbound state', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ bound: false }))
+
+      const result = await getLicensingStatus()
+
+      expect(result).toEqual({ bound: false })
+    })
+
+    it('returns full bound state', async () => {
+      const state = {
+        bound: true,
+        account_email: 'user@example.com',
+        plan: 'pro',
+        features: ['white_label'],
+        expires_at: 9999999999,
+        last_refresh_at: 1000000000,
+      }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(state))
+
+      const result = await getLicensingStatus()
+
+      expect(result).toEqual(state)
+    })
+
+    it('throws ApiError on failure', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Internal Server Error' }, false, 500))
+
+      await expect(getLicensingStatus()).rejects.toThrow()
+    })
+  })
+
+  describe('connectCloud', () => {
+    it('calls the correct endpoint with POST', async () => {
+      const payload = { code: 'ABC-123', pairing_url: 'https://cloud.zpan.space/pair', expires_at: '2026-01-01T00:00:00Z' }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
+
+      await connectCloud()
+
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toContain('/api/licensing/pair')
+      expect(init.method).toBe('POST')
+    })
+
+    it('returns pairing info', async () => {
+      const payload = { code: 'XYZ-789', pairing_url: 'https://cloud.zpan.space/pair', expires_at: '2026-01-01T00:00:00Z' }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
+
+      const result = await connectCloud()
+
+      expect(result).toEqual(payload)
+    })
+
+    it('throws ApiError on non-admin', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Forbidden' }, false, 403))
+
+      await expect(connectCloud()).rejects.toThrow()
+    })
+  })
+
+  describe('pollPairing', () => {
+    it('calls the correct endpoint with code', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ status: 'pending' }))
+
+      await pollPairing('ABC-123')
+
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toContain('/api/licensing/pair/ABC-123/poll')
+    })
+
+    it('returns pending status', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ status: 'pending' }))
+
+      const result = await pollPairing('CODE-1')
+
+      expect(result.status).toBe('pending')
+    })
+
+    it('returns approved status with plan', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ status: 'approved', plan: 'pro' }))
+
+      const result = await pollPairing('CODE-2')
+
+      expect(result.status).toBe('approved')
+      expect(result.plan).toBe('pro')
+    })
+
+    it('throws ApiError on error response', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Not Found' }, false, 404))
+
+      await expect(pollPairing('BAD-CODE')).rejects.toThrow()
+    })
+  })
+
+  describe('refreshLicense', () => {
+    it('calls the correct endpoint with POST', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ success: true, last_refresh_at: 1000000000 }))
+
+      await refreshLicense()
+
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toContain('/api/licensing/refresh')
+      expect(init.method).toBe('POST')
+    })
+
+    it('returns success with last_refresh_at', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ success: true, last_refresh_at: 1745000000 }))
+
+      const result = await refreshLicense()
+
+      expect(result.success).toBe(true)
+      expect(result.last_refresh_at).toBe(1745000000)
+    })
+
+    it('throws ApiError on failure', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Forbidden' }, false, 403))
+
+      await expect(refreshLicense()).rejects.toThrow()
+    })
+  })
+
+  describe('disconnectCloud', () => {
+    it('calls the correct endpoint with DELETE', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ deleted: true }))
+
+      await disconnectCloud()
+
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toContain('/api/licensing/binding')
+      expect(init.method).toBe('DELETE')
+    })
+
+    it('returns deleted: true on success', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ deleted: true }))
+
+      const result = await disconnectCloud()
+
+      expect(result).toEqual({ deleted: true })
+    })
+
+    it('throws ApiError on failure', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Forbidden' }, false, 403))
+
+      await expect(disconnectCloud()).rejects.toThrow()
     })
   })
 })

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,6 +9,7 @@ import type {
 import type {
   ActivityEvent,
   AuthProvider,
+  BindingState,
   IhostConfigResponse,
   ImageHosting,
   Notification,
@@ -27,6 +28,8 @@ import {
   ihostApi,
   ihostConfigApi,
   inviteCodes,
+  licensingAdminApi,
+  licensingApi,
   meApi,
   notificationsApi,
   objects,
@@ -542,6 +545,41 @@ export function revokeIhostApiKey(keyId: string) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ keyId }),
   })
+}
+
+// Licensing API
+
+export type { BindingState }
+
+export interface PairingInfo {
+  code: string
+  pairing_url: string
+  expires_at: string
+}
+
+export interface PairingPollResult {
+  status: 'pending' | 'approved' | 'denied' | 'expired'
+  plan?: string
+}
+
+export function getLicensingStatus() {
+  return unwrap<BindingState>(licensingApi.status.$get())
+}
+
+export function connectCloud() {
+  return unwrap<PairingInfo>(licensingAdminApi.pair.$post())
+}
+
+export function pollPairing(code: string) {
+  return unwrap<PairingPollResult>(licensingAdminApi.pair[':code'].poll.$get({ param: { code } }))
+}
+
+export function refreshLicense() {
+  return unwrap<{ success: boolean; last_refresh_at: number | null }>(licensingAdminApi.refresh.$post())
+}
+
+export function disconnectCloud() {
+  return unwrap<{ deleted: boolean }>(licensingAdminApi.binding.$delete())
 }
 
 // Auth API — Better Auth passthrough, not typed via Hono RPC

--- a/src/lib/rpc.ts
+++ b/src/lib/rpc.ts
@@ -7,6 +7,8 @@ import type {
   EmailConfigRoute,
   IhostConfigRoute,
   IhostRoute,
+  LicensingAdminRoute,
+  LicensingRoute,
   MeRoute,
   NotificationsRoute,
   ObjectsRoute,
@@ -48,3 +50,5 @@ export const authedSharesApi = hc<AuthedSharesRoute>('/api/shares', opts)
 
 export const ihostConfigApi = hc<IhostConfigRoute>('/api/ihost/config', opts)
 export const ihostApi = hc<IhostRoute>('/api/ihost', opts)
+export const licensingApi = hc<LicensingRoute>('/api/licensing', opts)
+export const licensingAdminApi = hc<LicensingAdminRoute>('/api/licensing', opts)


### PR DESCRIPTION
## Summary

- **`server/licensing/`** — Ed25519 PASETO verify, 60s entitlement cache, has-feature check, instance-id lazy init, entitlement refresh orchestration
- **`server/services/licensing-cloud.ts`** — HTTP client for `cloud.zpan.space`: `createPairing`, `pollPairing`, `refreshEntitlement` with 10s timeout; typed `CloudUnboundError` / `CloudNetworkError`
- **`server/routes/licensing.ts`** — public `GET /api/licensing/status` (no auth)
- **`server/routes/licensing-admin.ts`** — admin-only `POST /pair`, `GET /pair/:code/poll`, `POST /refresh`, `DELETE /binding`
- **`server/middleware/require-feature.ts`** — `requireFeature(name)` middleware, returns 402 when feature missing
- **`src/lib/api.ts`** — `getLicensingStatus()`, `connectCloud()`, `pollPairing()`, `refreshLicense()`, `disconnectCloud()` wrappers
- **`src/lib/api.test.ts`** — 17 new tests covering all 5 new api.ts wrappers
- **`shared/types/licensing.ts`** — `LicenseEntitlement.issued_at/expires_at` updated to `string` (ISO-8601) to match cloud wire format
- **`paseto-ts`** dependency added for PASETO v4 public key verification

### Behaviour notes

- `ZPAN_CLOUD_URL` env var overrides `https://cloud.zpan.space` for dev/testing
- `POST /api/licensing/refresh`: on `CloudUnboundError` (401) deletes binding row; on network error updates `last_refresh_error` only, keeps cached cert valid until its `expires_at`
- `DELETE /api/licensing/binding`: local unbind only — does not call cloud; callers instructed to unbind from cloud dashboard to free the subscription slot
- Pre-C5 path: if cloud `entitlement` is a plain object (not a PASETO string), stored as JSON with a TODO to assert PASETO string once C5 lands

## Test plan

- [ ] `POST /api/licensing/pair` returns a pairing code; non-admin → 401
- [ ] `GET /api/licensing/pair/:code/poll` returns `pending` then on approval stores refresh_token + cert, returns `approved`
- [ ] `POST /api/licensing/refresh` rotates token, updates `last_refresh_at`
- [ ] Cloud-side unbind (401) → binding row cleared, `GET /api/licensing/status` returns `{ bound: false }`
- [ ] Network timeout → `last_refresh_error` set, binding not deleted, cached cert still honored
- [ ] `ZPAN_CLOUD_URL` env override works
- [ ] All 2616 tests pass (`npm test` ✅) 
- [ ] `npm run typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)