### PR TITLE
feat: v2.6 Z7 white-label branding (logo, favicon, wordmark, hide footer)

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -8,6 +8,7 @@ import type { Env } from './middleware/platform'
 import { platformMiddleware } from './middleware/platform'
 import type { Platform } from './platform/interface'
 import { adminAuthProviders, publicAuthProviders } from './routes/auth-providers'
+import { brandingAdmin, publicBranding } from './routes/branding'
 import emailConfig from './routes/email-config'
 import ihost from './routes/ihost'
 import ihostConfig from './routes/ihost-config'
@@ -59,6 +60,7 @@ export function createApp(platform: Platform, auth: Auth) {
   app.route('/api/teams', publicTeams)
   app.route('/api/auth-providers', publicAuthProviders)
   app.route('/api/licensing', licensing)
+  app.route('/api/branding', publicBranding)
 
   app.use('/api/*', authMiddleware)
 
@@ -83,6 +85,7 @@ export function createApp(platform: Platform, auth: Auth) {
   app.route('/api/ihost', ihost)
   app.route('/api/ihost/config', ihostConfig)
   app.route('/api/licensing', licensingAdmin)
+  app.route('/api/admin/branding', brandingAdmin)
 
   app.get('/api/health', (c) => c.json({ status: 'ok' }))
 
@@ -115,3 +118,5 @@ export type IhostConfigRoute = typeof ihostConfig
 export type MeRoute = typeof me
 export type LicensingRoute = typeof licensing
 export type LicensingAdminRoute = typeof licensingAdmin
+export type PublicBrandingRoute = typeof publicBranding
+export type BrandingAdminRoute = typeof brandingAdmin

--- a/server/routes/branding.integration.test.ts
+++ b/server/routes/branding.integration.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { sql } from 'drizzle-orm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { S3Service } from '../services/s3.js'
 import { adminHeaders, authedHeaders, createTestApp } from '../test/setup.js'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const NOW = Date.now()
 
 async function seedProLicense(db: Awaited<ReturnType<typeof createTestApp>>['db']) {
   const { licenseBinding } = await import('../db/schema.js')
@@ -19,6 +23,13 @@ async function seedProLicense(db: Awaited<ReturnType<typeof createTestApp>>['db'
     }),
     cachedExpiresAt: Math.floor(Date.now() / 1000) + 99999,
   })
+}
+
+async function seedPublicStorage(db: Awaited<ReturnType<typeof createTestApp>>['db']) {
+  await db.run(sql`
+    INSERT INTO storages (id, title, mode, bucket, endpoint, region, access_key, secret_key, file_path, custom_host, capacity, used, status, created_at, updated_at)
+    VALUES ('branding-storage', 'Public', 'public', 'test-bucket', 'https://s3.example.com', 'us-east-1', 'key', 'secret', '', '', 0, 0, 'active', ${NOW}, ${NOW})
+  `)
 }
 
 async function seedBrandingOption(db: Awaited<ReturnType<typeof createTestApp>>['db'], key: string, value: string) {
@@ -47,11 +58,32 @@ describe('GET /api/branding', () => {
     const res = await app.request('/api/branding')
     expect(res.status).toBe(200)
   })
+
+  it('returns stored branding values when set', async () => {
+    const { app, db } = await createTestApp()
+    await seedBrandingOption(db, 'branding_wordmark_text', 'MyCloud')
+    await seedBrandingOption(db, 'branding_hide_powered_by', 'true')
+
+    const res = await app.request('/api/branding')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { wordmark_text: string; hide_powered_by: boolean }
+    expect(body.wordmark_text).toBe('MyCloud')
+    expect(body.hide_powered_by).toBe(true)
+  })
 })
 
 // ─── PUT /api/admin/branding ──────────────────────────────────────────────────
 
 describe('PUT /api/admin/branding', () => {
+  beforeEach(() => {
+    vi.spyOn(S3Service.prototype, 'putObject').mockResolvedValue(undefined)
+    vi.spyOn(S3Service.prototype, 'getPublicUrl').mockReturnValue('https://cdn.example.com/logo.png')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('returns 401 without auth', async () => {
     const { app } = await createTestApp()
     const res = await app.request('/api/admin/branding', { method: 'PUT' })
@@ -119,6 +151,67 @@ describe('PUT /api/admin/branding', () => {
     const getBody = (await getRes.json()) as { wordmark_text: string; hide_powered_by: boolean }
     expect(getBody.wordmark_text).toBe('MyCloud')
     expect(getBody.hide_powered_by).toBe(true)
+  })
+
+  it('uploads logo file to S3 and stores URL', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+    await seedProLicense(db)
+    await seedPublicStorage(db)
+
+    const logoFile = new File(['<svg></svg>'], 'logo.svg', { type: 'image/svg+xml' })
+    const form = new FormData()
+    form.set('logo', logoFile)
+
+    const res = await app.request('/api/admin/branding', { method: 'PUT', headers, body: form })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { logo_url: string }
+    expect(body.logo_url).toBe('https://cdn.example.com/logo.png')
+    expect(S3Service.prototype.putObject).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns 400 for invalid logo MIME type', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+    await seedProLicense(db)
+    await seedPublicStorage(db)
+
+    const badFile = new File(['data'], 'malware.exe', { type: 'application/octet-stream' })
+    const form = new FormData()
+    form.set('logo', badFile)
+
+    const res = await app.request('/api/admin/branding', { method: 'PUT', headers, body: form })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 413 for logo file exceeding 2MB', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+    await seedProLicense(db)
+    await seedPublicStorage(db)
+
+    // 2MB + 1 byte
+    const bigData = new Uint8Array(2 * 1024 * 1024 + 1)
+    const bigFile = new File([bigData], 'big.png', { type: 'image/png' })
+    const form = new FormData()
+    form.set('logo', bigFile)
+
+    const res = await app.request('/api/admin/branding', { method: 'PUT', headers, body: form })
+    expect(res.status).toBe(413)
+  })
+
+  it('returns 503 when no public storage is configured', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+    await seedProLicense(db)
+    // No storage seeded — selectStorage will throw
+
+    const logoFile = new File(['<svg></svg>'], 'logo.svg', { type: 'image/svg+xml' })
+    const form = new FormData()
+    form.set('logo', logoFile)
+
+    const res = await app.request('/api/admin/branding', { method: 'PUT', headers, body: form })
+    expect(res.status).toBe(503)
   })
 })
 

--- a/server/routes/branding.integration.test.ts
+++ b/server/routes/branding.integration.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+import { adminHeaders, authedHeaders, createTestApp } from '../test/setup.js'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function seedProLicense(db: Awaited<ReturnType<typeof createTestApp>>['db']) {
+  const { licenseBinding } = await import('../db/schema.js')
+  await db.insert(licenseBinding).values({
+    id: 1,
+    instanceId: 'test-instance',
+    refreshToken: 'tok',
+    cachedCert: JSON.stringify({
+      plan: 'pro',
+      features: ['white_label'],
+      account_id: 'a',
+      instance_id: 'test-instance',
+      issued_at: '2025-01-01',
+      expires_at: '2099-01-01',
+    }),
+    cachedExpiresAt: Math.floor(Date.now() / 1000) + 99999,
+  })
+}
+
+async function seedBrandingOption(db: Awaited<ReturnType<typeof createTestApp>>['db'], key: string, value: string) {
+  const { systemOptions } = await import('../db/schema.js')
+  await db.insert(systemOptions).values({ key, value, public: true })
+}
+
+// ─── GET /api/branding ────────────────────────────────────────────────────────
+
+describe('GET /api/branding', () => {
+  it('returns defaults when no branding configured', async () => {
+    const { app } = await createTestApp()
+    const res = await app.request('/api/branding')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toMatchObject({
+      logo_url: null,
+      favicon_url: null,
+      wordmark_text: null,
+      hide_powered_by: false,
+    })
+  })
+
+  it('is accessible without authentication', async () => {
+    const { app } = await createTestApp()
+    const res = await app.request('/api/branding')
+    expect(res.status).toBe(200)
+  })
+})
+
+// ─── PUT /api/admin/branding ──────────────────────────────────────────────────
+
+describe('PUT /api/admin/branding', () => {
+  it('returns 401 without auth', async () => {
+    const { app } = await createTestApp()
+    const res = await app.request('/api/admin/branding', { method: 'PUT' })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 for non-admin', async () => {
+    const { app } = await createTestApp()
+    // First user is auto-promoted to admin — create them first, then the non-admin
+    await adminHeaders(app)
+    const headers = await authedHeaders(app, 'user@example.com')
+    const res = await app.request('/api/admin/branding', { method: 'PUT', headers })
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 402 when white_label feature is not available (no Pro)', async () => {
+    const { app } = await createTestApp()
+    const headers = await adminHeaders(app)
+    const res = await app.request('/api/admin/branding', { method: 'PUT', headers })
+    expect(res.status).toBe(402)
+    const body = (await res.json()) as { feature: string }
+    expect(body.feature).toBe('white_label')
+  })
+
+  it('returns 415 when body is not multipart', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+    await seedProLicense(db)
+    const res = await app.request('/api/admin/branding', {
+      method: 'PUT',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    expect(res.status).toBe(415)
+  })
+
+  it('returns 422 when wordmark_text exceeds 24 chars', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+    await seedProLicense(db)
+
+    const form = new FormData()
+    form.set('wordmark_text', 'x'.repeat(25))
+    const res = await app.request('/api/admin/branding', { method: 'PUT', headers, body: form })
+    expect(res.status).toBe(422)
+  })
+
+  it('saves wordmark_text and hide_powered_by without file upload', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+    await seedProLicense(db)
+
+    const form = new FormData()
+    form.set('wordmark_text', 'MyCloud')
+    form.set('hide_powered_by', 'true')
+
+    const res = await app.request('/api/admin/branding', { method: 'PUT', headers, body: form })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { wordmark_text: string; hide_powered_by: boolean }
+    expect(body.wordmark_text).toBe('MyCloud')
+    expect(body.hide_powered_by).toBe(true)
+
+    // Verify GET reflects the update
+    const getRes = await app.request('/api/branding')
+    const getBody = (await getRes.json()) as { wordmark_text: string; hide_powered_by: boolean }
+    expect(getBody.wordmark_text).toBe('MyCloud')
+    expect(getBody.hide_powered_by).toBe(true)
+  })
+})
+
+// ─── DELETE /api/admin/branding/:field ────────────────────────────────────────
+
+describe('DELETE /api/admin/branding/:field', () => {
+  it('returns 401 without auth', async () => {
+    const { app } = await createTestApp()
+    const res = await app.request('/api/admin/branding/logo', { method: 'DELETE' })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 402 without Pro feature', async () => {
+    const { app } = await createTestApp()
+    const headers = await adminHeaders(app)
+    const res = await app.request('/api/admin/branding/logo', { method: 'DELETE', headers })
+    expect(res.status).toBe(402)
+  })
+
+  it('resets a text field', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+    await seedProLicense(db)
+    await seedBrandingOption(db, 'branding_wordmark_text', 'MyCloud')
+
+    const res = await app.request('/api/admin/branding/wordmark_text', { method: 'DELETE', headers })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { reset: boolean }
+    expect(body.reset).toBe(true)
+
+    // Verify removed from DB
+    const { systemOptions } = await import('../db/schema.js')
+    const { eq } = await import('drizzle-orm')
+    const rows = await db.select().from(systemOptions).where(eq(systemOptions.key, 'branding_wordmark_text'))
+    expect(rows.length).toBe(0)
+  })
+
+  it('returns 400 for invalid field name', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+    await seedProLicense(db)
+
+    const res = await app.request('/api/admin/branding/invalid_field', { method: 'DELETE', headers })
+    expect(res.status).toBe(400)
+  })
+})

