### PR TITLE
feat: v2.6 Z11 — production public key, Docker cron docs, release notes

### DIFF
--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -68,3 +68,37 @@ turso db tokens create your-db-name
 ```
 
 Or create one in the [Turso dashboard](https://app.turso.tech).
+
+## Pro licensing: external cron for 6h refresh
+
+ZPan refreshes its entitlement certificate every 6 hours via a built-in background timer. The Docker container runs a persistent Node.js process, so the background timer fires automatically — **no external cron is required**.
+
+If you prefer an explicit external trigger (e.g. to integrate with your monitoring or to refresh immediately after a plan change), you can call the refresh endpoint manually:
+
+### Setup
+
+1. **Generate a secret:**
+   ```sh
+   openssl rand -hex 32
+   ```
+
+2. **Add the env var** to your container environment:
+
+   ```yaml
+   environment:
+     REFRESH_CRON_SECRET: <the-secret-from-step-1>
+   ```
+
+3. **Trigger a refresh** with an HTTP POST:
+
+   ```
+   POST https://your-domain.example/api/licensing/refresh-cron?secret=<REFRESH_CRON_SECRET>
+   ```
+
+   To run on a schedule via host cron, add to your crontab:
+
+   ```cron
+   0 */6 * * * curl -s -X POST "https://your-domain.example/api/licensing/refresh-cron?secret=<REFRESH_CRON_SECRET>"
+   ```
+
+If `REFRESH_CRON_SECRET` is not set, the endpoint returns `401` for all requests.

--- a/docs/v2.6-release-notes.md
+++ b/docs/v2.6-release-notes.md
@@ -1,0 +1,94 @@
+# ZPan v2.6 Release Notes
+
+## What's New
+
+ZPan v2.6 introduces **ZPan Pro** — a paid tier that unlocks operator-grade features for people running ZPan as a platform for others. Community (self-hosted personal use) remains free and unlimited for everything it has always supported.
+
+---
+
+## ZPan Pro
+
+### Cloud Account Binding
+
+Connect your ZPan instance to a [ZPan Cloud](https://cloud.zpan.space) account using a device-code pairing flow — no callback URL required, so it works on home labs, internal networks, and NATted VPS hosts.
+
+1. Go to **Settings → Billing** and click **Connect to ZPan Cloud**.
+2. ZPan displays a short code. Visit `cloud.zpan.space/pair` on any device, sign in, and enter the code.
+3. ZPan detects confirmation and shows your plan within seconds.
+
+### Entitlement Certificates
+
+Pro status is verified locally using an Ed25519-signed certificate fetched from `cloud.zpan.space` every 6 hours. No network call happens per request — the certificate is cached in your database. ZPan tolerates up to 24 hours of cloud downtime before feature gates fall back to Community.
+
+### White-Label (first Pro feature)
+
+Customize the look of your ZPan instance:
+
+- Upload a custom logo and favicon
+- Set a custom wordmark text (replaces "ZPan" in titles and copy)
+- Hide the "Powered by ZPan" footer badge
+
+Manage in **Settings → Branding**.
+
+---
+
+## Retroactive Pro Gates
+
+Three features from earlier versions have moved to **Pro** in v2.6. These affect only operators running ZPan as a platform for unknown third parties.
+
+### Open Registration (`open_registration`)
+
+Registration modes `closed` and `invite-only` remain Community. **Open registration** (anyone can sign up without an invite) requires Pro.
+
+> **If you were using open registration mode, set up a Pro license before upgrading or your instance will fall back to invite-only.**
+
+### Team Count > 3 (`teams_unlimited`)
+
+Community instances may have up to **3 teams** (including the default personal workspace). Creating a 4th team requires Pro. Existing teams are never deleted; the gate only prevents creating new ones beyond the limit.
+
+### Per-Team Storage Quota (`team_quotas`)
+
+Setting a per-team storage quota is now Pro-only. Without Pro, the quota field is hidden in the admin UI and no per-team enforcement runs.
+
+---
+
+## Feature Gate Overview
+
+| Feature | Community | Pro |
+|---------|-----------|-----|
+| All v2.0–v2.5 features | ✅ | ✅ |
+| Open registration mode | — | ✅ |
+| Teams beyond 3 | — | ✅ |
+| Per-team storage quotas | — | ✅ |
+| White-label branding | — | ✅ |
+
+---
+
+## Upgrading
+
+1. Pull the latest image: `docker pull ghcr.io/saltbo/zpan:latest`
+2. Restart your container — migrations run automatically.
+3. If you use **open registration mode**, bind a Pro license before restarting (see above).
+4. Optional: go to **Settings → Billing** to connect your cloud account and activate Pro.
+
+For Cloudflare Workers deployments, trigger the `Deploy to Cloudflare Workers` workflow from your fork's Actions tab.
+
+---
+
+## Known Issues
+
+None at release time.
+
+---
+
+## Changelog Summary
+
+- `feat(licensing)`: Ed25519 entitlement verification layer (`server/licensing/`)
+- `feat(licensing)`: Cloud account binding via device-code flow
+- `feat(licensing)`: 6h background entitlement refresh with manual "Refresh now" button
+- `feat(ui)`: Settings → Billing page (bound / unbound states)
+- `feat(ui)`: `<ProBadge />` and `<UpgradeHint />` frontend primitives
+- `feat(branding)`: White-label settings page (logo, favicon, wordmark, footer toggle)
+- `feat(gates)`: Open registration gated behind `open_registration` Pro feature
+- `feat(gates)`: Team creation blocked at 3 for Community (`teams_unlimited` required for 4th)
+- `feat(gates)`: Per-team storage quota gated behind `team_quotas` Pro feature

--- a/server/licensing/entitlement.test.ts
+++ b/server/licensing/entitlement.test.ts
@@ -1,11 +1,12 @@
 // @vitest-environment node
 import Database from 'better-sqlite3'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
-import { sign } from 'paseto-ts/v4'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { generateKeys, sign } from 'paseto-ts/v4'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import * as authSchema from '../db/auth-schema'
 import * as appSchema from '../db/schema'
 import { invalidateEntitlementCache, loadEntitlement } from './entitlement'
+import { PUBLIC_KEYS } from './public-keys'
 
 const SCHEMA_SQL = `
   CREATE TABLE IF NOT EXISTS license_binding (
@@ -27,7 +28,22 @@ const SCHEMA_SQL = `
   );
 `
 
-const DEV_SECRET = 'k4.secret.K_XrtRH8ozh6oM38rkCz7oHxU_GbKIuExCg2jmBl9_VgfF29_7kGkFAnXvII1bHUBy2Yjw04DRdC4kmbuSND2Q'
+// Generate a fresh throwaway keypair for this test suite.
+// We inject the public key into PUBLIC_KEYS so verifyCertificate sees it,
+// and restore the original array after all tests complete.
+const { secretKey: TEST_SECRET, publicKey: TEST_PUBLIC } = generateKeys('public')
+const originalKeys: string[] = []
+
+beforeAll(() => {
+  originalKeys.push(...PUBLIC_KEYS)
+  PUBLIC_KEYS.length = 0
+  PUBLIC_KEYS.push(TEST_PUBLIC)
+})
+
+afterAll(() => {
+  PUBLIC_KEYS.length = 0
+  for (const k of originalKeys) PUBLIC_KEYS.push(k)
+})
 
 function makeDb() {
   const sqlite = new Database(':memory:')
@@ -70,7 +86,7 @@ describe('loadEntitlement', () => {
   it('returns entitlement summary for a valid PASETO cert', async () => {
     const db = makeDb()
 
-    const cert = sign(DEV_SECRET, {
+    const cert = sign(TEST_SECRET, {
       account_id: 'acct-1',
       instance_id: 'inst-1',
       plan: 'pro',
@@ -99,7 +115,7 @@ describe('loadEntitlement', () => {
   it('returns null for an invalid/expired PASETO cert', async () => {
     const db = makeDb()
 
-    const cert = sign(DEV_SECRET, {
+    const cert = sign(TEST_SECRET, {
       account_id: 'acct-1',
       instance_id: 'inst-1',
       plan: 'pro',
@@ -132,7 +148,7 @@ describe('invalidateEntitlementCache', () => {
     await loadEntitlement(db)
 
     // Now insert a binding
-    const cert = sign(DEV_SECRET, {
+    const cert = sign(TEST_SECRET, {
       account_id: 'acct-1',
       instance_id: 'inst-1',
       plan: 'pro',

--- a/server/licensing/public-keys.ts
+++ b/server/licensing/public-keys.ts
@@ -1,10 +1,13 @@
-// Replace DEV key with production key from cloud.zpan.space before Z11
+// Cloud public keys for verifying PASETO v4 entitlement certificates.
 //
-// Rotation: add new key to the array; old certs signed by any key in the list
-// will continue to verify. Remove a key only after all certs signed by it have
-// expired or been re-issued.
+// ZPan verifies every entitlement certificate against this list.
+// Multiple keys are supported to allow zero-downtime key rotation:
+//   1. Add the new key here and deploy ZPan.
+//   2. Update the cloud Worker secret (LICENSE_SIGNING_KEY) to the new key and deploy.
+//   3. After 24 h (old certs expired), remove the old key here and deploy ZPan again.
 //
-// DEV placeholder keypair (throwaway — real production key lands via a
-// cross-repo PR from cloud's C5 task):
-//   secret: k4.secret.K_XrtRH8ozh6oM38rkCz7oHxU_GbKIuExCg2jmBl9_VgfF29_7kGkFAnXvII1bHUBy2Yjw04DRdC4kmbuSND2Q
-export const PUBLIC_KEYS: string[] = ['k4.public.YHxdvf-5BpBQJ17yCNWx1ActmI8NOA0XQuJJm7kjQ9k']
+// Keys are PASERK k4.public.* strings (Ed25519, 32 raw bytes, base64url-encoded).
+export const PUBLIC_KEYS: string[] = [
+  // cloud.zpan.space production key — provisioned 2026-04-23
+  'k4.public.sphdaogcyIh2_6_yZnO4_xQsi2m52HH9j2CPHcKlGGw',
+]

--- a/server/licensing/verify.test.ts
+++ b/server/licensing/verify.test.ts
@@ -1,10 +1,25 @@
 // @vitest-environment node
 import { generateKeys, sign } from 'paseto-ts/v4'
-import { describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { PUBLIC_KEYS } from './public-keys'
 import { verifyCertificate } from './verify'
 
-// DEV keypair matching PUBLIC_KEYS[0] — used to sign test certs
-const DEV_SECRET = 'k4.secret.K_XrtRH8ozh6oM38rkCz7oHxU_GbKIuExCg2jmBl9_VgfF29_7kGkFAnXvII1bHUBy2Yjw04DRdC4kmbuSND2Q'
+// Generate a fresh throwaway keypair for this test suite.
+// We inject the public key into PUBLIC_KEYS so verifyCertificate sees it,
+// and restore the original array after all tests complete.
+const { secretKey: TEST_SECRET, publicKey: TEST_PUBLIC } = generateKeys('public')
+const originalKeys: string[] = []
+
+beforeAll(() => {
+  originalKeys.push(...PUBLIC_KEYS)
+  PUBLIC_KEYS.length = 0
+  PUBLIC_KEYS.push(TEST_PUBLIC)
+})
+
+afterAll(() => {
+  PUBLIC_KEYS.length = 0
+  for (const k of originalKeys) PUBLIC_KEYS.push(k)
+})
 
 function futureIso(offsetMs: number): string {
   return new Date(Date.now() + offsetMs).toISOString()
@@ -14,7 +29,7 @@ function pastIso(offsetMs: number): string {
   return new Date(Date.now() - offsetMs).toISOString()
 }
 
-function signCert(overrides: Record<string, unknown> = {}, key = DEV_SECRET): string {
+function signCert(overrides: Record<string, unknown> = {}, key = TEST_SECRET): string {
   return sign(key, {
     account_id: 'acct-1',
     instance_id: 'inst-abc',
@@ -55,12 +70,8 @@ describe('verifyCertificate', () => {
     expect(verifyCertificate(cert, 'inst-DIFFERENT')).toBeNull()
   })
 
-  it('verifies a cert signed by a second key when two keys are in PUBLIC_KEYS', async () => {
+  it('verifies a cert signed by a second key when two keys are in PUBLIC_KEYS', () => {
     const { secretKey: altSecret, publicKey: altPublic } = generateKeys('public')
-
-    // Temporarily inject the alt key into PUBLIC_KEYS for this test
-    const { PUBLIC_KEYS } = await import('./public-keys')
-    const original = [...PUBLIC_KEYS]
     PUBLIC_KEYS.push(altPublic)
 
     try {
@@ -69,8 +80,7 @@ describe('verifyCertificate', () => {
       expect(result).not.toBeNull()
       expect(result?.plan).toBe('pro')
     } finally {
-      PUBLIC_KEYS.length = 0
-      for (const k of original) PUBLIC_KEYS.push(k)
+      PUBLIC_KEYS.splice(PUBLIC_KEYS.indexOf(altPublic), 1)
     }
   })
 


### PR DESCRIPTION
## Summary

- **Production public key**: Replaces the DEV placeholder in `server/licensing/public-keys.ts` with the `cloud.zpan.space` Ed25519 production key (`k4.public.sphdaogcyIh2_6_yZnO4_xQsi2m52HH9j2CPHcKlGGw`) from the cloud C5 cross-repo PR #340
- **Docker cron docs**: Adds the \"Pro licensing: external cron for 6h refresh\" section to `docs/deploy/docker.md` — the only non-CF deploy target doc that was missing it (all others already had it from prior tasks)
- **Release notes**: Creates `docs/v2.6-release-notes.md` with what's new, retroactive gate notices, upgrade instructions, and changelog summary

## Retroactive gate notice (bold in release notes)

> **If you were using open registration mode, set up a Pro license before upgrading or your instance will fall back to invite-only.**

## Deployment note

Cloud health check (`curl https://cloud.zpan.space/health`) was not reachable at time of writing — cloud C11 must be complete before the smoke-test checklist items can be verified. The code changes in this PR are independent of cloud availability.

## Test plan

- [x] `vitest run server/licensing/public-keys.test.ts` — 2/2 tests pass
- [x] Pre-commit hooks (typecheck + biome) pass
- [ ] End-to-end smoke test on zpan.space (blocked on cloud C11 deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)