### PR TITLE
[codex] Show OAuth provider icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "react-pdf": "^10.4.1",
         "remark-gfm": "^4.0.1",
         "shiki": "^4.0.2",
+        "simple-icons": "^16.18.0",
         "sonner": "^1.7.0",
         "tailwind-merge": "^2.6.0",
         "yet-another-react-lightbox": "^3.30.1",
@@ -16343,6 +16344,25 @@
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-icons": {
+      "version": "16.18.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-16.18.0.tgz",
+      "integrity": "sha512-5KbjcP456Gm1lrk+rhDuX4zFri+3lRX39IjzXAvoMAO8Ne76WlVlM+Z3kA6jdZ7+QHadgXsf++R7g2jaYVbYig==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/simple-icons"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/simple-icons"
+        }
+      ],
+      "license": "CC0-1.0",
+      "engines": {
+        "node": ">=0.12.18"
       }
     },
     "node_modules/slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "react-pdf": "^10.4.1",
     "remark-gfm": "^4.0.1",
     "shiki": "^4.0.2",
+    "simple-icons": "^16.18.0",
     "sonner": "^1.7.0",
     "tailwind-merge": "^2.6.0",
     "yet-another-react-lightbox": "^3.30.1",

--- a/src/components/admin/oauth-providers-section.tsx
+++ b/src/components/admin/oauth-providers-section.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
+import { OAuthProviderIcon } from '@/components/oauth-provider-icon'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
@@ -45,6 +46,21 @@ const emptyForm: FormState = {
 
 function providerName(providerId: string): string {
   return OAuthProviderMeta[providerId]?.name ?? providerId
+}
+
+function providerIcon(providerId: string): string {
+  return OAuthProviderMeta[providerId]?.icon ?? providerId
+}
+
+function ProviderLabel({ providerId }: { providerId: string }) {
+  const name = providerName(providerId)
+
+  return (
+    <span className="inline-flex min-w-0 items-center gap-2">
+      <OAuthProviderIcon icon={providerIcon(providerId)} name={name} />
+      <span className="truncate">{name}</span>
+    </span>
+  )
 }
 
 export function OAuthProvidersSection() {
@@ -155,7 +171,9 @@ export function OAuthProvidersSection() {
             <TableBody>
               {providers.map((p) => (
                 <TableRow key={p.providerId} className="border-b last:border-0 hover:bg-muted/30">
-                  <TableCell className="px-4 py-3 font-medium">{providerName(p.providerId)}</TableCell>
+                  <TableCell className="px-4 py-3 font-medium">
+                    <ProviderLabel providerId={p.providerId} />
+                  </TableCell>
                   <TableCell className="px-4 py-3 text-sm">{p.type}</TableCell>
                   <TableCell className="px-4 py-3 text-sm font-mono">{p.clientId}</TableCell>
                   <TableCell className="px-4 py-3">
@@ -217,7 +235,7 @@ export function OAuthProvidersSection() {
                   <SelectContent>
                     {BUILTIN_PROVIDER_IDS.map((id) => (
                       <SelectItem key={id} value={id}>
-                        {OAuthProviderMeta[id]?.name ?? id}
+                        <ProviderLabel providerId={id} />
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/src/components/oauth-buttons.test.ts
+++ b/src/components/oauth-buttons.test.ts
@@ -1,4 +1,6 @@
+import { BUILTIN_PROVIDER_IDS, OAuthProviderMeta } from '@shared/oauth-providers'
 import { describe, expect, it } from 'vitest'
+import { hasOAuthProviderIcon } from '@/components/oauth-provider-icon'
 import type { AuthProvider } from '@/lib/api'
 
 // OAuthButtons is a React rendering component. The project has no jsdom or
@@ -53,7 +55,7 @@ describe('OAuthButtons — render visibility logic', () => {
 // ---------------------------------------------------------------------------
 
 function makeProvider(providerId: string, name: string): AuthProvider {
-  return { providerId, type: 'oauth', name, icon: '' }
+  return { providerId, type: 'oauth', name, icon: providerId }
 }
 
 describe('OAuthButtons — provider data contract', () => {
@@ -67,6 +69,12 @@ describe('OAuthButtons — provider data contract', () => {
     const p = makeProvider('google', 'Google')
 
     expect(p.name).toBe('Google')
+  })
+
+  it('provider has an icon field used in the button', () => {
+    const p = makeProvider('github', 'GitHub')
+
+    expect(p.icon).toBe('github')
   })
 
   it('each provider produces a distinct button key via providerId', () => {
@@ -112,5 +120,15 @@ const AUTH_PROVIDERS_QUERY_KEY = ['auth-providers']
 describe('OAuthButtons — query key', () => {
   it('query key is ["auth-providers"]', () => {
     expect(AUTH_PROVIDERS_QUERY_KEY).toEqual(['auth-providers'])
+  })
+})
+
+describe('OAuthButtons — provider icons', () => {
+  it('has an icon mapping for every built-in provider', () => {
+    for (const providerId of BUILTIN_PROVIDER_IDS) {
+      const meta = OAuthProviderMeta[providerId]!
+
+      expect(hasOAuthProviderIcon(meta.icon), meta.icon).toBe(true)
+    }
   })
 })

--- a/src/components/oauth-buttons.tsx
+++ b/src/components/oauth-buttons.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { OAuthProviderIcon } from '@/components/oauth-provider-icon'
 import { Button } from '@/components/ui/button'
 import { listAuthProviders } from '@/lib/api'
 import { authClient } from '@/lib/auth-client'
@@ -40,6 +41,7 @@ export function OAuthButtons() {
           className="w-full"
           onClick={() => handleOAuth(provider.providerId)}
         >
+          <OAuthProviderIcon icon={provider.icon} name={provider.name} />
           {t('auth.continueWith', { provider: provider.name })}
         </Button>
       ))}

--- a/src/components/oauth-provider-icon.test.tsx
+++ b/src/components/oauth-provider-icon.test.tsx
@@ -1,0 +1,39 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { OAuthProviderIcon } from '@/components/oauth-provider-icon'
+
+afterEach(cleanup)
+
+describe('OAuthProviderIcon', () => {
+  it('renders a fixed-size simple icon for supported brand icons', () => {
+    const { container } = render(<OAuthProviderIcon icon="github" name="GitHub" />)
+
+    const icon = container.querySelector('svg')
+    expect(icon).not.toBeNull()
+    expect(icon?.getAttribute('viewBox')).toBe('0 0 24 24')
+    expect(icon?.getAttribute('aria-hidden')).toBe('true')
+    expect(icon?.getAttribute('fill')).toBe('currentColor')
+    expect(icon?.classList.contains('size-4')).toBe(true)
+    expect(icon?.classList.contains('shrink-0')).toBe(true)
+    expect(icon?.querySelector('path')).not.toBeNull()
+  })
+
+  it('renders a fixed-size lucide icon for supported non-brand icons', () => {
+    const { container } = render(<OAuthProviderIcon icon="microsoft" name="Microsoft" />)
+
+    const icon = container.querySelector('svg')
+    expect(icon).not.toBeNull()
+    expect(icon?.getAttribute('aria-hidden')).toBe('true')
+    expect(icon?.classList.contains('size-4')).toBe(true)
+    expect(icon?.classList.contains('shrink-0')).toBe(true)
+  })
+
+  it('renders a fixed-size fallback initial for custom providers', () => {
+    const { getByText } = render(<OAuthProviderIcon icon="company-sso" name="Company SSO" />)
+
+    const icon = getByText('C')
+    expect(icon.getAttribute('aria-hidden')).toBe('true')
+    expect(icon.classList.contains('size-4')).toBe(true)
+    expect(icon.classList.contains('shrink-0')).toBe(true)
+  })
+})

--- a/src/components/oauth-provider-icon.tsx
+++ b/src/components/oauth-provider-icon.tsx
@@ -1,0 +1,99 @@
+import type { LucideIcon } from 'lucide-react'
+import { BadgeDollarSign, Cloud, KeyRound, Linkedin, PanelsTopLeft, Slack } from 'lucide-react'
+import {
+  type SimpleIcon,
+  siApple,
+  siAtlassian,
+  siDiscord,
+  siDropbox,
+  siFacebook,
+  siFigma,
+  siGithub,
+  siGitlab,
+  siGoogle,
+  siHuggingface,
+  siKakao,
+  siKick,
+  siLine,
+  siLinear,
+  siNaver,
+  siNotion,
+  siPaypal,
+  siPolars,
+  siRailway,
+  siReddit,
+  siRoblox,
+  siSpotify,
+  siTiktok,
+  siTwitch,
+  siVercel,
+  siVk,
+  siWechat,
+  siX,
+  siZoom,
+} from 'simple-icons'
+
+const simpleIcons = {
+  apple: siApple,
+  atlassian: siAtlassian,
+  discord: siDiscord,
+  dropbox: siDropbox,
+  facebook: siFacebook,
+  figma: siFigma,
+  github: siGithub,
+  gitlab: siGitlab,
+  google: siGoogle,
+  huggingface: siHuggingface,
+  kakao: siKakao,
+  kick: siKick,
+  line: siLine,
+  linear: siLinear,
+  naver: siNaver,
+  notion: siNotion,
+  paypal: siPaypal,
+  polar: siPolars,
+  railway: siRailway,
+  reddit: siReddit,
+  roblox: siRoblox,
+  spotify: siSpotify,
+  tiktok: siTiktok,
+  twitch: siTwitch,
+  twitter: siX,
+  vercel: siVercel,
+  vk: siVk,
+  wechat: siWechat,
+  zoom: siZoom,
+} satisfies Record<string, SimpleIcon>
+
+const lucideIcons = {
+  cognito: KeyRound,
+  linkedin: Linkedin,
+  microsoft: PanelsTopLeft,
+  paybin: BadgeDollarSign,
+  salesforce: Cloud,
+  slack: Slack,
+} satisfies Record<string, LucideIcon>
+
+export function hasOAuthProviderIcon(icon: string): boolean {
+  return icon in simpleIcons || icon in lucideIcons
+}
+
+export function OAuthProviderIcon({ icon, name }: { icon: string; name: string }) {
+  const simpleIcon = simpleIcons[icon as keyof typeof simpleIcons]
+  if (simpleIcon) {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true" className="size-4 shrink-0" fill="currentColor">
+        <path d={simpleIcon.path} />
+      </svg>
+    )
+  }
+
+  const Icon = lucideIcons[icon as keyof typeof lucideIcons]
+  if (Icon) return <Icon aria-hidden="true" className="size-4 shrink-0" />
+
+  return (
+    <span aria-hidden="true" className="inline-flex size-4 shrink-0 items-center justify-center text-xs font-semibold">
+      {name.trim().charAt(0).toUpperCase()}
+    </span>
+  )
+}


### PR DESCRIPTION
## Summary

Show OAuth provider icons consistently across the auth surfaces.

- Add a shared `OAuthProviderIcon` component backed by `simple-icons` plus existing Lucide icons for providers not covered by Simple Icons.
- Render provider icons on social login buttons.
- Render provider icons in the admin OAuth providers table and built-in provider dropdown.
- Add tests for built-in provider icon coverage and icon rendering branches.

## Root Cause

The public auth providers API already returned an `icon` field, but the frontend only rendered provider names. The admin OAuth management UI also rendered provider labels as plain text.

## Validation

- `npm test -- --run`
- `npm run typecheck`
- `npm run build`
- Pre-commit hook: `npm run typecheck` and `biome check --write --no-errors-on-unmatched`