--- a/server/routes/branding.ts
+++ b/server/routes/branding.ts
@@ -1,0 +1,71 @@
+import { Hono } from 'hono'
+import { requireAdmin } from '../middleware/auth'
+import type { Env } from '../middleware/platform'
+import { requireFeature } from '../middleware/require-feature'
+import {
+  type BRANDING_KEYS,
+  readBranding,
+  resetBrandingField,
+  setBrandingField,
+  uploadBrandingImage,
+} from '../services/branding'
+
+type BrandingField = keyof typeof BRANDING_KEYS
+
+const VALID_RESET_FIELDS = new Set<BrandingField>(['logo', 'favicon', 'wordmark_text', 'hide_powered_by'])
+
+// Public — no auth required. Used on sign-in/sign-up pages too.
+export const publicBranding = new Hono<Env>().get('/', async (c) => {
+  const db = c.get('platform').db
+  const config = await readBranding(db)
+  return c.json(config)
+})
+
+// Admin — requires auth + admin role + white_label feature.
+export const brandingAdmin = new Hono<Env>()
+  .use(requireAdmin)
+  .use(requireFeature('white_label'))
+  .put('/', async (c) => {
+    const platform = c.get('platform')
+
+    // Multipart is not expressible via Hono RPC (same documented exception as avatar/team logo);
+    // check content-type before calling formData() to give a clear 415 on wrong media type.
+    if (!c.req.header('content-type')?.includes('multipart/form-data')) {
+      return c.json({ error: 'Expected multipart/form-data' }, 415)
+    }
+    const form = await c.req.formData()
+
+    const logoFile = form.get('logo')
+    if (logoFile instanceof File && logoFile.size > 0) {
+      const result = await uploadBrandingImage(platform, 'logo', logoFile)
+      if (!result.ok) return c.json({ error: result.error }, result.status)
+    }
+
+    const faviconFile = form.get('favicon')
+    if (faviconFile instanceof File && faviconFile.size > 0) {
+      const result = await uploadBrandingImage(platform, 'favicon', faviconFile)
+      if (!result.ok) return c.json({ error: result.error }, result.status)
+    }
+
+    const wordmarkRaw = form.get('wordmark_text')
+    if (typeof wordmarkRaw === 'string') {
+      if (wordmarkRaw.length > 24) return c.json({ error: 'wordmark_text must be 24 characters or fewer' }, 422)
+      await setBrandingField(platform.db, 'wordmark_text', wordmarkRaw)
+    }
+
+    const hidePoweredByRaw = form.get('hide_powered_by')
+    if (hidePoweredByRaw !== null) {
+      const value = hidePoweredByRaw === 'true' || hidePoweredByRaw === '1' ? 'true' : 'false'
+      await setBrandingField(platform.db, 'hide_powered_by', value)
+    }
+
+    return c.json(await readBranding(platform.db))
+  })
+  .delete('/:field', async (c) => {
+    const rawField = c.req.param('field')
+    if (!VALID_RESET_FIELDS.has(rawField as BrandingField)) {
+      return c.json({ error: `Invalid field. Valid fields: ${[...VALID_RESET_FIELDS].join(', ')}` }, 400)
+    }
+    await resetBrandingField(c.get('platform').db, rawField as BrandingField)
+    return c.json({ field: rawField, reset: true })
+  })

