### PR TITLE
feat: add quota store backend

### DIFF
--- a/migrations/0018_quota-store.sql
+++ b/migrations/0018_quota-store.sql
@@ -1,0 +1,60 @@
+CREATE TABLE `quota_delivery_events` (
+	`id` text PRIMARY KEY NOT NULL,
+	`event_id` text NOT NULL,
+	`cloud_order_id` text NOT NULL,
+	`payload_hash` text NOT NULL,
+	`raw_payload` text NOT NULL,
+	`status` text NOT NULL,
+	`error` text,
+	`created_at` integer NOT NULL,
+	`processed_at` integer
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `quota_delivery_events_event_uniq` ON `quota_delivery_events` (`event_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `quota_delivery_events_order_uniq` ON `quota_delivery_events` (`cloud_order_id`);--> statement-breakpoint
+CREATE TABLE `quota_grants` (
+	`id` text PRIMARY KEY NOT NULL,
+	`org_id` text NOT NULL,
+	`source` text NOT NULL,
+	`external_event_id` text,
+	`cloud_order_id` text,
+	`code` text,
+	`bytes` integer NOT NULL,
+	`package_snapshot` text,
+	`granted_by` text,
+	`terminal_user_id` text,
+	`terminal_user_email` text,
+	`active` integer DEFAULT true NOT NULL,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `quota_grants_org_created_idx` ON `quota_grants` (`org_id`,`created_at`);--> statement-breakpoint
+CREATE UNIQUE INDEX `quota_grants_external_event_uniq` ON `quota_grants` (`external_event_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `quota_grants_cloud_order_uniq` ON `quota_grants` (`cloud_order_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `quota_grants_code_uniq` ON `quota_grants` (`code`);--> statement-breakpoint
+CREATE TABLE `quota_store_packages` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`description` text DEFAULT '' NOT NULL,
+	`bytes` integer NOT NULL,
+	`amount` integer NOT NULL,
+	`currency` text NOT NULL,
+	`active` integer DEFAULT true NOT NULL,
+	`sort_order` integer DEFAULT 0 NOT NULL,
+	`cloud_package_id` text,
+	`sync_status` text DEFAULT 'pending' NOT NULL,
+	`sync_error` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `quota_store_packages_active_sort_idx` ON `quota_store_packages` (`active`,`sort_order`);--> statement-breakpoint
+CREATE TABLE `quota_store_settings` (
+	`id` text PRIMARY KEY NOT NULL,
+	`enabled` integer DEFAULT false NOT NULL,
+	`cloud_base_url` text NOT NULL,
+	`public_instance_url` text NOT NULL,
+	`webhook_signing_secret` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);

--- a/migrations/meta/0018_snapshot.json
+++ b/migrations/meta/0018_snapshot.json
@@ -1,0 +1,2690 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f7f1598c-9d78-4d11-9fa2-d0b67e262951",
+  "prevId": "98cf8886-a548-4438-a4b9-a57bfabf2529",
+  "tables": {
+    "activity_events": {
+      "name": "activity_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "announcements": {
+      "name": "announcements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "announcements_status_priority_idx": {
+          "name": "announcements_status_priority_idx",
+          "columns": [
+            "status",
+            "priority"
+          ],
+          "isUnique": false
+        },
+        "announcements_published_idx": {
+          "name": "announcements_published_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "image_hosting_configs": {
+      "name": "image_hosting_configs",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_domain": {
+          "name": "custom_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cf_hostname_id": {
+          "name": "cf_hostname_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "domain_verified_at": {
+          "name": "domain_verified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referer_allowlist": {
+          "name": "referer_allowlist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "image_hosting_configs_custom_domain_unique": {
+          "name": "image_hosting_configs_custom_domain_unique",
+          "columns": [
+            "custom_domain"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "image_hosting_configs_org_id_organization_id_fk": {
+          "name": "image_hosting_configs_org_id_organization_id_fk",
+          "tableFrom": "image_hosting_configs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "image_hostings": {
+      "name": "image_hostings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "image_hostings_token_unique": {
+          "name": "image_hostings_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "image_hostings_org_path_uniq": {
+          "name": "image_hostings_org_path_uniq",
+          "columns": [
+            "org_id",
+            "path"
+          ],
+          "isUnique": true
+        },
+        "image_hostings_org_created_idx": {
+          "name": "image_hostings_org_created_idx",
+          "columns": [
+            "org_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "image_hostings_token_idx": {
+          "name": "image_hostings_token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "image_hostings_org_id_organization_id_fk": {
+          "name": "image_hostings_org_id_organization_id_fk",
+          "tableFrom": "image_hostings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "image_hostings_storage_id_storages_id_fk": {
+          "name": "image_hostings_storage_id_storages_id_fk",
+          "tableFrom": "image_hostings",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invite_codes": {
+      "name": "invite_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invite_codes_code_unique": {
+          "name": "invite_codes_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "license_bindings": {
+      "name": "license_bindings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_binding_id": {
+          "name": "cloud_binding_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_account_id": {
+          "name": "cloud_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_account_email": {
+          "name": "cloud_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cached_certificate": {
+          "name": "cached_certificate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cached_certificate_expires_at": {
+          "name": "cached_certificate_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bound_at": {
+          "name": "bound_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disconnected_at": {
+          "name": "disconnected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refresh_at": {
+          "name": "last_refresh_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refresh_error": {
+          "name": "last_refresh_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "license_bindings_active_uniq": {
+          "name": "license_bindings_active_uniq",
+          "columns": [
+            "status"
+          ],
+          "isUnique": true,
+          "where": "status = 'active'"
+        },
+        "license_bindings_cloud_binding_idx": {
+          "name": "license_bindings_cloud_binding_idx",
+          "columns": [
+            "cloud_binding_id"
+          ],
+          "isUnique": false
+        },
+        "license_bindings_instance_idx": {
+          "name": "license_bindings_instance_idx",
+          "columns": [
+            "instance_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "matters": {
+      "name": "matters",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dirtype": {
+          "name": "dirtype",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "parent": {
+          "name": "parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "trashed_at": {
+          "name": "trashed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "matters_alias_unique": {
+          "name": "matters_alias_unique",
+          "columns": [
+            "alias"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "notifications_user_read_idx": {
+          "name": "notifications_user_read_idx",
+          "columns": [
+            "user_id",
+            "read_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "org_quotas": {
+      "name": "org_quotas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quota": {
+          "name": "quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_delivery_events": {
+      "name": "quota_delivery_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_order_id": {
+          "name": "cloud_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "quota_delivery_events_event_uniq": {
+          "name": "quota_delivery_events_event_uniq",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": true
+        },
+        "quota_delivery_events_order_uniq": {
+          "name": "quota_delivery_events_order_uniq",
+          "columns": [
+            "cloud_order_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_grants": {
+      "name": "quota_grants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloud_order_id": {
+          "name": "cloud_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "package_snapshot": {
+          "name": "package_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_user_id": {
+          "name": "terminal_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_user_email": {
+          "name": "terminal_user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "quota_grants_org_created_idx": {
+          "name": "quota_grants_org_created_idx",
+          "columns": [
+            "org_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "quota_grants_external_event_uniq": {
+          "name": "quota_grants_external_event_uniq",
+          "columns": [
+            "external_event_id"
+          ],
+          "isUnique": true
+        },
+        "quota_grants_cloud_order_uniq": {
+          "name": "quota_grants_cloud_order_uniq",
+          "columns": [
+            "cloud_order_id"
+          ],
+          "isUnique": true
+        },
+        "quota_grants_code_uniq": {
+          "name": "quota_grants_code_uniq",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_store_packages": {
+      "name": "quota_store_packages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cloud_package_id": {
+          "name": "cloud_package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "quota_store_packages_active_sort_idx": {
+          "name": "quota_store_packages_active_sort_idx",
+          "columns": [
+            "active",
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_store_settings": {
+      "name": "quota_store_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cloud_base_url": {
+          "name": "cloud_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_instance_url": {
+          "name": "public_instance_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "webhook_signing_secret": {
+          "name": "webhook_signing_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_recipients": {
+      "name": "share_recipients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "share_id": {
+          "name": "share_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "share_recipients_share_id_idx": {
+          "name": "share_recipients_share_id_idx",
+          "columns": [
+            "share_id"
+          ],
+          "isUnique": false
+        },
+        "share_recipients_user_id_idx": {
+          "name": "share_recipients_user_id_idx",
+          "columns": [
+            "recipient_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shares": {
+      "name": "shares",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matter_id": {
+          "name": "matter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_limit": {
+          "name": "download_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "downloads": {
+          "name": "downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "shares_token_unique": {
+          "name": "shares_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "shares_creator_status_created_idx": {
+          "name": "shares_creator_status_created_idx",
+          "columns": [
+            "creator_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_invitations": {
+      "name": "site_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "site_invitations_token_unique": {
+          "name": "site_invitations_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "site_invitations_email_idx": {
+          "name": "site_invitations_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "site_invitations_created_idx": {
+          "name": "site_invitations_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "site_invitations_expires_idx": {
+          "name": "site_invitations_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "storages": {
+      "name": "storages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'auto'"
+        },
+        "access_key": {
+          "name": "access_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_key": {
+          "name": "secret_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "custom_host": {
+          "name": "custom_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_options": {
+      "name": "system_options",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "public": {
+          "name": "public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_invite_links": {
+      "name": "team_invite_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_invite_links_token_unique": {
+          "name": "team_invite_links_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_config_id_idx": {
+          "name": "apikey_config_id_idx",
+          "columns": [
+            "config_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_reference_id_idx": {
+          "name": "apikey_reference_id_idx",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1777771763793,
       "tag": "0017_add-announcements",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1777965260476,
+      "tag": "0018_quota-store",
+      "breakpoints": true
     }
   ]
 }

--- a/server/app.ts
+++ b/server/app.ts
@@ -21,6 +21,7 @@ import { me } from './routes/me'
 import { notifications } from './routes/notifications'
 import objects from './routes/objects'
 import profile from './routes/profile'
+import { adminQuotaStore, quotaStore, quotaStoreWebhooks } from './routes/quota-store'
 import { adminQuotas, userQuotas } from './routes/quotas'
 import redirect from './routes/redirect'
 import { authedShares, publicShares } from './routes/shares'
@@ -65,6 +66,7 @@ export function createApp(platform: Platform, auth: Auth) {
   app.route('/api/licensing', licensing)
   app.route('/api/branding', publicBranding)
   app.route('/api/site-invitations', publicSiteInvitations)
+  app.route('/api/quota-store/webhooks', quotaStoreWebhooks)
 
   app.use('/api/*', authMiddleware)
 
@@ -85,6 +87,8 @@ export function createApp(platform: Platform, auth: Auth) {
   app.route('/api/admin/site-invitations', adminSiteInvitations)
   app.route('/api/admin/quotas', adminQuotas)
   app.route('/api/quotas', userQuotas)
+  app.route('/api/quota-store', quotaStore)
+  app.route('/api/admin/quota-store', adminQuotaStore)
   app.route('/api/system', system)
   app.route('/api/admin/auth-providers', adminAuthProviders)
   app.route('/api/notifications', notifications)
@@ -120,6 +124,9 @@ export type PublicSiteInvitationsRoute = typeof publicSiteInvitations
 export type AuthProvidersRoute = typeof publicAuthProviders
 export type AdminAuthProvidersRoute = typeof adminAuthProviders
 export type ProfileRoute = typeof profile
+export type QuotaStoreRoute = typeof quotaStore
+export type QuotaStoreWebhooksRoute = typeof quotaStoreWebhooks
+export type AdminQuotaStoreRoute = typeof adminQuotaStore
 export type TeamsRoute = typeof teams
 export type PublicTeamsRoute = typeof publicTeams
 export type NotificationsRoute = typeof notifications

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -44,6 +44,80 @@ export const orgQuotas = sqliteTable('org_quotas', {
   used: integer('used').notNull().default(0),
 })
 
+export const quotaStoreSettings = sqliteTable('quota_store_settings', {
+  id: text('id').primaryKey(),
+  enabled: integer('enabled', { mode: 'boolean' }).notNull().default(false),
+  cloudBaseUrl: text('cloud_base_url').notNull(),
+  publicInstanceUrl: text('public_instance_url').notNull(),
+  webhookSigningSecret: text('webhook_signing_secret').notNull(),
+  createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+  updatedAt: integer('updated_at', { mode: 'timestamp_ms' }).notNull(),
+})
+
+export const quotaStorePackages = sqliteTable(
+  'quota_store_packages',
+  {
+    id: text('id').primaryKey(),
+    name: text('name').notNull(),
+    description: text('description').notNull().default(''),
+    bytes: integer('bytes').notNull(),
+    amount: integer('amount').notNull(),
+    currency: text('currency').notNull(),
+    active: integer('active', { mode: 'boolean' }).notNull().default(true),
+    sortOrder: integer('sort_order').notNull().default(0),
+    cloudPackageId: text('cloud_package_id'),
+    syncStatus: text('sync_status').notNull().default('pending'),
+    syncError: text('sync_error'),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+    updatedAt: integer('updated_at', { mode: 'timestamp_ms' }).notNull(),
+  },
+  (t) => [index('quota_store_packages_active_sort_idx').on(t.active, t.sortOrder)],
+)
+
+export const quotaGrants = sqliteTable(
+  'quota_grants',
+  {
+    id: text('id').primaryKey(),
+    orgId: text('org_id').notNull(),
+    source: text('source').notNull(),
+    externalEventId: text('external_event_id'),
+    cloudOrderId: text('cloud_order_id'),
+    code: text('code'),
+    bytes: integer('bytes').notNull(),
+    packageSnapshot: text('package_snapshot'),
+    grantedBy: text('granted_by'),
+    terminalUserId: text('terminal_user_id'),
+    terminalUserEmail: text('terminal_user_email'),
+    active: integer('active', { mode: 'boolean' }).notNull().default(true),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+  },
+  (t) => [
+    index('quota_grants_org_created_idx').on(t.orgId, t.createdAt),
+    uniqueIndex('quota_grants_external_event_uniq').on(t.externalEventId),
+    uniqueIndex('quota_grants_cloud_order_uniq').on(t.cloudOrderId),
+    uniqueIndex('quota_grants_code_uniq').on(t.code),
+  ],
+)
+
+export const quotaDeliveryEvents = sqliteTable(
+  'quota_delivery_events',
+  {
+    id: text('id').primaryKey(),
+    eventId: text('event_id').notNull(),
+    cloudOrderId: text('cloud_order_id').notNull(),
+    payloadHash: text('payload_hash').notNull(),
+    rawPayload: text('raw_payload').notNull(),
+    status: text('status').notNull(),
+    error: text('error'),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+    processedAt: integer('processed_at', { mode: 'timestamp_ms' }),
+  },
+  (t) => [
+    uniqueIndex('quota_delivery_events_event_uniq').on(t.eventId),
+    uniqueIndex('quota_delivery_events_order_uniq').on(t.cloudOrderId),
+  ],
+)
+
 export const inviteCodes = sqliteTable('invite_codes', {
   id: text('id').primaryKey(),
   code: text('code').notNull().unique(),
@@ -147,6 +221,7 @@ export const announcements = sqliteTable(
     status: text('status').notNull().default('draft'),
     priority: integer('priority').notNull().default(0),
     publishedAt: integer('published_at', { mode: 'timestamp' }),
+    expiresAt: integer('expires_at', { mode: 'timestamp' }),
     createdBy: text('created_by').notNull(),
     createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
     updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),

--- a/server/routes/quota-store.integration.test.ts
+++ b/server/routes/quota-store.integration.test.ts
@@ -79,6 +79,42 @@ describe('Quota Store API', () => {
     })
   })
 
+  it('keeps the existing webhook secret when settings update omits it', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+    await seedSettings(app, headers)
+    const orgId = await getFirstOrgId(db)
+
+    const updated = await app.request('/api/admin/quota-store/settings', {
+      method: 'PUT',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        enabled: true,
+        cloudBaseUrl: 'https://cloud.example',
+        publicInstanceUrl: 'https://zpan.example/updated',
+      }),
+    })
+    const delivery = await postWebhook(
+      app,
+      JSON.stringify({
+        eventId: 'evt-preserved-secret',
+        cloudOrderId: 'order-preserved-secret',
+        orgId,
+        source: 'redeem_code',
+        code: 'PRESERVED',
+        bytes: 1024,
+      }),
+    )
+
+    expect(updated.status).toBe(200)
+    await expect(updated.json()).resolves.toMatchObject({
+      publicInstanceUrl: 'https://zpan.example/updated',
+      webhookSigningSecretSet: true,
+    })
+    expect(delivery.status).toBe(200)
+  })
+
   it('creates, lists, and syncs quota store packages', async () => {
     const { app, db } = await createTestApp()
     await seedProLicense(db)
@@ -121,6 +157,29 @@ describe('Quota Store API', () => {
     const headers = await adminHeaders(app)
     await seedSettings(app, headers)
     vi.mocked(fetch).mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) } as Response)
+
+    const res = await app.request('/api/admin/quota-store/packages', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Small', description: '', bytes: 4096, amount: 500, currency: 'usd' }),
+    })
+
+    expect(res.status).toBe(202)
+    await expect(res.json()).resolves.toMatchObject({ syncStatus: 'failed', syncError: 'invalid_cloud_response' })
+  })
+
+  it('rejects non-json successful package sync responses', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+    await seedSettings(app, headers)
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error('not_json')
+      },
+    } as unknown as Response)
 
     const res = await app.request('/api/admin/quota-store/packages', {
       method: 'POST',
@@ -216,6 +275,21 @@ describe('Quota Store API', () => {
     expect(res.status).toBe(403)
   })
 
+  it('rejects redemption target orgs the user cannot access', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await authedHeaders(app, 'buyer@example.com')
+    await seedSettings(app, headers)
+
+    const res = await app.request('/api/quota-store/redemptions', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: 'CODE-NOPE', targetOrgId: 'other-org' }),
+    })
+
+    expect(res.status).toBe(403)
+  })
+
   it('lists purchasable packages, targets, checkout, redemptions, and grants', async () => {
     const { app, db } = await createTestApp()
     await seedProLicense(db)
@@ -268,6 +342,52 @@ describe('Quota Store API', () => {
 
     expect(res.status).toBe(502)
     await expect(res.json()).resolves.toEqual({ error: 'invalid_cloud_response' })
+  })
+
+  it('surfaces Cloud checkout error responses', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await authedHeaders(app, 'buyer@example.com')
+    await seedSettings(app, headers)
+    const orgId = await getFirstOrgId(db)
+    const packageId = await seedPackage(db)
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: 'cloud_down' }),
+    } as Response)
+
+    const res = await app.request('/api/quota-store/checkout', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ packageId, targetOrgId: orgId }),
+    })
+
+    expect(res.status).toBe(502)
+    await expect(res.json()).resolves.toEqual({ error: 'cloud_down' })
+  })
+
+  it('uses status errors when Cloud checkout error bodies have no string error', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await authedHeaders(app, 'buyer@example.com')
+    await seedSettings(app, headers)
+    const orgId = await getFirstOrgId(db)
+    const packageId = await seedPackage(db)
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 504,
+      json: async () => ({ error: 504 }),
+    } as Response)
+
+    const res = await app.request('/api/quota-store/checkout', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ packageId, targetOrgId: orgId }),
+    })
+
+    expect(res.status).toBe(502)
+    await expect(res.json()).resolves.toEqual({ error: 'cloud_request_failed_504' })
   })
 
   it('valid Cloud delivery creates one grant and increases effective quota once', async () => {
@@ -385,6 +505,75 @@ describe('Quota Store API', () => {
     const retry = await postWebhook(app, payload)
     expect(retry.status).toBe(200)
     await expect(retry.json()).resolves.toMatchObject({ success: true, duplicate: false })
+  })
+
+  it('marks delivery events failed when grant insertion fails', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+    await seedSettings(app, headers)
+    const orgId = await getFirstOrgId(db)
+    const packageId = await seedPackage(db)
+    await db.run(sql`
+      CREATE TRIGGER quota_grants_abort_test
+      BEFORE INSERT ON quota_grants
+      BEGIN
+        SELECT RAISE(ABORT, 'grant_insert_failed');
+      END
+    `)
+
+    const res = await postWebhook(
+      app,
+      JSON.stringify({
+        eventId: 'evt-grant-insert-failed',
+        cloudOrderId: 'order-grant-insert-failed',
+        orgId,
+        packageId,
+        source: 'stripe',
+        bytes: 4096,
+      }),
+    )
+
+    expect(res.status).toBe(400)
+    const events = await db.all<{ status: string; error: string | null }>(
+      sql`
+        SELECT status, error
+        FROM quota_delivery_events
+        WHERE event_id = 'evt-grant-insert-failed'
+      `,
+    )
+    expect(events).toEqual([{ status: 'failed', error: expect.stringContaining('grant_insert_failed') }])
+  })
+
+  it('rejects deliveries when ledger insertion fails', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+    await seedSettings(app, headers)
+    const orgId = await getFirstOrgId(db)
+    const packageId = await seedPackage(db)
+    await db.run(sql`
+      CREATE TRIGGER quota_delivery_events_abort_test
+      BEFORE INSERT ON quota_delivery_events
+      BEGIN
+        SELECT RAISE(ABORT, 'ledger_insert_failed');
+      END
+    `)
+
+    const res = await postWebhook(
+      app,
+      JSON.stringify({
+        eventId: 'evt-ledger-insert-failed',
+        cloudOrderId: 'order-ledger-insert-failed',
+        orgId,
+        packageId,
+        source: 'stripe',
+        bytes: 4096,
+      }),
+    )
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: expect.stringContaining('ledger_insert_failed') })
   })
 
   it('rejects failed delivery retries when the payload hash changes', async () => {

--- a/server/routes/quota-store.integration.test.ts
+++ b/server/routes/quota-store.integration.test.ts
@@ -1,0 +1,438 @@
+import { sql } from 'drizzle-orm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { adminHeaders, authedHeaders, createTestApp, seedProLicense } from '../test/setup.js'
+
+const SECRET = 'quota-secret'
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ cloudPackageId: 'cloud-pkg-1', checkoutUrl: 'https://cloud.example/checkout' }),
+    } as Response),
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('Quota Store API', () => {
+  it('returns 402 when Pro quota_store is absent', async () => {
+    const { app } = await createTestApp()
+    const headers = await adminHeaders(app)
+
+    const res = await app.request('/api/admin/quota-store/packages', { headers })
+
+    expect(res.status).toBe(402)
+  })
+
+  it('returns 402 for Cloud delivery when Pro quota_store is absent', async () => {
+    const { app, db } = await createTestApp()
+    await seedSettingsRow(db)
+    const payload = JSON.stringify({
+      eventId: 'evt-no-pro',
+      cloudOrderId: 'order-no-pro',
+      orgId: 'org-no-pro',
+      source: 'stripe',
+      bytes: 1024,
+    })
+
+    const res = await postWebhook(app, payload)
+
+    expect(res.status).toBe(402)
+  })
+
+  it('validates positive package bytes and amount', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+
+    const res = await app.request('/api/admin/quota-store/packages', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Bad', description: '', bytes: 0, amount: 0, currency: 'usd' }),
+    })
+
+    expect(res.status).toBe(400)
+  })
+
+  it('syncs package deletion to Cloud before deleting locally', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+    await seedSettings(app, headers)
+    const packageId = await seedPackage(db)
+
+    const res = await app.request(`/api/admin/quota-store/packages/${packageId}`, {
+      method: 'DELETE',
+      headers,
+    })
+
+    expect(res.status).toBe(200)
+    const calls = vi.mocked(fetch).mock.calls
+    const [, init] = calls[calls.length - 1] as [URL, RequestInit]
+    expect(JSON.parse(init.body as string)).toMatchObject({ action: 'delete', package: { id: packageId } })
+  })
+
+  it('preserves existing Cloud package id when update sync fails', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+    await seedSettings(app, headers)
+    const packageId = await seedPackage(db)
+    await db.run(sql`UPDATE quota_store_packages SET cloud_package_id = 'cloud-existing' WHERE id = ${packageId}`)
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      json: async () => ({ error: 'cloud_down' }),
+    } as Response)
+
+    const res = await app.request(`/api/admin/quota-store/packages/${packageId}`, {
+      method: 'PUT',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Small', description: '', bytes: 4096, amount: 500, currency: 'usd' }),
+    })
+
+    expect(res.status).toBe(200)
+    const rows = await db.all<{ cloudPackageId: string | null }>(
+      sql`SELECT cloud_package_id AS cloudPackageId FROM quota_store_packages WHERE id = ${packageId}`,
+    )
+    expect(rows[0].cloudPackageId).toBe('cloud-existing')
+  })
+
+  it('keeps the local package when Cloud deletion sync fails', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+    await seedSettings(app, headers)
+    const packageId = await seedPackage(db)
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: 'cloud_unavailable' }),
+    } as Response)
+
+    const res = await app.request(`/api/admin/quota-store/packages/${packageId}`, {
+      method: 'DELETE',
+      headers,
+    })
+
+    expect(res.status).toBe(502)
+    await expect(res.json()).resolves.toEqual({ error: 'cloud_unavailable' })
+    const rows = await db.all<{ count: number }>(
+      sql`SELECT COUNT(*) AS count FROM quota_store_packages WHERE id = ${packageId}`,
+    )
+    expect(rows[0].count).toBe(1)
+  })
+
+  it('rejects checkout target orgs the user cannot access', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await authedHeaders(app, 'buyer@example.com')
+    await seedSettings(app, headers)
+
+    const res = await app.request('/api/quota-store/checkout', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ packageId: 'pkg-1', targetOrgId: 'other-org' }),
+    })
+
+    expect(res.status).toBe(403)
+  })
+
+  it('valid Cloud delivery creates one grant and increases effective quota once', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+    await seedSettings(app, headers)
+    const orgId = await getFirstOrgId(db)
+    const packageId = await seedPackage(db)
+
+    const payload = JSON.stringify({
+      eventId: 'evt-1',
+      cloudOrderId: 'order-1',
+      orgId,
+      packageId,
+      source: 'stripe',
+      bytes: 4096,
+    })
+
+    const first = await postWebhook(app, payload)
+    await db.run(sql`UPDATE quota_store_packages SET bytes = 8192 WHERE id = ${packageId}`)
+    const duplicate = await postWebhook(app, payload)
+
+    expect(first.status).toBe(200)
+    await expect(first.json()).resolves.toMatchObject({ success: true, duplicate: false })
+    expect(duplicate.status).toBe(200)
+    await expect(duplicate.json()).resolves.toMatchObject({ success: true, duplicate: true, grantId: null })
+    const grants = await db.all<{ count: number }>(
+      sql`SELECT COUNT(*) AS count FROM quota_grants WHERE org_id = ${orgId}`,
+    )
+    expect(grants[0].count).toBe(1)
+    const events = await db.all<{ status: string; error: string | null; processedAt: number | null }>(
+      sql`SELECT status, error, processed_at AS processedAt FROM quota_delivery_events WHERE event_id = 'evt-1'`,
+    )
+    expect(events).toEqual([{ status: 'processed', error: null, processedAt: expect.any(Number) }])
+
+    const quotaRes = await app.request('/api/quotas/me', { headers })
+    const quota = (await quotaRes.json()) as { baseQuota: number; grantedQuota: number; quota: number }
+    expect(quota.grantedQuota).toBe(4096)
+    expect(quota.quota).toBe(quota.baseQuota + 4096)
+  })
+
+  it('marks a new delivery event duplicate when the grant already exists', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+    await seedSettings(app, headers)
+    const orgId = await getFirstOrgId(db)
+
+    const first = await postWebhook(
+      app,
+      JSON.stringify({
+        eventId: 'evt-code-1',
+        cloudOrderId: 'order-code-1',
+        orgId,
+        source: 'redeem_code',
+        code: 'CODE-1',
+        bytes: 4096,
+      }),
+    )
+    const duplicate = await postWebhook(
+      app,
+      JSON.stringify({
+        eventId: 'evt-code-2',
+        cloudOrderId: 'order-code-2',
+        orgId,
+        source: 'redeem_code',
+        code: 'CODE-1',
+        bytes: 4096,
+      }),
+    )
+
+    expect(first.status).toBe(200)
+    expect(duplicate.status).toBe(200)
+    await expect(duplicate.json()).resolves.toMatchObject({ success: true, duplicate: true, grantId: null })
+    const events = await db.all<{ eventId: string; status: string; error: string | null }>(
+      sql`SELECT event_id AS eventId, status, error FROM quota_delivery_events ORDER BY event_id`,
+    )
+    expect(events).toEqual([
+      { eventId: 'evt-code-1', status: 'processed', error: null },
+      { eventId: 'evt-code-2', status: 'duplicate', error: null },
+    ])
+  })
+
+  it('marks delivery events failed when package validation fails', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+    await seedSettings(app, headers)
+    const orgId = await getFirstOrgId(db)
+    const packageId = await seedPackage(db)
+    const payload = JSON.stringify({
+      eventId: 'evt-invalid-package',
+      cloudOrderId: 'order-invalid-package',
+      orgId,
+      packageId,
+      source: 'stripe',
+      bytes: 8192,
+    })
+
+    const res = await postWebhook(app, payload)
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: 'invalid_package_delivery' })
+    const events = await db.all<{ status: string; error: string | null; processedAt: number | null }>(
+      sql`
+        SELECT status, error, processed_at AS processedAt
+        FROM quota_delivery_events
+        WHERE event_id = 'evt-invalid-package'
+      `,
+    )
+    expect(events).toEqual([{ status: 'failed', error: 'invalid_package_delivery', processedAt: expect.any(Number) }])
+
+    await db.run(sql`UPDATE quota_store_packages SET bytes = 8192 WHERE id = ${packageId}`)
+    const retry = await postWebhook(app, payload)
+    expect(retry.status).toBe(200)
+    await expect(retry.json()).resolves.toMatchObject({ success: true, duplicate: false })
+  })
+
+  it('rejects failed delivery retries when the payload hash changes', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+    await seedSettings(app, headers)
+    const orgId = await getFirstOrgId(db)
+    const packageId = await seedPackage(db)
+    const payload = JSON.stringify({
+      eventId: 'evt-hash-conflict',
+      cloudOrderId: 'order-hash-conflict',
+      orgId,
+      packageId,
+      source: 'stripe',
+      bytes: 8192,
+    })
+
+    const failed = await postWebhook(app, payload)
+    const retry = await postWebhook(
+      app,
+      JSON.stringify({
+        eventId: 'evt-hash-conflict',
+        cloudOrderId: 'order-hash-conflict',
+        orgId,
+        packageId,
+        source: 'stripe',
+        bytes: 4096,
+      }),
+    )
+
+    expect(failed.status).toBe(400)
+    expect(retry.status).toBe(400)
+    await expect(retry.json()).resolves.toEqual({ error: 'delivery_payload_conflict' })
+  })
+
+  it('rejects invalid Cloud signatures', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+    await seedSettings(app, headers)
+
+    const res = await app.request('/api/quota-store/webhooks/cloud', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-zpan-signature': 'bad' },
+      body: JSON.stringify({ eventId: 'evt-bad' }),
+    })
+
+    expect(res.status).toBe(401)
+  })
+
+  it('rejects same-length invalid Cloud signatures', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+    await seedSettings(app, headers)
+    const payload = JSON.stringify({ eventId: 'evt-bad-same-length' })
+    const signature = await signPayload(payload)
+    const badSignature = `${signature.slice(0, -1)}${signature.endsWith('0') ? '1' : '0'}`
+
+    const res = await app.request('/api/quota-store/webhooks/cloud', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-zpan-signature': badSignature },
+      body: payload,
+    })
+
+    expect(res.status).toBe(401)
+  })
+
+  it('rejects signed malformed Cloud payloads', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+    await seedSettings(app, headers)
+    const payload = '{bad-json'
+
+    const res = await postWebhook(app, payload)
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ error: 'invalid_payload' })
+  })
+
+  it('rejects purchase deliveries without a package id', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+    await seedSettings(app, headers)
+    const payload = JSON.stringify({
+      eventId: 'evt-no-package',
+      cloudOrderId: 'order-no-package',
+      orgId: await getFirstOrgId(db),
+      source: 'stripe',
+      bytes: 4096,
+    })
+
+    const res = await postWebhook(app, payload)
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ error: 'invalid_payload' })
+  })
+
+  it('rejects redemption deliveries without a code', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+    await seedSettings(app, headers)
+    const payload = JSON.stringify({
+      eventId: 'evt-no-code',
+      cloudOrderId: 'order-no-code',
+      orgId: await getFirstOrgId(db),
+      source: 'redeem_code',
+      bytes: 4096,
+    })
+
+    const res = await postWebhook(app, payload)
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ error: 'invalid_payload' })
+  })
+})
+
+async function seedSettings(app: Awaited<ReturnType<typeof createTestApp>>['app'], headers: Record<string, string>) {
+  await app.request('/api/admin/quota-store/settings', {
+    method: 'PUT',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      enabled: true,
+      cloudBaseUrl: 'https://cloud.example',
+      publicInstanceUrl: 'https://zpan.example',
+      webhookSigningSecret: SECRET,
+    }),
+  })
+}
+
+async function getFirstOrgId(db: Awaited<ReturnType<typeof createTestApp>>['db']): Promise<string> {
+  const rows = await db.all<{ id: string }>(sql`SELECT id FROM organization LIMIT 1`)
+  return rows[0].id
+}
+
+async function seedPackage(db: Awaited<ReturnType<typeof createTestApp>>['db']): Promise<string> {
+  const id = 'pkg-1'
+  const now = Date.now()
+  await db.run(sql`
+    INSERT INTO quota_store_packages
+      (id, name, description, bytes, amount, currency, active, sort_order, sync_status, created_at, updated_at)
+    VALUES (${id}, 'Small', '', 4096, 500, 'usd', 1, 0, 'synced', ${now}, ${now})
+  `)
+  return id
+}
+
+async function seedSettingsRow(db: Awaited<ReturnType<typeof createTestApp>>['db']) {
+  const now = Date.now()
+  await db.run(sql`
+    INSERT INTO quota_store_settings
+      (id, enabled, cloud_base_url, public_instance_url, webhook_signing_secret, created_at, updated_at)
+    VALUES ('default', 1, 'https://cloud.example', 'https://zpan.example', ${SECRET}, ${now}, ${now})
+  `)
+}
+
+async function postWebhook(app: Awaited<ReturnType<typeof createTestApp>>['app'], payload: string) {
+  return app.request('/api/quota-store/webhooks/cloud', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-zpan-signature': await signPayload(payload) },
+    body: payload,
+  })
+}
+
+async function signPayload(payload: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(SECRET),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+  const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(payload))
+  return [...new Uint8Array(signature)].map((b) => b.toString(16).padStart(2, '0')).join('')
+}

--- a/server/routes/quota-store.integration.test.ts
+++ b/server/routes/quota-store.integration.test.ts
@@ -59,6 +59,79 @@ describe('Quota Store API', () => {
     expect(res.status).toBe(400)
   })
 
+  it('reads and updates quota store settings', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+
+    const empty = await app.request('/api/admin/quota-store/settings', { headers })
+    await seedSettings(app, headers)
+    const filled = await app.request('/api/admin/quota-store/settings', { headers })
+
+    expect(empty.status).toBe(200)
+    await expect(empty.json()).resolves.toBeNull()
+    expect(filled.status).toBe(200)
+    await expect(filled.json()).resolves.toMatchObject({
+      enabled: true,
+      cloudBaseUrl: 'https://cloud.example',
+      publicInstanceUrl: 'https://zpan.example',
+      webhookSigningSecretSet: true,
+    })
+  })
+
+  it('creates, lists, and syncs quota store packages', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+    await seedSettings(app, headers)
+
+    const created = await app.request('/api/admin/quota-store/packages', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Small', description: 'starter', bytes: 4096, amount: 500, currency: 'USD' }),
+    })
+    const listed = await app.request('/api/admin/quota-store/packages', { headers })
+
+    expect(created.status).toBe(201)
+    await expect(created.json()).resolves.toMatchObject({ cloudPackageId: 'cloud-pkg-1', syncStatus: 'synced' })
+    expect(listed.status).toBe(200)
+    await expect(listed.json()).resolves.toMatchObject({ total: 1 })
+  })
+
+  it('surfaces package create sync failures without clearing the local package', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+    await seedSettings(app, headers)
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 502, json: async () => ({}) } as Response)
+
+    const res = await app.request('/api/admin/quota-store/packages', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Small', description: '', bytes: 4096, amount: 500, currency: 'usd' }),
+    })
+
+    expect(res.status).toBe(202)
+    await expect(res.json()).resolves.toMatchObject({ syncStatus: 'failed', syncError: 'cloud_request_failed_502' })
+  })
+
+  it('rejects malformed successful package sync responses', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+    await seedSettings(app, headers)
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) } as Response)
+
+    const res = await app.request('/api/admin/quota-store/packages', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Small', description: '', bytes: 4096, amount: 500, currency: 'usd' }),
+    })
+
+    expect(res.status).toBe(202)
+    await expect(res.json()).resolves.toMatchObject({ syncStatus: 'failed', syncError: 'invalid_cloud_response' })
+  })
+
   it('syncs package deletion to Cloud before deleting locally', async () => {
     const { app, db } = await createTestApp()
     await seedProLicense(db)
@@ -141,6 +214,60 @@ describe('Quota Store API', () => {
     })
 
     expect(res.status).toBe(403)
+  })
+
+  it('lists purchasable packages, targets, checkout, redemptions, and grants', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await authedHeaders(app, 'buyer@example.com')
+    await seedSettings(app, headers)
+    const orgId = await getFirstOrgId(db)
+    const packageId = await seedPackage(db)
+    await seedGrant(db, orgId)
+
+    const packages = await app.request('/api/quota-store/packages', { headers })
+    const targets = await app.request('/api/quota-store/targets', { headers })
+    const checkout = await app.request('/api/quota-store/checkout', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ packageId, targetOrgId: orgId }),
+    })
+    const redemption = await app.request('/api/quota-store/redemptions', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: 'CODE-OK', targetOrgId: orgId }),
+    })
+    const grants = await app.request('/api/quota-store/grants', { headers })
+
+    expect(packages.status).toBe(200)
+    await expect(packages.json()).resolves.toMatchObject({ total: 1 })
+    expect(targets.status).toBe(200)
+    await expect(targets.json()).resolves.toMatchObject({ total: 1, items: [{ orgId, type: 'personal' }] })
+    expect(checkout.status).toBe(200)
+    await expect(checkout.json()).resolves.toEqual({ checkoutUrl: 'https://cloud.example/checkout' })
+    expect(redemption.status).toBe(200)
+    await expect(redemption.json()).resolves.toMatchObject({ checkoutUrl: 'https://cloud.example/checkout' })
+    expect(grants.status).toBe(200)
+    await expect(grants.json()).resolves.toMatchObject({ total: 1, items: [{ orgId, bytes: 512 }] })
+  })
+
+  it('rejects malformed successful checkout responses', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await authedHeaders(app, 'buyer@example.com')
+    await seedSettings(app, headers)
+    const orgId = await getFirstOrgId(db)
+    const packageId = await seedPackage(db)
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) } as Response)
+
+    const res = await app.request('/api/quota-store/checkout', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ packageId, targetOrgId: orgId }),
+    })
+
+    expect(res.status).toBe(502)
+    await expect(res.json()).resolves.toEqual({ error: 'invalid_cloud_response' })
   })
 
   it('valid Cloud delivery creates one grant and increases effective quota once', async () => {
@@ -414,6 +541,14 @@ async function seedSettingsRow(db: Awaited<ReturnType<typeof createTestApp>>['db
     INSERT INTO quota_store_settings
       (id, enabled, cloud_base_url, public_instance_url, webhook_signing_secret, created_at, updated_at)
     VALUES ('default', 1, 'https://cloud.example', 'https://zpan.example', ${SECRET}, ${now}, ${now})
+  `)
+}
+
+async function seedGrant(db: Awaited<ReturnType<typeof createTestApp>>['db'], orgId: string) {
+  await db.run(sql`
+    INSERT INTO quota_grants
+      (id, org_id, source, external_event_id, cloud_order_id, bytes, active, created_at)
+    VALUES ('grant-user-list', ${orgId}, 'stripe', 'evt-user-list', 'order-user-list', 512, 1, ${Date.now()})
   `)
 }
 

--- a/server/routes/quota-store.ts
+++ b/server/routes/quota-store.ts
@@ -1,0 +1,244 @@
+import { zValidator } from '@hono/zod-validator'
+import {
+  checkoutInputSchema,
+  cloudDeliveryEventSchema,
+  quotaStorePackageInputSchema,
+  quotaStoreSettingsSchema,
+  redemptionInputSchema,
+} from '@shared/schemas'
+import type { QuotaStorePackage } from '@shared/types'
+import { Hono } from 'hono'
+import { requireAdmin, requireAuth } from '../middleware/auth'
+import type { Env } from '../middleware/platform'
+import { requireFeature } from '../middleware/require-feature'
+import {
+  canAccessTargetOrg,
+  createQuotaStorePackage,
+  deleteQuotaStorePackage,
+  getAccessibleTargets,
+  getQuotaStorePackage,
+  getQuotaStoreSettings,
+  getRequiredSettings,
+  listGrantsForUser,
+  listQuotaStorePackages,
+  markPackageSynced,
+  processCloudDelivery,
+  updateQuotaStorePackage,
+  upsertQuotaStoreSettings,
+} from '../services/quota-store'
+
+const adminQuotaStore = new Hono<Env>()
+  .use(requireAdmin)
+  .use(requireFeature('quota_store'))
+  .get('/settings', async (c) => {
+    const settings = await getQuotaStoreSettings(c.get('platform').db)
+    return c.json(settings ?? null)
+  })
+  .put('/settings', zValidator('json', quotaStoreSettingsSchema), async (c) => {
+    const settings = await upsertQuotaStoreSettings(c.get('platform').db, c.req.valid('json'))
+    return c.json(settings)
+  })
+  .get('/packages', async (c) => {
+    const items = await listQuotaStorePackages(c.get('platform').db)
+    return c.json({ items, total: items.length })
+  })
+  .post('/packages', zValidator('json', quotaStorePackageInputSchema), async (c) => {
+    const db = c.get('platform').db
+    const pkg = await createQuotaStorePackage(db, c.req.valid('json'))
+    const synced = await syncPackage(db, pkg, 'upsert')
+    return c.json(synced, synced.syncStatus === 'failed' ? 202 : 201)
+  })
+  .put('/packages/:id', zValidator('json', quotaStorePackageInputSchema), async (c) => {
+    const db = c.get('platform').db
+    const pkg = await updateQuotaStorePackage(db, c.req.param('id'), c.req.valid('json'))
+    if (!pkg) return c.json({ error: 'Package not found' }, 404)
+    const synced = await syncPackage(db, pkg, 'upsert')
+    return c.json(synced)
+  })
+  .delete('/packages/:id', async (c) => {
+    const db = c.get('platform').db
+    const id = c.req.param('id')
+    const pkg = await getQuotaStorePackage(db, id)
+    if (!pkg) return c.json({ error: 'Package not found' }, 404)
+
+    const syncError = await syncPackageDelete(db, pkg)
+    if (syncError) return c.json({ error: syncError }, 502)
+
+    const deleted = await deleteQuotaStorePackage(db, id)
+    if (!deleted) return c.json({ error: 'Package not found' }, 404)
+    return c.json({ id, deleted: true })
+  })
+
+const quotaStore = new Hono<Env>()
+  .use(requireAuth)
+  .use(requireFeature('quota_store'))
+  .get('/packages', async (c) => {
+    const items = await listQuotaStorePackages(c.get('platform').db, true)
+    return c.json({ items, total: items.length })
+  })
+  .get('/targets', async (c) => {
+    const items = await getAccessibleTargets(c.get('platform').db, c.get('userId')!)
+    return c.json({ items, total: items.length })
+  })
+  .post('/checkout', zValidator('json', checkoutInputSchema), async (c) => {
+    const body = c.req.valid('json')
+    const db = c.get('platform').db
+    if (!(await canAccessTargetOrg(db, c.get('userId')!, body.targetOrgId))) {
+      return c.json({ error: 'Forbidden' }, 403)
+    }
+
+    const settings = await getRequiredSettings(db)
+    const result = await postSignedCloud(
+      settings.cloudBaseUrl,
+      '/api/quota-store/checkout',
+      settings.webhookSigningSecret,
+      {
+        ...body,
+        callbackUrl: `${settings.publicInstanceUrl}/api/quota-store/webhooks/cloud`,
+        userId: c.get('userId'),
+      },
+    )
+    return c.json({ checkoutUrl: result.checkoutUrl })
+  })
+  .post('/redemptions', zValidator('json', redemptionInputSchema), async (c) => {
+    const body = c.req.valid('json')
+    const db = c.get('platform').db
+    if (!(await canAccessTargetOrg(db, c.get('userId')!, body.targetOrgId))) {
+      return c.json({ error: 'Forbidden' }, 403)
+    }
+
+    const settings = await getRequiredSettings(db)
+    const result = await postSignedCloud(
+      settings.cloudBaseUrl,
+      '/api/quota-store/redemptions',
+      settings.webhookSigningSecret,
+      {
+        ...body,
+        callbackUrl: `${settings.publicInstanceUrl}/api/quota-store/webhooks/cloud`,
+        userId: c.get('userId'),
+      },
+    )
+    return c.json(result)
+  })
+  .get('/grants', async (c) => {
+    const items = await listGrantsForUser(c.get('platform').db, c.get('userId')!)
+    return c.json({ items, total: items.length })
+  })
+
+const quotaStoreWebhooks = new Hono<Env>().use(requireFeature('quota_store')).post('/cloud', async (c) => {
+  const db = c.get('platform').db
+  const settings = await getRequiredSettings(db)
+  const rawPayload = await c.req.text()
+  const signature = c.req.header('x-zpan-signature') ?? ''
+  if (!(await verifySignature(rawPayload, settings.webhookSigningSecret, signature))) {
+    return c.json({ error: 'invalid_signature' }, 401)
+  }
+
+  const body = parseJson(rawPayload)
+  if (!body) return c.json({ error: 'invalid_payload' }, 400)
+
+  const parsed = cloudDeliveryEventSchema.safeParse(body)
+  if (!parsed.success) return c.json({ error: 'invalid_payload' }, 400)
+
+  try {
+    const result = await processCloudDelivery(db, parsed.data, rawPayload, await sha256Hex(rawPayload))
+    return c.json({ success: true, duplicate: result.duplicate, grantId: result.grantId })
+  } catch (error) {
+    return c.json({ error: (error as Error).message }, 400)
+  }
+})
+
+export { adminQuotaStore, quotaStore, quotaStoreWebhooks }
+
+async function syncPackage(db: Parameters<typeof markPackageSynced>[0], pkg: QuotaStorePackage, action: 'upsert') {
+  try {
+    const settings = await getRequiredSettings(db)
+    const result = await postSignedCloud(
+      settings.cloudBaseUrl,
+      '/api/quota-store/packages',
+      settings.webhookSigningSecret,
+      {
+        action,
+        package: pkg,
+      },
+    )
+    return markPackageSynced(db, pkg.id, { cloudPackageId: result.cloudPackageId })
+  } catch (error) {
+    return markPackageSynced(db, pkg.id, { error: (error as Error).message })
+  }
+}
+
+async function syncPackageDelete(db: Parameters<typeof markPackageSynced>[0], pkg: QuotaStorePackage) {
+  try {
+    const settings = await getRequiredSettings(db)
+    await postSignedCloud(settings.cloudBaseUrl, '/api/quota-store/packages', settings.webhookSigningSecret, {
+      action: 'delete',
+      package: pkg,
+    })
+    return null
+  } catch (error) {
+    return (error as Error).message
+  }
+}
+
+async function postSignedCloud(baseUrl: string, path: string, secret: string, payload: object) {
+  const body = JSON.stringify(payload)
+  const res = await fetch(new URL(path, baseUrl), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-zpan-signature': await signPayload(body, secret) },
+    body,
+  })
+  const data = (await res.json().catch(() => ({}))) as Record<string, string>
+  if (!res.ok) throw new Error(data.error ?? `cloud_request_failed_${res.status}`)
+  return data
+}
+
+async function signPayload(payload: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey('raw', encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
+  const signature = await crypto.subtle.sign('HMAC', key, encode(payload))
+  return hex(signature)
+}
+
+async function verifySignature(payload: string, secret: string, signature: string): Promise<boolean> {
+  const expected = hexToBytes(await signPayload(payload, secret))
+  const received = hexToBytes(signature)
+  if (!expected || !received || received.length !== expected.length) return false
+  return timingSafeEqual(received, expected)
+}
+
+function parseJson(payload: string): unknown | null {
+  try {
+    return JSON.parse(payload) as unknown
+  } catch {
+    return null
+  }
+}
+
+async function sha256Hex(payload: string): Promise<string> {
+  return hex(await crypto.subtle.digest('SHA-256', encode(payload)))
+}
+
+function encode(value: string): ArrayBuffer {
+  return new TextEncoder().encode(value).buffer as ArrayBuffer
+}
+
+function hex(buffer: ArrayBuffer): string {
+  return [...new Uint8Array(buffer)].map((b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+function hexToBytes(value: string): Uint8Array | null {
+  if (!/^[0-9a-f]+$/i.test(value) || value.length % 2 !== 0) return null
+  const bytes = new Uint8Array(value.length / 2)
+  for (let i = 0; i < bytes.length; i += 1) {
+    bytes[i] = Number.parseInt(value.slice(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}
+
+function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  let diff = 0
+  for (let i = 0; i < a.length; i += 1) {
+    diff |= a[i] ^ b[i]
+  }
+  return diff === 0
+}

--- a/server/routes/quota-store.ts
+++ b/server/routes/quota-store.ts
@@ -8,6 +8,7 @@ import {
 } from '@shared/schemas'
 import type { QuotaStorePackage } from '@shared/types'
 import { Hono } from 'hono'
+import { z } from 'zod'
 import { requireAdmin, requireAuth } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
 import { requireFeature } from '../middleware/require-feature'
@@ -26,6 +27,10 @@ import {
   updateQuotaStorePackage,
   upsertQuotaStoreSettings,
 } from '../services/quota-store'
+
+const cloudCheckoutResponseSchema = z.object({ checkoutUrl: z.string().url() })
+const cloudPackageSyncResponseSchema = z.object({ cloudPackageId: z.string().min(1) })
+const cloudRedemptionResponseSchema = z.object({ checkoutUrl: z.string().url() }).passthrough()
 
 const adminQuotaStore = new Hono<Env>()
   .use(requireAdmin)
@@ -88,16 +93,17 @@ const quotaStore = new Hono<Env>()
     }
 
     const settings = await getRequiredSettings(db)
-    const result = await postSignedCloud(
-      settings.cloudBaseUrl,
+    const result = await postUserCloud(
+      settings,
       '/api/quota-store/checkout',
-      settings.webhookSigningSecret,
       {
         ...body,
         callbackUrl: `${settings.publicInstanceUrl}/api/quota-store/webhooks/cloud`,
         userId: c.get('userId'),
       },
+      cloudCheckoutResponseSchema,
     )
+    if ('error' in result) return c.json(result, 502)
     return c.json({ checkoutUrl: result.checkoutUrl })
   })
   .post('/redemptions', zValidator('json', redemptionInputSchema), async (c) => {
@@ -108,16 +114,17 @@ const quotaStore = new Hono<Env>()
     }
 
     const settings = await getRequiredSettings(db)
-    const result = await postSignedCloud(
-      settings.cloudBaseUrl,
+    const result = await postUserCloud(
+      settings,
       '/api/quota-store/redemptions',
-      settings.webhookSigningSecret,
       {
         ...body,
         callbackUrl: `${settings.publicInstanceUrl}/api/quota-store/webhooks/cloud`,
         userId: c.get('userId'),
       },
+      cloudRedemptionResponseSchema,
     )
+    if ('error' in result) return c.json(result, 502)
     return c.json(result)
   })
   .get('/grants', async (c) => {
@@ -161,6 +168,7 @@ async function syncPackage(db: Parameters<typeof markPackageSynced>[0], pkg: Quo
         action,
         package: pkg,
       },
+      cloudPackageSyncResponseSchema,
     )
     return markPackageSynced(db, pkg.id, { cloudPackageId: result.cloudPackageId })
   } catch (error) {
@@ -171,26 +179,70 @@ async function syncPackage(db: Parameters<typeof markPackageSynced>[0], pkg: Quo
 async function syncPackageDelete(db: Parameters<typeof markPackageSynced>[0], pkg: QuotaStorePackage) {
   try {
     const settings = await getRequiredSettings(db)
-    await postSignedCloud(settings.cloudBaseUrl, '/api/quota-store/packages', settings.webhookSigningSecret, {
-      action: 'delete',
-      package: pkg,
-    })
+    await postSignedCloud(
+      settings.cloudBaseUrl,
+      '/api/quota-store/packages',
+      settings.webhookSigningSecret,
+      {
+        action: 'delete',
+        package: pkg,
+      },
+      z.unknown(),
+    )
     return null
   } catch (error) {
     return (error as Error).message
   }
 }
 
-async function postSignedCloud(baseUrl: string, path: string, secret: string, payload: object) {
+async function postUserCloud<T>(
+  settings: Awaited<ReturnType<typeof getRequiredSettings>>,
+  path: string,
+  payload: object,
+  responseSchema: z.ZodType<T>,
+) {
+  try {
+    return await postSignedCloud(settings.cloudBaseUrl, path, settings.webhookSigningSecret, payload, responseSchema)
+  } catch (error) {
+    return { error: (error as Error).message }
+  }
+}
+
+async function postSignedCloud<T>(
+  baseUrl: string,
+  path: string,
+  secret: string,
+  payload: object,
+  responseSchema: z.ZodType<T>,
+): Promise<T> {
   const body = JSON.stringify(payload)
   const res = await fetch(new URL(path, baseUrl), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'x-zpan-signature': await signPayload(body, secret) },
     body,
   })
-  const data = (await res.json().catch(() => ({}))) as Record<string, string>
-  if (!res.ok) throw new Error(data.error ?? `cloud_request_failed_${res.status}`)
-  return data
+  const data = await readCloudJson(res)
+  if (!res.ok) throw new Error(readCloudError(data) ?? `cloud_request_failed_${res.status}`)
+  return parseCloudResponse(data, responseSchema)
+}
+
+async function readCloudJson(res: Response): Promise<unknown> {
+  try {
+    return await res.json()
+  } catch {
+    return {}
+  }
+}
+
+function readCloudError(data: unknown): string | null {
+  if (!data || typeof data !== 'object' || !('error' in data)) return null
+  return typeof data.error === 'string' ? data.error : null
+}
+
+function parseCloudResponse<T>(data: unknown, schema: z.ZodType<T>): T {
+  const parsed = schema.safeParse(data)
+  if (!parsed.success) throw new Error('invalid_cloud_response')
+  return parsed.data
 }
 
 async function signPayload(payload: string, secret: string): Promise<string> {

--- a/server/routes/quotas.integration.test.ts
+++ b/server/routes/quotas.integration.test.ts
@@ -237,4 +237,31 @@ describe('User Quotas API — /api/quotas', () => {
     expect(body.quota).toBe(10000)
     expect(body.used).toBe(0)
   })
+
+  it('admin quota updates base quota while paid grants remain effective', async () => {
+    const { app, db } = await createTestApp()
+    const adminH = await adminHeaders(app)
+    const orgs = await db.all<{ id: string }>(
+      sql`SELECT o.id FROM organization o WHERE o.metadata LIKE '%"type":"personal"%' LIMIT 1`,
+    )
+    const orgId = orgs[0].id
+
+    await db.run(sql`
+      INSERT INTO quota_grants
+        (id, org_id, source, external_event_id, cloud_order_id, bytes, active, created_at)
+      VALUES ('grant-1', ${orgId}, 'stripe', 'evt-quota', 'order-quota', 500, 1, ${Date.now()})
+    `)
+
+    await app.request(`/api/admin/quotas/${orgId}`, {
+      method: 'PUT',
+      headers: { ...adminH, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ quota: 1000 }),
+    })
+
+    const res = await app.request('/api/quotas/me', { headers: adminH })
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.baseQuota).toBe(1000)
+    expect(body.grantedQuota).toBe(500)
+    expect(body.quota).toBe(1500)
+  })
 })

--- a/server/routes/quotas.ts
+++ b/server/routes/quotas.ts
@@ -8,6 +8,7 @@ import { orgQuotas } from '../db/schema'
 import { requireAdmin, requireAuth } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
 import { recordActivity } from '../services/activity'
+import { getEffectiveQuota } from '../services/effective-quota'
 import { findPersonalOrg } from '../services/org'
 
 const updateQuotaSchema = z.object({
@@ -79,13 +80,8 @@ const userQuotas = new Hono<Env>().use(requireAuth).get('/me', async (c) => {
     return c.json({ error: 'No organization found' }, 404)
   }
 
-  const rows = await db
-    .select({ quota: orgQuotas.quota, used: orgQuotas.used })
-    .from(orgQuotas)
-    .where(eq(orgQuotas.orgId, orgId))
-
-  const quotaRow = rows[0] ?? { quota: 0, used: 0 }
-  return c.json({ orgId, quota: quotaRow.quota, used: quotaRow.used })
+  const quota = await getEffectiveQuota(db, orgId)
+  return c.json(quota)
 })
 
 export { adminQuotas, userQuotas }

--- a/server/services/announcement.ts
+++ b/server/services/announcement.ts
@@ -39,6 +39,7 @@ export async function createAnnouncement(
     status: input.status,
     priority: input.priority,
     publishedAt: publishedAtFor(input),
+    expiresAt: null,
     createdBy,
     createdAt: now,
     updatedAt: now,

--- a/server/services/effective-quota.ts
+++ b/server/services/effective-quota.ts
@@ -1,0 +1,76 @@
+import { eq, sql } from 'drizzle-orm'
+import { orgQuotas, quotaGrants, storages } from '../db/schema'
+import type { Database } from '../platform/interface'
+
+export interface EffectiveQuota {
+  orgId: string
+  baseQuota: number
+  grantedQuota: number
+  quota: number
+  used: number
+}
+
+export async function getEffectiveQuota(db: Database, orgId: string): Promise<EffectiveQuota> {
+  const quotaRows = await db
+    .select({ baseQuota: orgQuotas.quota, used: orgQuotas.used })
+    .from(orgQuotas)
+    .where(eq(orgQuotas.orgId, orgId))
+    .limit(1)
+
+  const grantRows = await db
+    .select({ total: sql<number>`COALESCE(SUM(${quotaGrants.bytes}), 0)` })
+    .from(quotaGrants)
+    .where(sql`${quotaGrants.orgId} = ${orgId} AND ${quotaGrants.active} = 1`)
+
+  const baseQuota = quotaRows[0]?.baseQuota ?? 0
+  const grantedQuota = Number(grantRows[0]?.total ?? 0)
+  return {
+    orgId,
+    baseQuota,
+    grantedQuota,
+    quota: baseQuota === 0 ? 0 : baseQuota + grantedQuota,
+    used: quotaRows[0]?.used ?? 0,
+  }
+}
+
+export async function hasQuotaForBytes(db: Database, orgId: string, bytes: number): Promise<boolean> {
+  if (bytes <= 0) return true
+  const quota = await getEffectiveQuota(db, orgId)
+  if (quota.baseQuota === 0) return true
+  return quota.used + bytes <= quota.quota
+}
+
+export async function incrementUsageIfEffectiveQuotaAllows(
+  db: Database,
+  orgId: string,
+  storageId: string,
+  bytes: number,
+  teamQuotaEnabled = true,
+): Promise<boolean> {
+  if (teamQuotaEnabled) {
+    const rows = await db.select({ id: orgQuotas.id }).from(orgQuotas).where(eq(orgQuotas.orgId, orgId)).limit(1)
+    if (rows.length > 0) {
+      const updated = await db
+        .update(orgQuotas)
+        .set({ used: sql`${orgQuotas.used} + ${bytes}` })
+        .where(
+          sql`${orgQuotas.orgId} = ${orgId}
+            AND (${orgQuotas.quota} = 0 OR ${orgQuotas.used} + ${bytes} <= ${orgQuotas.quota} + (
+              SELECT COALESCE(SUM(${quotaGrants.bytes}), 0)
+              FROM ${quotaGrants}
+              WHERE ${quotaGrants.orgId} = ${orgId} AND ${quotaGrants.active} = 1
+            ))`,
+        )
+        .returning({ id: orgQuotas.id })
+
+      if (updated.length === 0) return false
+    }
+  }
+
+  await db
+    .update(storages)
+    .set({ used: sql`${storages.used} + ${bytes}` })
+    .where(eq(storages.id, storageId))
+
+  return true
+}

--- a/server/services/image-hosting.ts
+++ b/server/services/image-hosting.ts
@@ -4,6 +4,7 @@ import type { AllowedImageMime } from '../../shared/schemas'
 import type { ImageHosting } from '../../shared/types'
 import { imageHostingConfigs, imageHostings, orgQuotas, storages } from '../db/schema'
 import type { Database } from '../platform/interface'
+import { incrementUsageIfEffectiveQuotaAllows } from './effective-quota'
 
 // ── Token-based redirect helpers (used by /r/:token route) ───────────────────
 
@@ -294,26 +295,7 @@ export async function incrementImageQuotaIfAllowed(
   storageId: string,
   bytes: number,
 ): Promise<boolean> {
-  const rows = await db
-    .select({ quota: orgQuotas.quota, used: orgQuotas.used })
-    .from(orgQuotas)
-    .where(eq(orgQuotas.orgId, orgId))
-
-  const [row] = rows
-  if (row) {
-    if (row.quota > 0 && row.used + bytes > row.quota) return false
-    await db
-      .update(orgQuotas)
-      .set({ used: sql`${orgQuotas.used} + ${bytes}` })
-      .where(eq(orgQuotas.orgId, orgId))
-  }
-
-  await db
-    .update(storages)
-    .set({ used: sql`${storages.used} + ${bytes}` })
-    .where(eq(storages.id, storageId))
-
-  return true
+  return incrementUsageIfEffectiveQuotaAllows(db, orgId, storageId, bytes)
 }
 
 export async function decrementImageQuota(

--- a/server/services/matter.integration.test.ts
+++ b/server/services/matter.integration.test.ts
@@ -3,6 +3,7 @@ import { nanoid } from 'nanoid'
 import { describe, expect, it } from 'vitest'
 import { orgQuotas } from '../db/schema.js'
 import { createTestApp } from '../test/setup.js'
+import { getEffectiveQuota, hasQuotaForBytes } from './effective-quota.js'
 import { confirmUpload, incrementUsageIfAllowed, listTrashedRoots, updateMatter } from './matter.js'
 
 type TestDb = Awaited<ReturnType<typeof createTestApp>>['db']
@@ -66,6 +67,20 @@ describe('incrementUsageIfAllowed', () => {
     expect(rows[0].used).toBe(1000099)
   })
 
+  it('treats base quota 0 as unlimited even when grants exist', async () => {
+    const { db } = await createTestApp()
+    const orgId = nanoid()
+    await insertOrgQuota(db, orgId, 0, 5000)
+    await db.run(sql`
+      INSERT INTO quota_grants
+        (id, org_id, source, external_event_id, cloud_order_id, bytes, active, created_at)
+      VALUES ('grant-unlimited', ${orgId}, 'stripe', 'evt-unlimited', 'order-unlimited', 100, 1, ${Date.now()})
+    `)
+
+    await expect(hasQuotaForBytes(db, orgId, 10_000_000)).resolves.toBe(true)
+    await expect(getEffectiveQuota(db, orgId)).resolves.toMatchObject({ baseQuota: 0, grantedQuota: 100, quota: 0 })
+  })
+
   it('returns true and increments when used + bytes is within quota', async () => {
     const { db } = await createTestApp()
     const orgId = nanoid()
@@ -103,6 +118,24 @@ describe('incrementUsageIfAllowed', () => {
     expect(storageRows[0].used).toBe(50) // unchanged
     const quotaRows = await db.all<{ used: number }>(sql`SELECT used FROM org_quotas WHERE org_id = ${orgId}`)
     expect(quotaRows[0].used).toBe(800) // unchanged
+  })
+
+  it('allows upload usage against base quota plus active grants', async () => {
+    const { db } = await createTestApp()
+    const orgId = nanoid()
+    const storageId = await insertStorage(db, { id: 'st-grant', used: 0 })
+    await insertOrgQuota(db, orgId, 1000, 800)
+    await db.run(sql`
+      INSERT INTO quota_grants
+        (id, org_id, source, external_event_id, cloud_order_id, bytes, active, created_at)
+      VALUES ('grant-upload', ${orgId}, 'stripe', 'evt-upload', 'order-upload', 500, 1, ${Date.now()})
+    `)
+
+    const result = await incrementUsageIfAllowed(db, orgId, storageId, 600)
+
+    expect(result).toBe(true)
+    const quotaRows = await db.all<{ used: number }>(sql`SELECT used FROM org_quotas WHERE org_id = ${orgId}`)
+    expect(quotaRows[0].used).toBe(1400)
   })
 
   it('returns false and does not increment when quota is fully consumed', async () => {

--- a/server/services/matter.ts
+++ b/server/services/matter.ts
@@ -5,6 +5,7 @@ import { DirType } from '../../shared/constants'
 import { matters, orgQuotas, storages } from '../db/schema'
 import type { Database } from '../platform/interface'
 import { recordActivity } from './activity'
+import { incrementUsageIfEffectiveQuotaAllows } from './effective-quota'
 import {
   applyConflictResolution,
   type ConflictStrategy,
@@ -315,32 +316,7 @@ export async function incrementUsageIfAllowed(
   bytes: number,
   teamQuotaEnabled = true,
 ): Promise<boolean> {
-  if (teamQuotaEnabled) {
-    // Check if a quota row exists and try atomic check-and-increment in one flow
-    const rows = await db
-      .select({ quota: orgQuotas.quota, used: orgQuotas.used })
-      .from(orgQuotas)
-      .where(eq(orgQuotas.orgId, orgId))
-
-    const [row] = rows
-    if (row) {
-      // quota=0 means unlimited; otherwise enforce the limit
-      if (row.quota > 0 && row.used + bytes > row.quota) return false
-
-      await db
-        .update(orgQuotas)
-        .set({ used: sql`${orgQuotas.used} + ${bytes}` })
-        .where(eq(orgQuotas.orgId, orgId))
-    }
-    // No quota row means no org-level limit — allow, but still track per-storage usage
-  }
-
-  await db
-    .update(storages)
-    .set({ used: sql`${storages.used} + ${bytes}` })
-    .where(eq(storages.id, storageId))
-
-  return true
+  return incrementUsageIfEffectiveQuotaAllows(db, orgId, storageId, bytes, teamQuotaEnabled)
 }
 
 export async function copyMatter(

--- a/server/services/quota-store.ts
+++ b/server/services/quota-store.ts
@@ -1,0 +1,340 @@
+import type { CloudDeliveryEvent, QuotaStorePackageInput, QuotaStoreSettingsInput } from '@shared/schemas'
+import type { QuotaGrant, QuotaStorePackage, QuotaStoreSettings, QuotaTarget } from '@shared/types'
+import { and, eq, inArray, sql } from 'drizzle-orm'
+import { nanoid } from 'nanoid'
+import { member, organization } from '../db/auth-schema'
+import { quotaDeliveryEvents, quotaGrants, quotaStorePackages, quotaStoreSettings } from '../db/schema'
+import type { Database } from '../platform/interface'
+
+const SETTINGS_ID = 'default'
+
+export async function getQuotaStoreSettings(db: Database): Promise<QuotaStoreSettings | null> {
+  const settings = await getRawSettings(db)
+  return settings ? settingsDto(settings) : null
+}
+
+export async function upsertQuotaStoreSettings(
+  db: Database,
+  input: QuotaStoreSettingsInput,
+): Promise<QuotaStoreSettings> {
+  const now = new Date()
+  const existing = await getQuotaStoreSettings(db)
+  const values = {
+    enabled: input.enabled,
+    cloudBaseUrl: input.cloudBaseUrl,
+    publicInstanceUrl: input.publicInstanceUrl,
+    webhookSigningSecret: input.webhookSigningSecret ?? '',
+    updatedAt: now,
+  }
+
+  if (existing) {
+    const secret = input.webhookSigningSecret ?? (await getRawSettings(db))!.webhookSigningSecret
+    await db
+      .update(quotaStoreSettings)
+      .set({ ...values, webhookSigningSecret: secret })
+      .where(eq(quotaStoreSettings.id, SETTINGS_ID))
+  } else {
+    await db.insert(quotaStoreSettings).values({ id: SETTINGS_ID, ...values, createdAt: now })
+  }
+
+  return (await getQuotaStoreSettings(db))!
+}
+
+export async function listQuotaStorePackages(db: Database, activeOnly = false): Promise<QuotaStorePackage[]> {
+  const query = db.select().from(quotaStorePackages)
+  const rows = activeOnly
+    ? await query
+        .where(eq(quotaStorePackages.active, true))
+        .orderBy(quotaStorePackages.sortOrder, quotaStorePackages.name)
+    : await query.orderBy(quotaStorePackages.sortOrder, quotaStorePackages.name)
+  return rows.map(packageDto)
+}
+
+export async function createQuotaStorePackage(db: Database, input: QuotaStorePackageInput): Promise<QuotaStorePackage> {
+  const now = new Date()
+  const row = {
+    id: nanoid(),
+    ...input,
+    cloudPackageId: null,
+    syncStatus: 'pending',
+    syncError: null,
+    createdAt: now,
+    updatedAt: now,
+  }
+  await db.insert(quotaStorePackages).values(row)
+  return packageDto(row)
+}
+
+export async function updateQuotaStorePackage(
+  db: Database,
+  id: string,
+  input: QuotaStorePackageInput,
+): Promise<QuotaStorePackage | null> {
+  const now = new Date()
+  const rows = await db
+    .update(quotaStorePackages)
+    .set({ ...input, syncStatus: 'pending', syncError: null, updatedAt: now })
+    .where(eq(quotaStorePackages.id, id))
+    .returning()
+  return rows[0] ? packageDto(rows[0]) : null
+}
+
+export async function deleteQuotaStorePackage(db: Database, id: string): Promise<boolean> {
+  const rows = await db
+    .delete(quotaStorePackages)
+    .where(eq(quotaStorePackages.id, id))
+    .returning({ id: quotaStorePackages.id })
+  return rows.length > 0
+}
+
+export async function getQuotaStorePackage(db: Database, id: string): Promise<QuotaStorePackage | null> {
+  const rows = await db.select().from(quotaStorePackages).where(eq(quotaStorePackages.id, id)).limit(1)
+  return rows[0] ? packageDto(rows[0]) : null
+}
+
+export async function markPackageSynced(
+  db: Database,
+  id: string,
+  result: { cloudPackageId?: string | null; error?: string | null },
+): Promise<QuotaStorePackage> {
+  const values: Partial<typeof quotaStorePackages.$inferInsert> = {
+    syncStatus: result.error ? 'failed' : 'synced',
+    syncError: result.error ?? null,
+    updatedAt: new Date(),
+  }
+  if (result.cloudPackageId !== undefined) values.cloudPackageId = result.cloudPackageId
+
+  const rows = await db.update(quotaStorePackages).set(values).where(eq(quotaStorePackages.id, id)).returning()
+  return packageDto(rows[0])
+}
+
+export async function getAccessibleTargets(db: Database, userId: string): Promise<QuotaTarget[]> {
+  const rows = await db
+    .select({ orgId: organization.id, name: organization.name, metadata: organization.metadata, role: member.role })
+    .from(member)
+    .innerJoin(organization, eq(organization.id, member.organizationId))
+    .where(eq(member.userId, userId))
+    .orderBy(organization.name)
+
+  return rows.map((r) => ({ orgId: r.orgId, name: r.name, type: parseOrgType(r.metadata), role: r.role }))
+}
+
+export async function canAccessTargetOrg(db: Database, userId: string, orgId: string): Promise<boolean> {
+  const rows = await db
+    .select({ id: member.id })
+    .from(member)
+    .where(and(eq(member.userId, userId), eq(member.organizationId, orgId)))
+    .limit(1)
+  return rows.length > 0
+}
+
+export async function listGrantsForUser(db: Database, userId: string): Promise<QuotaGrant[]> {
+  const targets = await getAccessibleTargets(db, userId)
+  if (targets.length === 0) return []
+  const rows = await db
+    .select()
+    .from(quotaGrants)
+    .where(
+      inArray(
+        quotaGrants.orgId,
+        targets.map((t) => t.orgId),
+      ),
+    )
+    .orderBy(sql`${quotaGrants.createdAt} DESC`)
+  return rows.map(grantDto)
+}
+
+export async function processCloudDelivery(
+  db: Database,
+  event: CloudDeliveryEvent,
+  rawPayload: string,
+  payloadHash: string,
+): Promise<{ duplicate: boolean; grantId: string | null }> {
+  const delivery = await beginDeliveryEvent(db, event, rawPayload, payloadHash)
+  if (delivery.duplicate) return { duplicate: true, grantId: null }
+
+  const packageSnapshot = await validateDeliveryPackage(db, delivery.id, event)
+  const now = new Date()
+  const grantId = nanoid()
+
+  try {
+    await db.insert(quotaGrants).values({
+      id: grantId,
+      orgId: event.orgId,
+      source: event.source,
+      externalEventId: event.eventId,
+      cloudOrderId: event.cloudOrderId,
+      code: event.code ?? null,
+      bytes: event.bytes,
+      packageSnapshot,
+      terminalUserId: event.terminalUserId ?? null,
+      terminalUserEmail: event.terminalUserEmail ?? null,
+      active: true,
+      createdAt: now,
+    })
+  } catch (error) {
+    if (isUniqueConflict(error)) {
+      await markDeliveryEvent(db, delivery.id, 'duplicate', null)
+      return { duplicate: true, grantId: null }
+    }
+    await markDeliveryEvent(db, delivery.id, 'failed', (error as Error).message)
+    throw error
+  }
+
+  await markDeliveryEvent(db, delivery.id, 'processed', null)
+  return { duplicate: false, grantId }
+}
+
+export async function getRequiredSettings(db: Database) {
+  const settings = await getRawSettings(db)
+  if (!settings?.enabled) throw new Error('quota_store_disabled')
+  if (!settings.webhookSigningSecret) throw new Error('quota_store_webhook_secret_missing')
+  return settings
+}
+
+async function getRawSettings(db: Database) {
+  const rows = await db.select().from(quotaStoreSettings).where(eq(quotaStoreSettings.id, SETTINGS_ID)).limit(1)
+  return rows[0] ?? null
+}
+
+async function validatePackageBytes(db: Database, event: CloudDeliveryEvent): Promise<string | null> {
+  if (event.source === 'stripe' && !event.packageId) throw new Error('package_required')
+  if (event.source === 'redeem_code' && !event.code) throw new Error('code_required')
+  if (!event.packageId) return null
+  const rows = await db.select().from(quotaStorePackages).where(eq(quotaStorePackages.id, event.packageId)).limit(1)
+  const pkg = rows[0]
+  if (!pkg || pkg.bytes !== event.bytes) throw new Error('invalid_package_delivery')
+  return JSON.stringify(packageDto(pkg))
+}
+
+async function validateDeliveryPackage(
+  db: Database,
+  eventId: string,
+  event: CloudDeliveryEvent,
+): Promise<string | null> {
+  try {
+    return await validatePackageBytes(db, event)
+  } catch (error) {
+    await markDeliveryEvent(db, eventId, 'failed', (error as Error).message)
+    throw error
+  }
+}
+
+async function beginDeliveryEvent(
+  db: Database,
+  event: CloudDeliveryEvent,
+  rawPayload: string,
+  payloadHash: string,
+): Promise<{ id: string; duplicate: boolean }> {
+  const id = nanoid()
+  try {
+    await db.insert(quotaDeliveryEvents).values({
+      id,
+      eventId: event.eventId,
+      cloudOrderId: event.cloudOrderId,
+      payloadHash,
+      rawPayload,
+      status: 'processing',
+      createdAt: new Date(),
+    })
+    return { id, duplicate: false }
+  } catch (error) {
+    if (isUniqueConflict(error)) return resumeDeliveryEvent(db, event, rawPayload, payloadHash)
+    throw error
+  }
+}
+
+async function resumeDeliveryEvent(
+  db: Database,
+  event: CloudDeliveryEvent,
+  rawPayload: string,
+  payloadHash: string,
+): Promise<{ id: string; duplicate: boolean }> {
+  const rows = await db
+    .select({
+      id: quotaDeliveryEvents.id,
+      payloadHash: quotaDeliveryEvents.payloadHash,
+      status: quotaDeliveryEvents.status,
+    })
+    .from(quotaDeliveryEvents)
+    .where(
+      sql`${quotaDeliveryEvents.eventId} = ${event.eventId} OR ${quotaDeliveryEvents.cloudOrderId} = ${event.cloudOrderId}`,
+    )
+    .limit(1)
+
+  const existing = rows[0]
+  if (!existing) throw new Error('delivery_event_conflict')
+  if (existing.payloadHash !== payloadHash) throw new Error('delivery_payload_conflict')
+  if (existing.status === 'processed' || existing.status === 'duplicate') return { id: existing.id, duplicate: true }
+
+  await db
+    .update(quotaDeliveryEvents)
+    .set({ rawPayload, status: 'processing', error: null, processedAt: null })
+    .where(eq(quotaDeliveryEvents.id, existing.id))
+
+  return { id: existing.id, duplicate: false }
+}
+
+async function markDeliveryEvent(db: Database, id: string, status: string, error: string | null): Promise<void> {
+  await db
+    .update(quotaDeliveryEvents)
+    .set({ status, error, processedAt: new Date() })
+    .where(eq(quotaDeliveryEvents.id, id))
+}
+
+function settingsDto(row: typeof quotaStoreSettings.$inferSelect): QuotaStoreSettings {
+  return {
+    id: row.id,
+    enabled: row.enabled,
+    cloudBaseUrl: row.cloudBaseUrl,
+    publicInstanceUrl: row.publicInstanceUrl,
+    webhookSigningSecretSet: row.webhookSigningSecret.length > 0,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  }
+}
+
+function packageDto(row: typeof quotaStorePackages.$inferSelect): QuotaStorePackage {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    bytes: row.bytes,
+    amount: row.amount,
+    currency: row.currency,
+    active: row.active,
+    sortOrder: row.sortOrder,
+    cloudPackageId: row.cloudPackageId,
+    syncStatus: row.syncStatus as QuotaStorePackage['syncStatus'],
+    syncError: row.syncError,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  }
+}
+
+function grantDto(row: typeof quotaGrants.$inferSelect): QuotaGrant {
+  return {
+    id: row.id,
+    orgId: row.orgId,
+    source: row.source as QuotaGrant['source'],
+    externalEventId: row.externalEventId,
+    cloudOrderId: row.cloudOrderId,
+    code: row.code,
+    bytes: row.bytes,
+    packageSnapshot: row.packageSnapshot,
+    grantedBy: row.grantedBy,
+    terminalUserId: row.terminalUserId,
+    terminalUserEmail: row.terminalUserEmail,
+    active: row.active,
+    createdAt: row.createdAt.toISOString(),
+  }
+}
+
+function parseOrgType(metadata: string | null): string {
+  if (!metadata) return 'unknown'
+  return (JSON.parse(metadata) as { type?: string }).type ?? 'unknown'
+}
+
+function isUniqueConflict(error: unknown): boolean {
+  return error instanceof Error && error.message.toLowerCase().includes('unique')
+}

--- a/server/services/save-to-drive.ts
+++ b/server/services/save-to-drive.ts
@@ -1,9 +1,10 @@
 import { and, eq, like, or } from 'drizzle-orm'
 import { DirType } from '../../shared/constants'
 import type { Storage as S3StorageType } from '../../shared/types'
-import { matters, orgQuotas } from '../db/schema'
+import { matters } from '../db/schema'
 import type { Database } from '../platform/interface'
 import { recordActivity } from './activity'
+import { hasQuotaForBytes } from './effective-quota'
 import type { Matter } from './matter'
 import { createMatter, incrementUsageIfAllowed } from './matter'
 import { buildObjectKey } from './path-template'
@@ -70,14 +71,7 @@ export async function computeSourceBytes(db: Database, matter: Matter): Promise<
 }
 
 export async function isQuotaSufficient(db: Database, orgId: string, bytes: number): Promise<boolean> {
-  if (bytes <= 0) return true
-  const rows = await db
-    .select({ quota: orgQuotas.quota, used: orgQuotas.used })
-    .from(orgQuotas)
-    .where(eq(orgQuotas.orgId, orgId))
-  const row = rows[0]
-  if (!row || row.quota === 0) return true
-  return row.used + bytes <= row.quota
+  return hasQuotaForBytes(db, orgId, bytes)
 }
 
 // ─── File copy ────────────────────────────────────────────────────────────────

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -134,6 +134,63 @@ const APP_SCHEMA_SQL = `
     quota INTEGER NOT NULL DEFAULT 0,
     used INTEGER NOT NULL DEFAULT 0
   );
+  CREATE TABLE IF NOT EXISTS quota_store_settings (
+    id TEXT PRIMARY KEY,
+    enabled INTEGER NOT NULL DEFAULT 0,
+    cloud_base_url TEXT NOT NULL,
+    public_instance_url TEXT NOT NULL,
+    webhook_signing_secret TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS quota_store_packages (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    bytes INTEGER NOT NULL,
+    amount INTEGER NOT NULL,
+    currency TEXT NOT NULL,
+    active INTEGER NOT NULL DEFAULT 1,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    cloud_package_id TEXT,
+    sync_status TEXT NOT NULL DEFAULT 'pending',
+    sync_error TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS quota_store_packages_active_sort_idx ON quota_store_packages(active, sort_order);
+  CREATE TABLE IF NOT EXISTS quota_grants (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL,
+    source TEXT NOT NULL,
+    external_event_id TEXT,
+    cloud_order_id TEXT,
+    code TEXT,
+    bytes INTEGER NOT NULL,
+    package_snapshot TEXT,
+    granted_by TEXT,
+    terminal_user_id TEXT,
+    terminal_user_email TEXT,
+    active INTEGER NOT NULL DEFAULT 1,
+    created_at INTEGER NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS quota_grants_org_created_idx ON quota_grants(org_id, created_at);
+  CREATE UNIQUE INDEX IF NOT EXISTS quota_grants_external_event_uniq ON quota_grants(external_event_id);
+  CREATE UNIQUE INDEX IF NOT EXISTS quota_grants_cloud_order_uniq ON quota_grants(cloud_order_id);
+  CREATE UNIQUE INDEX IF NOT EXISTS quota_grants_code_uniq ON quota_grants(code);
+  CREATE TABLE IF NOT EXISTS quota_delivery_events (
+    id TEXT PRIMARY KEY,
+    event_id TEXT NOT NULL,
+    cloud_order_id TEXT NOT NULL,
+    payload_hash TEXT NOT NULL,
+    raw_payload TEXT NOT NULL,
+    status TEXT NOT NULL,
+    error TEXT,
+    created_at INTEGER NOT NULL,
+    processed_at INTEGER
+  );
+  CREATE UNIQUE INDEX IF NOT EXISTS quota_delivery_events_event_uniq ON quota_delivery_events(event_id);
+  CREATE UNIQUE INDEX IF NOT EXISTS quota_delivery_events_order_uniq ON quota_delivery_events(cloud_order_id);
   CREATE TABLE IF NOT EXISTS system_options (
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL DEFAULT '',
@@ -260,6 +317,7 @@ const APP_SCHEMA_SQL = `
     status TEXT NOT NULL DEFAULT 'draft',
     priority INTEGER NOT NULL DEFAULT 0,
     published_at INTEGER,
+    expires_at INTEGER,
     created_by TEXT NOT NULL,
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL

--- a/shared/feature-registry.ts
+++ b/shared/feature-registry.ts
@@ -110,6 +110,13 @@ export const FEATURE_REGISTRY = [
     gateKey: 'storages_unlimited',
   },
   {
+    i18nKey: 'features.quotaStore',
+    category: 'pro',
+    community: false,
+    pro: true,
+    gateKey: 'quota_store',
+  },
+  {
     i18nKey: 'features.multiIdpSso',
     category: 'pro',
     community: false,

--- a/shared/schemas/index.ts
+++ b/shared/schemas/index.ts
@@ -16,6 +16,20 @@ export type { ListAdminAuditQuery } from './audit'
 export { listAdminAuditQuerySchema } from './audit'
 export type { ListNotificationsQuery } from './notification'
 export { listNotificationsQuerySchema } from './notification'
+export type {
+  CheckoutInput,
+  CloudDeliveryEvent,
+  QuotaStorePackageInput,
+  QuotaStoreSettingsInput,
+  RedemptionInput,
+} from './quota-store'
+export {
+  checkoutInputSchema,
+  cloudDeliveryEventSchema,
+  quotaStorePackageInputSchema,
+  quotaStoreSettingsSchema,
+  redemptionInputSchema,
+} from './quota-store'
 export type { CreateShareInput, CreateShareRequest, ShareKind } from './share'
 export {
   createShareRequestSchema,

--- a/shared/schemas/quota-store.ts
+++ b/shared/schemas/quota-store.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod'
+
+export const quotaStoreSettingsSchema = z.object({
+  enabled: z.boolean(),
+  cloudBaseUrl: z.string().url(),
+  publicInstanceUrl: z.string().url(),
+  webhookSigningSecret: z.string().min(1).optional(),
+})
+
+export const quotaStorePackageInputSchema = z.object({
+  name: z.string().min(1).max(120),
+  description: z.string().max(1000).default(''),
+  bytes: z.number().int().positive(),
+  amount: z.number().int().positive(),
+  currency: z
+    .string()
+    .min(3)
+    .max(12)
+    .transform((v) => v.toLowerCase()),
+  active: z.boolean().default(true),
+  sortOrder: z.number().int().default(0),
+})
+
+export const checkoutInputSchema = z.object({
+  packageId: z.string().min(1),
+  targetOrgId: z.string().min(1),
+})
+
+export const redemptionInputSchema = z.object({
+  code: z.string().min(1),
+  targetOrgId: z.string().min(1),
+})
+
+export const cloudDeliveryEventSchema = z
+  .object({
+    eventId: z.string().min(1),
+    cloudOrderId: z.string().min(1),
+    orgId: z.string().min(1),
+    packageId: z.string().min(1).optional(),
+    source: z.enum(['stripe', 'redeem_code', 'admin_adjustment']),
+    code: z.string().min(1).optional(),
+    bytes: z.number().int().positive(),
+    terminalUserId: z.string().optional(),
+    terminalUserEmail: z.string().email().optional(),
+  })
+  .superRefine((event, ctx) => {
+    if (event.source === 'stripe' && !event.packageId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['packageId'],
+        message: 'packageId is required for stripe deliveries',
+      })
+    }
+    if (event.source === 'redeem_code' && !event.code) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['code'],
+        message: 'code is required for redeem_code deliveries',
+      })
+    }
+  })
+
+export type QuotaStoreSettingsInput = z.infer<typeof quotaStoreSettingsSchema>
+export type QuotaStorePackageInput = z.infer<typeof quotaStorePackageInputSchema>
+export type CheckoutInput = z.infer<typeof checkoutInputSchema>
+export type RedemptionInput = z.infer<typeof redemptionInputSchema>
+export type CloudDeliveryEvent = z.infer<typeof cloudDeliveryEventSchema>

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -41,6 +41,59 @@ export interface OrgQuota {
   used: number
 }
 
+export type QuotaGrantSource = 'stripe' | 'redeem_code' | 'admin_adjustment'
+export type QuotaPackageSyncStatus = 'pending' | 'synced' | 'failed'
+export type QuotaDeliveryEventStatus = 'processed' | 'duplicate' | 'failed'
+
+export interface QuotaStoreSettings {
+  id: string
+  enabled: boolean
+  cloudBaseUrl: string
+  publicInstanceUrl: string
+  webhookSigningSecretSet: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface QuotaStorePackage {
+  id: string
+  name: string
+  description: string
+  bytes: number
+  amount: number
+  currency: string
+  active: boolean
+  sortOrder: number
+  cloudPackageId: string | null
+  syncStatus: QuotaPackageSyncStatus
+  syncError: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface QuotaGrant {
+  id: string
+  orgId: string
+  source: QuotaGrantSource
+  externalEventId: string | null
+  cloudOrderId: string | null
+  code: string | null
+  bytes: number
+  packageSnapshot: string | null
+  grantedBy: string | null
+  terminalUserId: string | null
+  terminalUserEmail: string | null
+  active: boolean
+  createdAt: string
+}
+
+export interface QuotaTarget {
+  orgId: string
+  name: string
+  type: string
+  role: string
+}
+
 export interface Organization {
   id: string
   name: string

--- a/src/components/UpgradeHint.tsx
+++ b/src/components/UpgradeHint.tsx
@@ -8,6 +8,7 @@ const FEATURE_LABELS: Record<ProFeature, string> = {
   open_registration: 'open registration',
   teams_unlimited: 'unlimited teams',
   storages_unlimited: 'unlimited storages',
+  quota_store: 'quota store',
   audit_log: 'audit logs',
 }
 

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -17,6 +17,8 @@ import {
   createIhostApiKey,
   createIhostImagePresign,
   createObject,
+  createQuotaCheckout,
+  createQuotaStorePackage,
   createShare,
   createSiteInvitation,
   createStorage,
@@ -25,6 +27,7 @@ import {
   deleteIhostConfig,
   deleteIhostImage,
   deleteObject,
+  deleteQuotaStorePackage,
   deleteShare,
   deleteStorage,
   deleteTeamLogo,
@@ -39,6 +42,7 @@ import {
   getLicensingStatus,
   getObject,
   getProfile,
+  getQuotaStoreSettings,
   getSession,
   getShare,
   getSiteInvitation,
@@ -55,6 +59,10 @@ import {
   listIhostImages,
   listNotifications,
   listObjects,
+  listPurchasableQuotaPackages,
+  listQuotaGrants,
+  listQuotaStorePackages,
+  listQuotaStoreTargets,
   listQuotas,
   listShareObjects,
   listShares,
@@ -65,6 +73,7 @@ import {
   markAllNotificationsRead,
   markNotificationRead,
   pollPairing,
+  redeemQuotaCode,
   refreshLicense,
   resendSiteInvitation,
   resetBrandingField,
@@ -81,6 +90,8 @@ import {
   updateIhostConfig,
   updateObject,
   updateQuota,
+  updateQuotaStorePackage,
+  updateQuotaStoreSettings,
   updateStorage,
   updateUserStatus,
   uploadAvatar,
@@ -255,6 +266,127 @@ describe('api', () => {
       vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'duplicate invitation' }, false, 409))
 
       await expect(createSiteInvitation('new@example.com')).rejects.toThrow('duplicate invitation')
+    })
+  })
+
+  describe('quota store api', () => {
+    it('gets admin settings', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(null))
+
+      await getQuotaStoreSettings()
+
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toBe('/api/admin/quota-store/settings')
+      expect(init.method).toBe('GET')
+    })
+
+    it('updates admin settings payload', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ enabled: true }))
+
+      await updateQuotaStoreSettings({
+        enabled: true,
+        cloudBaseUrl: 'https://cloud.example',
+        publicInstanceUrl: 'https://zpan.example',
+        webhookSigningSecret: 'secret',
+      })
+
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toBe('/api/admin/quota-store/settings')
+      expect(init.method).toBe('PUT')
+      expect(JSON.parse(init.body as string)).toMatchObject({ enabled: true, webhookSigningSecret: 'secret' })
+    })
+
+    it('creates and updates packages with typed RPC paths', async () => {
+      const payload = { name: 'Small', bytes: 1024, amount: 500, currency: 'usd' }
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(makeResponse({ id: 'pkg-1' }))
+        .mockResolvedValueOnce(makeResponse({ id: 'pkg-1' }))
+
+      await createQuotaStorePackage(payload)
+      await updateQuotaStorePackage('pkg-1', payload)
+
+      const [createUrl, createInit] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      const [updateUrl, updateInit] = vi.mocked(fetch).mock.calls[1] as [string, RequestInit]
+      expect(createUrl).toBe('/api/admin/quota-store/packages')
+      expect(createInit.method).toBe('POST')
+      expect(updateUrl).toBe('/api/admin/quota-store/packages/pkg-1')
+      expect(updateInit.method).toBe('PUT')
+    })
+
+    it('lists and deletes admin packages', async () => {
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(makeResponse({ items: [], total: 0 }))
+        .mockResolvedValueOnce(makeResponse({ id: 'pkg-1', deleted: true }))
+
+      await listQuotaStorePackages()
+      await deleteQuotaStorePackage('pkg-1')
+
+      expect((vi.mocked(fetch).mock.calls[0] as [string])[0]).toBe('/api/admin/quota-store/packages')
+      const [deleteUrl, deleteInit] = vi.mocked(fetch).mock.calls[1] as [string, RequestInit]
+      expect(deleteUrl).toBe('/api/admin/quota-store/packages/pkg-1')
+      expect(deleteInit.method).toBe('DELETE')
+    })
+
+    it('calls user store endpoints', async () => {
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(makeResponse({ items: [], total: 0 }))
+        .mockResolvedValueOnce(makeResponse({ items: [], total: 0 }))
+        .mockResolvedValueOnce(makeResponse({ checkoutUrl: 'https://cloud.example/checkout' }))
+        .mockResolvedValueOnce(makeResponse({ redeemed: true }))
+        .mockResolvedValueOnce(makeResponse({ items: [], total: 0 }))
+
+      await listPurchasableQuotaPackages()
+      await listQuotaStoreTargets()
+      await createQuotaCheckout('pkg-1', 'org-1')
+      await redeemQuotaCode('CODE', 'org-1')
+      await listQuotaGrants()
+
+      const calls = vi.mocked(fetch).mock.calls as Array<[string, RequestInit]>
+      expect(calls[0][0]).toBe('/api/quota-store/packages')
+      expect(calls[1][0]).toBe('/api/quota-store/targets')
+      expect(calls[2][0]).toBe('/api/quota-store/checkout')
+      expect(JSON.parse(calls[2][1].body as string)).toEqual({ packageId: 'pkg-1', targetOrgId: 'org-1' })
+      expect(calls[3][0]).toBe('/api/quota-store/redemptions')
+      expect(JSON.parse(calls[3][1].body as string)).toEqual({ code: 'CODE', targetOrgId: 'org-1' })
+      expect(calls[4][0]).toBe('/api/quota-store/grants')
+    })
+
+    it('throws ApiError for quota store failures', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'feature_not_available' }, false, 402))
+
+      await expect(listQuotaStorePackages()).rejects.toThrow('feature_not_available')
+    })
+
+    it.each([
+      ['getQuotaStoreSettings', () => getQuotaStoreSettings()],
+      [
+        'updateQuotaStoreSettings',
+        () =>
+          updateQuotaStoreSettings({
+            enabled: true,
+            cloudBaseUrl: 'https://cloud.example',
+            publicInstanceUrl: 'https://zpan.example',
+          }),
+      ],
+      ['listQuotaStorePackages', () => listQuotaStorePackages()],
+      [
+        'createQuotaStorePackage',
+        () => createQuotaStorePackage({ name: 'Small', bytes: 1024, amount: 500, currency: 'usd' }),
+      ],
+      [
+        'updateQuotaStorePackage',
+        () => updateQuotaStorePackage('pkg-1', { name: 'Small', bytes: 1024, amount: 500, currency: 'usd' }),
+      ],
+      ['deleteQuotaStorePackage', () => deleteQuotaStorePackage('pkg-1')],
+      ['listPurchasableQuotaPackages', () => listPurchasableQuotaPackages()],
+      ['listQuotaStoreTargets', () => listQuotaStoreTargets()],
+      ['createQuotaCheckout', () => createQuotaCheckout('pkg-1', 'org-1')],
+      ['redeemQuotaCode', () => redeemQuotaCode('CODE', 'org-1')],
+      ['listQuotaGrants', () => listQuotaGrants()],
+    ])('throws ApiError for %s failures', async (_name, call) => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'quota store failed' }, false, 400))
+
+      await expect(call()).rejects.toThrow('quota store failed')
     })
   })
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -19,6 +19,10 @@ import type {
   ImageHosting,
   Notification,
   PaginatedResponse,
+  QuotaGrant,
+  QuotaStorePackage,
+  QuotaStoreSettings,
+  QuotaTarget,
   ShareListItem,
   ShareView,
   SiteInvitation,
@@ -29,6 +33,7 @@ import {
   adminAnnouncementsApi,
   adminAuditApi,
   adminAuthProviders,
+  adminQuotaStoreApi,
   adminQuotas,
   adminSiteInvitations,
   announcementsApi,
@@ -48,6 +53,7 @@ import {
   publicBrandingApi,
   publicSharesApi,
   publicSiteInvitations,
+  quotaStoreApi,
   storages,
   system,
   teamsApi,
@@ -272,7 +278,68 @@ export function updateQuota(orgId: string, quota: number) {
 // User Quotas API
 
 export function getUserQuota() {
-  return unwrap<{ orgId: string; quota: number; used: number }>(userQuotas.me.$get())
+  return unwrap<{ orgId: string; baseQuota: number; grantedQuota: number; quota: number; used: number }>(
+    userQuotas.me.$get(),
+  )
+}
+
+// Quota Store API
+
+export function getQuotaStoreSettings() {
+  return unwrap<QuotaStoreSettings | null>(adminQuotaStoreApi.settings.$get())
+}
+
+export function updateQuotaStoreSettings(data: {
+  enabled: boolean
+  cloudBaseUrl: string
+  publicInstanceUrl: string
+  webhookSigningSecret?: string
+}) {
+  return unwrap<QuotaStoreSettings>(adminQuotaStoreApi.settings.$put({ json: data }))
+}
+
+export function listQuotaStorePackages() {
+  return unwrap<{ items: QuotaStorePackage[]; total: number }>(adminQuotaStoreApi.packages.$get())
+}
+
+export function createQuotaStorePackage(data: {
+  name: string
+  description?: string
+  bytes: number
+  amount: number
+  currency: string
+  active?: boolean
+  sortOrder?: number
+}) {
+  return unwrap<QuotaStorePackage>(adminQuotaStoreApi.packages.$post({ json: data }))
+}
+
+export function updateQuotaStorePackage(id: string, data: Parameters<typeof createQuotaStorePackage>[0]) {
+  return unwrap<QuotaStorePackage>(adminQuotaStoreApi.packages[':id'].$put({ param: { id }, json: data }))
+}
+
+export function deleteQuotaStorePackage(id: string) {
+  return unwrap<{ id: string; deleted: boolean }>(adminQuotaStoreApi.packages[':id'].$delete({ param: { id } }))
+}
+
+export function listPurchasableQuotaPackages() {
+  return unwrap<{ items: QuotaStorePackage[]; total: number }>(quotaStoreApi.packages.$get())
+}
+
+export function listQuotaStoreTargets() {
+  return unwrap<{ items: QuotaTarget[]; total: number }>(quotaStoreApi.targets.$get())
+}
+
+export function createQuotaCheckout(packageId: string, targetOrgId: string) {
+  return unwrap<{ checkoutUrl: string }>(quotaStoreApi.checkout.$post({ json: { packageId, targetOrgId } }))
+}
+
+export function redeemQuotaCode(code: string, targetOrgId: string) {
+  return unwrap<Record<string, unknown>>(quotaStoreApi.redemptions.$post({ json: { code, targetOrgId } }))
+}
+
+export function listQuotaGrants() {
+  return unwrap<{ items: QuotaGrant[]; total: number }>(quotaStoreApi.grants.$get())
 }
 
 // System Options API

--- a/src/lib/rpc.ts
+++ b/src/lib/rpc.ts
@@ -3,6 +3,7 @@ import type {
   AdminAuditRoute,
   AdminAuthProvidersRoute,
   AdminInviteCodesRoute,
+  AdminQuotaStoreRoute,
   AdminQuotasRoute,
   AdminSiteInvitationsRoute,
   AnnouncementsRoute,
@@ -22,6 +23,7 @@ import type {
   PublicSharesRoute,
   PublicSiteInvitationsRoute,
   PublicTeamsRoute,
+  QuotaStoreRoute,
   StoragesRoute,
   SystemRoute,
   TeamsRoute,
@@ -38,7 +40,9 @@ export const trash = hc<TrashRoute>('/api/trash', opts)
 export const storages = hc<StoragesRoute>('/api/admin/storages', opts)
 export const users = hc<UsersRoute>('/api/admin/users', opts)
 export const adminQuotas = hc<AdminQuotasRoute>('/api/admin/quotas', opts)
+export const adminQuotaStoreApi = hc<AdminQuotaStoreRoute>('/api/admin/quota-store', opts)
 export const userQuotas = hc<UserQuotasRoute>('/api/quotas', opts)
+export const quotaStoreApi = hc<QuotaStoreRoute>('/api/quota-store', opts)
 export const system = hc<SystemRoute>('/api/system', opts)
 export const authProviders = hc<AuthProvidersRoute>('/api/auth-providers', opts)
 export const adminAuthProviders = hc<AdminAuthProvidersRoute>('/api/admin/auth-providers', opts)


### PR DESCRIPTION
## Summary
- add Pro-gated quota store settings, package, grant, and delivery ledger data model with generated migration
- add admin/user quota store APIs plus signed Cloud delivery webhook with idempotent grant handling
- centralize effective quota calculation/enforcement across upload confirm, copy, save-to-drive, and image hosting paths
- add Hono RPC frontend wrappers and focused coverage for quota store flows

## Verification
- npm run typecheck
- npm run lint
- npm test
- npm run test:cf
- subagent test-writer focused pass
- subagent clean-code-reviewer final pass