--- a/server/services/branding.ts
+++ b/server/services/branding.ts
@@ -1,0 +1,94 @@
+import { eq, inArray } from 'drizzle-orm'
+// Shared type has uid field absent from DB schema — same mismatch as image-upload.ts.
+// Both use `as unknown as S3Storage` to bridge them. The fields used by S3Service
+// (endpoint, region, accessKey, secretKey, bucket, customHost) exist on both.
+import type { Storage as S3Storage } from '../../shared/types'
+import { systemOptions } from '../db/schema'
+import type { Database, Platform } from '../platform/interface'
+import { S3Service } from './s3'
+import { selectStorage } from './storage'
+
+const s3 = new S3Service()
+
+const LOGO_MIMES = ['image/png', 'image/jpeg', 'image/webp', 'image/svg+xml'] as const
+const FAVICON_MIMES = ['image/png', 'image/x-icon', 'image/vnd.microsoft.icon', 'image/svg+xml'] as const
+export const MAX_BRANDING_FILE_SIZE = 2 * 1024 * 1024 // 2 MiB
+
+const MIME_TO_EXT: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/webp': 'webp',
+  'image/svg+xml': 'svg',
+  'image/x-icon': 'ico',
+  'image/vnd.microsoft.icon': 'ico',
+}
+
+export const BRANDING_KEYS = {
+  logo: 'branding_logo_url',
+  favicon: 'branding_favicon_url',
+  wordmark_text: 'branding_wordmark_text',
+  hide_powered_by: 'branding_hide_powered_by',
+} as const
+
+export type BrandingUploadResult = { ok: true; url: string } | { ok: false; status: 400 | 413 | 503; error: string }
+
+export async function readBranding(db: Database) {
+  const keys = Object.values(BRANDING_KEYS)
+  const rows = await db.select().from(systemOptions).where(inArray(systemOptions.key, keys))
+  const map = new Map(rows.map((r) => [r.key, r.value]))
+  return {
+    logo_url: map.get(BRANDING_KEYS.logo) ?? null,
+    favicon_url: map.get(BRANDING_KEYS.favicon) ?? null,
+    wordmark_text: map.get(BRANDING_KEYS.wordmark_text) ?? null,
+    hide_powered_by: map.get(BRANDING_KEYS.hide_powered_by) === 'true',
+  }
+}
+
+export async function uploadBrandingImage(
+  platform: Platform,
+  field: 'logo' | 'favicon',
+  file: File,
+): Promise<BrandingUploadResult> {
+  const allowedMimes = field === 'logo' ? LOGO_MIMES : FAVICON_MIMES
+  if (!(allowedMimes as readonly string[]).includes(file.type)) {
+    return { ok: false, status: 400, error: `Invalid file type for ${field}. Allowed: ${allowedMimes.join(', ')}` }
+  }
+  if (file.size > MAX_BRANDING_FILE_SIZE) {
+    return { ok: false, status: 413, error: 'File too large. Max 2 MiB.' }
+  }
+
+  let storage: S3Storage
+  try {
+    storage = (await selectStorage(platform.db, 'public')) as unknown as S3Storage
+  } catch {
+    return { ok: false, status: 503, error: 'No public storage configured' }
+  }
+
+  const ext = MIME_TO_EXT[file.type] ?? 'bin'
+  const key = `_system/branding/${field}.${ext}`
+  const bytes = new Uint8Array(await file.arrayBuffer())
+  await s3.putObject(storage, key, bytes, file.type)
+  const url = s3.getPublicUrl(storage, key)
+
+  await upsertOption(platform.db, BRANDING_KEYS[field], url)
+  return { ok: true, url }
+}
+
+export async function setBrandingField(
+  db: Database,
+  field: 'wordmark_text' | 'hide_powered_by',
+  value: string,
+): Promise<void> {
+  await upsertOption(db, BRANDING_KEYS[field], value)
+}
+
+export async function resetBrandingField(db: Database, field: keyof typeof BRANDING_KEYS): Promise<void> {
+  await db.delete(systemOptions).where(eq(systemOptions.key, BRANDING_KEYS[field]))
+}
+
+async function upsertOption(db: Database, key: string, value: string): Promise<void> {
+  await db
+    .insert(systemOptions)
+    .values({ key, value, public: true })
+    .onConflictDoUpdate({ target: systemOptions.key, set: { value, public: true } })
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -241,3 +241,12 @@ export interface ImageHosting {
 }
 
 export type { BindingState, LicenseEntitlement, ProFeature } from './licensing'
+
+export interface BrandingConfig {
+  logo_url: string | null
+  favicon_url: string | null
+  wordmark_text: string | null
+  hide_powered_by: boolean
+}
+
+export type BrandingField = 'logo' | 'favicon' | 'wordmark_text' | 'hide_powered_by'

--- a/src/components/admin/admin-sidebar.tsx
+++ b/src/components/admin/admin-sidebar.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@tanstack/react-router'
-import { ArrowLeft, Database, KeyRound, Settings, Users } from 'lucide-react'
+import { ArrowLeft, Database, KeyRound, Paintbrush, Settings, Users } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import {
@@ -20,6 +20,7 @@ const adminNavItems = [
   { titleKey: 'admin.nav.users', url: '/admin/users', icon: Users },
   { titleKey: 'admin.nav.settings', url: '/admin/settings', icon: Settings },
   { titleKey: 'admin.nav.auth', url: '/admin/settings/auth', icon: KeyRound },
+  { titleKey: 'admin.nav.branding', url: '/admin/branding', icon: Paintbrush },
 ]
 
 export function AdminSidebar() {

--- a/src/components/branding/BrandingProvider.tsx
+++ b/src/components/branding/BrandingProvider.tsx
@@ -1,0 +1,68 @@
+import type { BrandingConfig } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+import { createContext, type ReactNode, useContext, useEffect } from 'react'
+import { getBranding } from '@/lib/api'
+
+export const brandingQueryKey = ['branding'] as const
+
+interface BrandingContext {
+  branding: BrandingConfig
+  isLoading: boolean
+}
+
+const defaultBranding: BrandingConfig = {
+  logo_url: null,
+  favicon_url: null,
+  wordmark_text: null,
+  hide_powered_by: false,
+}
+
+const BrandingCtx = createContext<BrandingContext>({
+  branding: defaultBranding,
+  isLoading: false,
+})
+
+export function useBranding() {
+  return useContext(BrandingCtx)
+}
+
+function applyFavicon(url: string | null) {
+  let link = document.querySelector<HTMLLinkElement>('link[rel~="icon"]')
+  if (!link) {
+    link = document.createElement('link')
+    link.rel = 'icon'
+    document.head.appendChild(link)
+  }
+  link.href = url ?? '/favicon.ico'
+}
+
+function BrandingEffects({ branding }: { branding: BrandingConfig }) {
+  const wordmark = branding.wordmark_text ?? ''
+
+  useEffect(() => {
+    document.documentElement.style.setProperty('--site-wordmark', JSON.stringify(wordmark))
+  }, [wordmark])
+
+  useEffect(() => {
+    applyFavicon(branding.favicon_url)
+  }, [branding.favicon_url])
+
+  return null
+}
+
+export function BrandingProvider({ children }: { children: ReactNode }) {
+  const { data, isLoading } = useQuery({
+    queryKey: brandingQueryKey,
+    queryFn: getBranding,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const branding = data ?? defaultBranding
+
+  return (
+    <BrandingCtx.Provider value={{ branding, isLoading }}>
+      <BrandingEffects branding={branding} />
+      {children}
+    </BrandingCtx.Provider>
+  )
+}

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -17,6 +17,7 @@ import {
   Video,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { useBranding } from '@/components/branding/BrandingProvider'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import {
@@ -67,6 +68,8 @@ export function AppSidebar() {
   const { data: session } = useSession()
   const { data: activeOrg } = useActiveOrganization()
   const { siteName } = useSiteOptions()
+  const { branding } = useBranding()
+  const wordmark = branding.wordmark_text || siteName || 'ZPan'
   const user = session?.user as { name: string; username?: string; role?: string; image?: string | null } | undefined
   const isAdmin = user?.role === 'admin'
   const { data: quota } = useQuery({
@@ -97,8 +100,8 @@ export function AppSidebar() {
     <Sidebar>
       <SidebarHeader className="gap-2 px-3 pt-3 pb-1">
         <div className="-mx-3 flex items-center gap-2.5 border-b px-4 pb-3">
-          <img src="/logo.svg" alt="ZPan" className="size-8" />
-          <span className="text-lg font-semibold">{siteName || 'ZPan'}</span>
+          <img src={branding.logo_url ?? '/logo.svg'} alt={wordmark} className="size-8" />
+          <span className="text-lg font-semibold">{wordmark}</span>
         </div>
         <OrgSwitcher />
       </SidebarHeader>
@@ -212,6 +215,9 @@ export function AppSidebar() {
               : t('quota.usageNoLimit', { used: formatSize(quota.used) })}
           </p>
         </div>
+      )}
+      {!branding.hide_powered_by && (
+        <div className="px-4 py-1.5 text-center text-xs text-muted-foreground/60">Powered by ZPan</div>
       )}
       <SidebarFooter className="border-t p-3">
         <SidebarMenu>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -142,6 +142,7 @@
   "admin.settings.defaultOrgQuotaHint": "Storage quota for new users. 0 means unlimited.",
   "admin.settings.saved": "Settings saved",
   "admin.nav.auth": "Auth",
+  "admin.nav.branding": "Branding",
   "admin.auth.title": "Authentication",
   "admin.auth.registrationSection": "Registration Mode",
   "admin.auth.registrationOpen": "Open",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -142,6 +142,7 @@
   "admin.settings.defaultOrgQuotaHint": "新用户的存储配额，0 表示不限制。",
   "admin.settings.saved": "设置已保存",
   "admin.nav.auth": "认证",
+  "admin.nav.branding": "品牌定制",
   "admin.auth.title": "身份认证",
   "admin.auth.registrationSection": "注册模式",
   "admin.auth.registrationOpen": "开放",

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -25,6 +25,7 @@ import {
   disconnectCloud,
   emptyTrash,
   enableIhostFeature,
+  getBranding,
   getIhostConfig,
   getLicensingStatus,
   getObject,
@@ -50,8 +51,10 @@ import {
   markNotificationRead,
   pollPairing,
   refreshLicense,
+  resetBrandingField,
   restoreObject,
   revokeIhostApiKey,
+  saveBranding,
   saveShareToDrive,
   setSystemOption,
   trashObject,
@@ -1945,6 +1948,98 @@ describe('api', () => {
       vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Forbidden' }, false, 403))
 
       await expect(disconnectCloud()).rejects.toThrow()
+    })
+  })
+
+  describe('getBranding', () => {
+    it('calls GET /api/branding and returns config', async () => {
+      const payload = { logo_url: null, favicon_url: null, wordmark_text: null, hide_powered_by: false }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
+
+      const result = await getBranding()
+
+      expect(result).toEqual(payload)
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toContain('/api/branding')
+    })
+
+    it('resolves with stored branding values', async () => {
+      const payload = {
+        logo_url: 'https://cdn.example.com/logo.svg',
+        favicon_url: null,
+        wordmark_text: 'MyCloud',
+        hide_powered_by: true,
+      }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
+
+      const result = await getBranding()
+
+      expect(result.logo_url).toBe('https://cdn.example.com/logo.svg')
+      expect(result.wordmark_text).toBe('MyCloud')
+      expect(result.hide_powered_by).toBe(true)
+    })
+
+    it('throws ApiError on non-ok response', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Internal error' }, false, 500))
+
+      await expect(getBranding()).rejects.toThrow('Internal error')
+    })
+  })
+
+  describe('saveBranding', () => {
+    it('sends PUT /api/admin/branding as multipart', async () => {
+      const payload = { logo_url: null, favicon_url: null, wordmark_text: 'MyCloud', hide_powered_by: false }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
+
+      await saveBranding({ wordmark_text: 'MyCloud' })
+
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toContain('/api/admin/branding')
+      expect(init.method).toBe('PUT')
+      expect(init.body).toBeInstanceOf(FormData)
+    })
+
+    it('includes logo file in FormData when provided', async () => {
+      const payload = {
+        logo_url: 'https://cdn/logo.png',
+        favicon_url: null,
+        wordmark_text: null,
+        hide_powered_by: false,
+      }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
+      const file = new File(['png-data'], 'logo.png', { type: 'image/png' })
+
+      await saveBranding({ logo: file })
+
+      const [, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      const form = init.body as FormData
+      expect(form.get('logo')).toBe(file)
+    })
+
+    it('throws ApiError on 402 (feature gated)', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(
+        makeResponse({ error: 'feature_not_available', feature: 'white_label' }, false, 402),
+      )
+
+      await expect(saveBranding({ wordmark_text: 'x' })).rejects.toThrow()
+    })
+  })
+
+  describe('resetBrandingField', () => {
+    it('sends DELETE /api/admin/branding/:field', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ field: 'logo', reset: true }))
+
+      await resetBrandingField('logo')
+
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toContain('/api/admin/branding/logo')
+      expect(init.method).toBe('DELETE')
+    })
+
+    it('throws ApiError on failure', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Forbidden' }, false, 403))
+
+      await expect(resetBrandingField('logo')).rejects.toThrow()
     })
   })
 })

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -10,6 +10,8 @@ import type {
   ActivityEvent,
   AuthProvider,
   BindingState,
+  BrandingConfig,
+  BrandingField,
   IhostConfigResponse,
   ImageHosting,
   Notification,
@@ -24,6 +26,7 @@ import {
   adminQuotas,
   authedSharesApi,
   authProviders,
+  brandingAdminApi,
   emailConfig,
   ihostApi,
   ihostConfigApi,
@@ -34,6 +37,7 @@ import {
   notificationsApi,
   objects,
   profiles,
+  publicBrandingApi,
   publicSharesApi,
   storages,
   system,
@@ -681,6 +685,50 @@ export function uploadTeamLogo(teamId: string, file: File) {
 
 export async function deleteTeamLogo(teamId: string) {
   const res = await teamsApi[':teamId'].logo.$delete({ param: { teamId } })
+  if (!res.ok) {
+    const parsed = (await res.json().catch(() => ({}))) as ApiErrorBody
+    throw new ApiError(res.status, { ...parsed, error: parsed.error ?? res.statusText })
+  }
+}
+
+// Branding API
+
+export type { BrandingConfig, BrandingField }
+
+export function getBranding() {
+  return unwrap<BrandingConfig>(publicBrandingApi.index.$get())
+}
+
+// PUT uses multipart/form-data (logo/favicon are File objects).
+// Hono RPC does not express multipart cleanly — same documented exception as avatar/team logo uploads.
+export async function saveBranding(data: {
+  logo?: File | null
+  favicon?: File | null
+  wordmark_text?: string
+  hide_powered_by?: boolean
+}): Promise<BrandingConfig> {
+  const form = new FormData()
+  if (data.logo) form.set('logo', data.logo)
+  if (data.favicon) form.set('favicon', data.favicon)
+  // Empty string is submitted as an explicit clear; server treats it as setting wordmark to "".
+  // Use resetBrandingField('wordmark_text') to fully remove the key.
+  if (data.wordmark_text !== undefined) form.set('wordmark_text', data.wordmark_text)
+  if (data.hide_powered_by !== undefined) form.set('hide_powered_by', data.hide_powered_by ? 'true' : 'false')
+
+  const res = await fetch('/api/admin/branding', {
+    method: 'PUT',
+    body: form,
+    credentials: 'include',
+  })
+  if (!res.ok) {
+    const parsed = (await res.json().catch(() => ({}))) as ApiErrorBody
+    throw new ApiError(res.status, { ...parsed, error: parsed.error ?? res.statusText })
+  }
+  return res.json() as Promise<BrandingConfig>
+}
+
+export async function resetBrandingField(field: BrandingField): Promise<void> {
+  const res = await brandingAdminApi[':field'].$delete({ param: { field } })
   if (!res.ok) {
     const parsed = (await res.json().catch(() => ({}))) as ApiErrorBody
     throw new ApiError(res.status, { ...parsed, error: parsed.error ?? res.statusText })

--- a/src/lib/rpc.ts
+++ b/src/lib/rpc.ts
@@ -4,6 +4,7 @@ import type {
   AdminQuotasRoute,
   AuthedSharesRoute,
   AuthProvidersRoute,
+  BrandingAdminRoute,
   EmailConfigRoute,
   IhostConfigRoute,
   IhostRoute,
@@ -13,6 +14,7 @@ import type {
   NotificationsRoute,
   ObjectsRoute,
   ProfileRoute,
+  PublicBrandingRoute,
   PublicSharesRoute,
   PublicTeamsRoute,
   StoragesRoute,
@@ -52,3 +54,5 @@ export const ihostConfigApi = hc<IhostConfigRoute>('/api/ihost/config', opts)
 export const ihostApi = hc<IhostRoute>('/api/ihost', opts)
 export const licensingApi = hc<LicensingRoute>('/api/licensing', opts)
 export const licensingAdminApi = hc<LicensingAdminRoute>('/api/licensing', opts)
+export const publicBrandingApi = hc<PublicBrandingRoute>('/api/branding', opts)
+export const brandingAdminApi = hc<BrandingAdminRoute>('/api/admin/branding', opts)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createRouter, RouterProvider } from '@tanstack/react-router'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { BrandingProvider } from './components/branding/BrandingProvider'
 import { i18nReady } from './i18n'
 import { routeTree } from './routeTree.gen'
 import './styles/globals.css'
@@ -19,7 +20,9 @@ i18nReady.then(() => {
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
       <QueryClientProvider client={queryClient}>
-        <RouterProvider router={router} />
+        <BrandingProvider>
+          <RouterProvider router={router} />
+        </BrandingProvider>
       </QueryClientProvider>
     </React.StrictMode>,
   )

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -40,6 +40,7 @@ import { Route as AuthenticatedTeamsTeamIdSettingsRouteImport } from './routes/_
 import { Route as AuthenticatedTeamsTeamIdMembersRouteImport } from './routes/_authenticated/teams/$teamId/members'
 import { Route as AuthenticatedTeamsTeamIdActivityRouteImport } from './routes/_authenticated/teams/$teamId/activity'
 import { Route as AuthenticatedAdminSettingsAuthRouteImport } from './routes/_authenticated/admin/settings/auth'
+import { Route as AuthenticatedAdminBrandingIndexRouteImport } from './routes/_authenticated/admin/branding/index'
 
 const SRouteRoute = SRouteRouteImport.update({
   id: '/s',
@@ -214,6 +215,12 @@ const AuthenticatedAdminSettingsAuthRoute =
     path: '/settings/auth',
     getParentRoute: () => AuthenticatedAdminRouteRoute,
   } as any)
+const AuthenticatedAdminBrandingIndexRoute =
+  AuthenticatedAdminBrandingIndexRouteImport.update({
+    id: '/branding/',
+    path: '/branding/',
+    getParentRoute: () => AuthenticatedAdminRouteRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof AuthenticatedIndexRoute
@@ -245,6 +252,7 @@ export interface FileRoutesByFullPath {
   '/admin/settings/': typeof AuthenticatedAdminSettingsIndexRoute
   '/admin/storages/': typeof AuthenticatedAdminStoragesIndexRoute
   '/admin/users/': typeof AuthenticatedAdminUsersIndexRoute
+  '/admin/branding/': typeof AuthenticatedAdminBrandingIndexRoute
   '/teams/$teamId/': typeof AuthenticatedTeamsTeamIdIndexRoute
 }
 export interface FileRoutesByTo {
@@ -275,6 +283,7 @@ export interface FileRoutesByTo {
   '/admin/settings': typeof AuthenticatedAdminSettingsIndexRoute
   '/admin/storages': typeof AuthenticatedAdminStoragesIndexRoute
   '/admin/users': typeof AuthenticatedAdminUsersIndexRoute
+  '/admin/branding': typeof AuthenticatedAdminBrandingIndexRoute
   '/teams/$teamId': typeof AuthenticatedTeamsTeamIdIndexRoute
 }
 export interface FileRoutesById {
@@ -309,6 +318,7 @@ export interface FileRoutesById {
   '/_authenticated/admin/settings/': typeof AuthenticatedAdminSettingsIndexRoute
   '/_authenticated/admin/storages/': typeof AuthenticatedAdminStoragesIndexRoute
   '/_authenticated/admin/users/': typeof AuthenticatedAdminUsersIndexRoute
+  '/_authenticated/admin/branding/': typeof AuthenticatedAdminBrandingIndexRoute
   '/_authenticated/teams/$teamId/': typeof AuthenticatedTeamsTeamIdIndexRoute
 }
 export interface FileRouteTypes {
@@ -343,6 +353,7 @@ export interface FileRouteTypes {
     | '/admin/settings/'
     | '/admin/storages/'
     | '/admin/users/'
+    | '/admin/branding/'
     | '/teams/$teamId/'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -373,6 +384,7 @@ export interface FileRouteTypes {
     | '/admin/settings'
     | '/admin/storages'
     | '/admin/users'
+    | '/admin/branding'
     | '/teams/$teamId'
   id:
     | '__root__'
@@ -406,6 +418,7 @@ export interface FileRouteTypes {
     | '/_authenticated/admin/settings/'
     | '/_authenticated/admin/storages/'
     | '/_authenticated/admin/users/'
+    | '/_authenticated/admin/branding/'
     | '/_authenticated/teams/$teamId/'
   fileRoutesById: FileRoutesById
 }
@@ -636,6 +649,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAdminSettingsAuthRouteImport
       parentRoute: typeof AuthenticatedAdminRouteRoute
     }
+    '/_authenticated/admin/branding/': {
+      id: '/_authenticated/admin/branding/'
+      path: '/branding/'
+      fullPath: '/admin/branding/'
+      preLoaderRoute: typeof AuthenticatedAdminBrandingIndexRouteImport
+      parentRoute: typeof AuthenticatedAdminRouteRoute
+    }
   }
 }
 
@@ -644,6 +664,7 @@ interface AuthenticatedAdminRouteRouteChildren {
   AuthenticatedAdminSettingsIndexRoute: typeof AuthenticatedAdminSettingsIndexRoute
   AuthenticatedAdminStoragesIndexRoute: typeof AuthenticatedAdminStoragesIndexRoute
   AuthenticatedAdminUsersIndexRoute: typeof AuthenticatedAdminUsersIndexRoute
+  AuthenticatedAdminBrandingIndexRoute: typeof AuthenticatedAdminBrandingIndexRoute
 }
 
 const AuthenticatedAdminRouteRouteChildren: AuthenticatedAdminRouteRouteChildren =
@@ -652,6 +673,7 @@ const AuthenticatedAdminRouteRouteChildren: AuthenticatedAdminRouteRouteChildren
     AuthenticatedAdminSettingsIndexRoute: AuthenticatedAdminSettingsIndexRoute,
     AuthenticatedAdminStoragesIndexRoute: AuthenticatedAdminStoragesIndexRoute,
     AuthenticatedAdminUsersIndexRoute: AuthenticatedAdminUsersIndexRoute,
+    AuthenticatedAdminBrandingIndexRoute: AuthenticatedAdminBrandingIndexRoute,
   }
 
 const AuthenticatedAdminRouteRouteWithChildren =

--- a/src/routes/_authenticated/admin/branding/index.tsx
+++ b/src/routes/_authenticated/admin/branding/index.tsx
@@ -1,0 +1,328 @@
+import type { BrandingConfig, BrandingField } from '@shared/types'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { createFileRoute } from '@tanstack/react-router'
+import { Trash2, Upload } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import { brandingQueryKey } from '@/components/branding/BrandingProvider'
+import { UpgradeHint } from '@/components/UpgradeHint'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+import { useEntitlement } from '@/hooks/useEntitlement'
+import { getBranding, resetBrandingField, saveBranding } from '@/lib/api'
+
+export const Route = createFileRoute('/_authenticated/admin/branding/')({
+  component: BrandingPage,
+})
+
+// ─── Hooks ────────────────────────────────────────────────────────────────────
+
+interface BrandingFormState {
+  logoFile: File | null
+  faviconFile: File | null
+  wordmarkText: string
+  hidePoweredBy: boolean
+  previewLogoUrl: string | null
+  faviconPreviewUrl: string | null
+}
+
+function useBrandingFormState(initial: BrandingConfig): {
+  state: BrandingFormState
+  setLogoFile: (f: File | null) => void
+  setFaviconFile: (f: File | null) => void
+  setWordmarkText: (v: string) => void
+  setHidePoweredBy: (v: boolean) => void
+} {
+  const [logoFile, setLogoFileRaw] = useState<File | null>(null)
+  const [faviconFile, setFaviconFileRaw] = useState<File | null>(null)
+  const [wordmarkText, setWordmarkText] = useState(initial.wordmark_text ?? '')
+  const [hidePoweredBy, setHidePoweredBy] = useState(initial.hide_powered_by)
+  const [previewLogoUrl, setPreviewLogoUrl] = useState<string | null>(initial.logo_url)
+  const [faviconPreviewUrl, setFaviconPreviewUrl] = useState<string | null>(initial.favicon_url)
+
+  // Revoke blob URL when it changes to avoid memory leaks
+  const prevLogoBlob = useRef<string | null>(null)
+  const prevFaviconBlob = useRef<string | null>(null)
+
+  function setLogoFile(f: File | null) {
+    if (prevLogoBlob.current) URL.revokeObjectURL(prevLogoBlob.current)
+    const url = f ? URL.createObjectURL(f) : initial.logo_url
+    prevLogoBlob.current = f ? url : null
+    setLogoFileRaw(f)
+    setPreviewLogoUrl(url)
+  }
+
+  function setFaviconFile(f: File | null) {
+    if (prevFaviconBlob.current) URL.revokeObjectURL(prevFaviconBlob.current)
+    const url = f ? URL.createObjectURL(f) : initial.favicon_url
+    prevFaviconBlob.current = f ? url : null
+    setFaviconFileRaw(f)
+    setFaviconPreviewUrl(url)
+  }
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (prevLogoBlob.current) URL.revokeObjectURL(prevLogoBlob.current)
+      if (prevFaviconBlob.current) URL.revokeObjectURL(prevFaviconBlob.current)
+    }
+  }, [])
+
+  return {
+    state: { logoFile, faviconFile, wordmarkText, hidePoweredBy, previewLogoUrl, faviconPreviewUrl },
+    setLogoFile,
+    setFaviconFile,
+    setWordmarkText,
+    setHidePoweredBy,
+  }
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function FileUploadField({
+  id,
+  label,
+  accept,
+  previewUrl,
+  onFileChange,
+  onReset,
+}: {
+  id: string
+  label: string
+  accept: string
+  previewUrl: string | null
+  onFileChange: (file: File | null) => void
+  onReset: () => void
+}) {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>{label}</Label>
+      <div className="flex items-center gap-3">
+        {previewUrl && (
+          <img src={previewUrl} alt={label} className="h-10 w-10 rounded border object-contain bg-muted/40" />
+        )}
+        <input
+          ref={inputRef}
+          id={id}
+          type="file"
+          accept={accept}
+          className="hidden"
+          onChange={(e) => onFileChange(e.target.files?.[0] ?? null)}
+        />
+        <Button type="button" variant="outline" size="sm" onClick={() => inputRef.current?.click()}>
+          <Upload className="mr-2 h-4 w-4" />
+          {previewUrl ? 'Replace' : 'Upload'}
+        </Button>
+        {previewUrl && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={onReset}
+            className="text-muted-foreground hover:text-destructive"
+          >
+            <Trash2 className="mr-1 h-4 w-4" />
+            Reset
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function LivePreview({ branding }: { branding: BrandingConfig }) {
+  const logoSrc = branding.logo_url ?? '/logo.svg'
+  const wordmark = branding.wordmark_text || 'ZPan'
+
+  return (
+    <div className="rounded-lg border bg-sidebar p-4 space-y-3">
+      <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Live Preview</p>
+      <div className="flex items-center gap-2.5 border-b border-border/50 pb-3">
+        <img src={logoSrc} alt={wordmark} className="size-8 rounded object-contain" />
+        <span className="text-lg font-semibold">{wordmark}</span>
+      </div>
+      {!branding.hide_powered_by && <p className="text-xs text-muted-foreground/60 text-center">Powered by ZPan</p>}
+    </div>
+  )
+}
+
+// ─── Main form ────────────────────────────────────────────────────────────────
+
+function BrandingForm({ initial }: { initial: BrandingConfig }) {
+  const queryClient = useQueryClient()
+  const { state, setLogoFile, setFaviconFile, setWordmarkText, setHidePoweredBy } = useBrandingFormState(initial)
+
+  const saveMutation = useMutation({
+    mutationFn: () =>
+      saveBranding({
+        logo: state.logoFile,
+        favicon: state.faviconFile,
+        wordmark_text: state.wordmarkText,
+        hide_powered_by: state.hidePoweredBy,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: brandingQueryKey })
+      toast.success('Branding saved')
+    },
+    onError: (err) => toast.error(err.message),
+  })
+
+  const resetMutation = useMutation({
+    mutationFn: (field: BrandingField) => resetBrandingField(field),
+    onSuccess: (_data, field) => {
+      queryClient.invalidateQueries({ queryKey: brandingQueryKey })
+      if (field === 'logo') setLogoFile(null)
+      if (field === 'favicon') setFaviconFile(null)
+      if (field === 'wordmark_text') setWordmarkText('')
+      if (field === 'hide_powered_by') setHidePoweredBy(false)
+      toast.success(`${field} reset to default`)
+    },
+    onError: (err) => toast.error(err.message),
+  })
+
+  const previewBranding: BrandingConfig = {
+    logo_url: state.previewLogoUrl,
+    favicon_url: state.faviconPreviewUrl,
+    wordmark_text: state.wordmarkText || null,
+    hide_powered_by: state.hidePoweredBy,
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_280px]">
+      <BrandingFormFields
+        state={state}
+        onLogoChange={setLogoFile}
+        onFaviconChange={setFaviconFile}
+        onWordmarkChange={setWordmarkText}
+        onHidePoweredByChange={setHidePoweredBy}
+        onReset={(f) => resetMutation.mutate(f)}
+        onSubmit={() => saveMutation.mutate()}
+        isSaving={saveMutation.isPending}
+      />
+      <div className="space-y-2">
+        <p className="text-sm font-medium">Preview</p>
+        <LivePreview branding={previewBranding} />
+      </div>
+    </div>
+  )
+}
+
+function BrandingFormFields({
+  state,
+  onLogoChange,
+  onFaviconChange,
+  onWordmarkChange,
+  onHidePoweredByChange,
+  onReset,
+  onSubmit,
+  isSaving,
+}: {
+  state: BrandingFormState
+  onLogoChange: (f: File | null) => void
+  onFaviconChange: (f: File | null) => void
+  onWordmarkChange: (v: string) => void
+  onHidePoweredByChange: (v: boolean) => void
+  onReset: (f: BrandingField) => void
+  onSubmit: () => void
+  isSaving: boolean
+}) {
+  return (
+    <form
+      className="space-y-6"
+      onSubmit={(e) => {
+        e.preventDefault()
+        onSubmit()
+      }}
+    >
+      <div className="rounded-md border p-4 space-y-5">
+        <h3 className="text-sm font-medium text-muted-foreground">Logo & Favicon</h3>
+        <FileUploadField
+          id="logo-upload"
+          label="Logo"
+          accept="image/png,image/jpeg,image/webp,image/svg+xml"
+          previewUrl={state.previewLogoUrl}
+          onFileChange={onLogoChange}
+          onReset={() => onReset('logo')}
+        />
+        <FileUploadField
+          id="favicon-upload"
+          label="Favicon"
+          accept="image/png,image/x-icon,image/vnd.microsoft.icon,image/svg+xml"
+          previewUrl={state.faviconPreviewUrl}
+          onFileChange={onFaviconChange}
+          onReset={() => onReset('favicon')}
+        />
+      </div>
+
+      <div className="rounded-md border p-4 space-y-4">
+        <h3 className="text-sm font-medium text-muted-foreground">Wordmark</h3>
+        <div className="space-y-1.5">
+          <Label htmlFor="wordmark-text">Wordmark text</Label>
+          <Input
+            id="wordmark-text"
+            value={state.wordmarkText}
+            maxLength={24}
+            onChange={(e) => onWordmarkChange(e.target.value)}
+            placeholder="My Cloud"
+          />
+          <p className="text-xs text-muted-foreground">Replaces "ZPan" in the sidebar. Max 24 characters.</p>
+        </div>
+      </div>
+
+      <div className="rounded-md border p-4">
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <Label htmlFor="hide-powered-by">Hide "Powered by ZPan"</Label>
+            <p className="text-xs text-muted-foreground">Remove the footer credit from the sidebar.</p>
+          </div>
+          <Switch id="hide-powered-by" checked={state.hidePoweredBy} onCheckedChange={onHidePoweredByChange} />
+        </div>
+      </div>
+
+      <Button type="submit" disabled={isSaving}>
+        {isSaving ? 'Saving…' : 'Save branding'}
+      </Button>
+    </form>
+  )
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+function BrandingPage() {
+  const { hasFeature, isLoading: entitlementLoading } = useEntitlement()
+  const { data: branding, isLoading: brandingLoading } = useQuery({
+    queryKey: brandingQueryKey,
+    queryFn: getBranding,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  if (entitlementLoading || brandingLoading) {
+    return (
+      <div className="flex items-center justify-center py-20 text-muted-foreground">
+        <p>Loading…</p>
+      </div>
+    )
+  }
+
+  if (!hasFeature('white_label')) {
+    return (
+      <div className="space-y-6">
+        <h2 className="text-xl font-semibold">Branding</h2>
+        <UpgradeHint feature="white_label" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-xl font-semibold">Branding</h2>
+      <BrandingForm
+        initial={branding ?? { logo_url: null, favicon_url: null, wordmark_text: null, hide_powered_by: false }}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **Server**: `GET /api/branding` (public), `PUT /api/admin/branding` (admin + `white_label` feature), `DELETE /api/admin/branding/:field` — all gated via `requireFeature('white_label')` middleware returning 402 on non-Pro
- **Service**: `server/services/branding.ts` uploads logo/favicon to `_system/branding/` in the public S3 bucket; stores config in `systemOptions` via atomic `onConflictDoUpdate`; shared types `BrandingConfig` / `BrandingField` live in `shared/types/`
- **Frontend**: `BrandingProvider` wraps `<App/>`, fetches branding on boot, applies favicon via `<link>` and sets `--site-wordmark` CSS var; `AppSidebar` uses custom logo src, wordmark text, and conditionally shows "Powered by ZPan" footer; Admin `/admin/branding` page shows `UpgradeHint` for non-Pro, upload form + live preview panel for Pro users

## Test plan

- [ ] Non-Pro instance: `GET /admin/branding` shows `UpgradeHint`. `PUT /api/admin/branding` returns 402.
- [ ] Pro instance: admin uploads logo → next page load shows new logo in nav sidebar
- [ ] Favicon updates in browser tab after upload
- [ ] Wordmark text "MyCloud" → sidebar shows "MyCloud" instead of "ZPan"
- [ ] Hide "Powered by ZPan" toggle removes footer credit from sidebar
- [ ] Reset logo endpoint (`DELETE /api/admin/branding/logo`) restores default
- [ ] Logo upload > 2MB rejected with 413
- [ ] Wordmark text > 24 chars rejected with 422
- [ ] Live preview in admin page updates without saving
- [ ] All 2701 tests pass, both typechecks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)