### PR TITLE
feat: add quota store backend and delivery ledger

### DIFF
--- a/migrations/0018_cheerful_chimera.sql
+++ b/migrations/0018_cheerful_chimera.sql
@@ -1,0 +1,57 @@
+CREATE TABLE `quota_delivery_events` (
+	`id` text PRIMARY KEY NOT NULL,
+	`event_id` text NOT NULL,
+	`cloud_order_id` text,
+	`payload_hash` text,
+	`raw_payload` text,
+	`status` text DEFAULT 'processed' NOT NULL,
+	`created_at` integer NOT NULL,
+	`processed_at` integer
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `quota_delivery_events_event_id_unique` ON `quota_delivery_events` (`event_id`);--> statement-breakpoint
+CREATE INDEX `quota_delivery_events_cloud_order_idx` ON `quota_delivery_events` (`cloud_order_id`);--> statement-breakpoint
+CREATE INDEX `quota_delivery_events_created_idx` ON `quota_delivery_events` (`created_at`);--> statement-breakpoint
+CREATE TABLE `quota_grants` (
+	`id` text PRIMARY KEY NOT NULL,
+	`org_id` text NOT NULL,
+	`source` text NOT NULL,
+	`external_event_id` text,
+	`cloud_order_id` text,
+	`code` text,
+	`bytes` integer NOT NULL,
+	`package_snapshot` text,
+	`granted_by` text,
+	`terminal_user_id` text,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `quota_grants_org_created_idx` ON `quota_grants` (`org_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `quota_grants_external_event_idx` ON `quota_grants` (`external_event_id`);--> statement-breakpoint
+CREATE INDEX `quota_grants_cloud_order_idx` ON `quota_grants` (`cloud_order_id`);--> statement-breakpoint
+CREATE TABLE `quota_store_packages` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`bytes` integer NOT NULL,
+	`amount` integer NOT NULL,
+	`currency` text DEFAULT 'usd' NOT NULL,
+	`active` integer DEFAULT true NOT NULL,
+	`sort_order` integer DEFAULT 0 NOT NULL,
+	`cloud_sync_id` text,
+	`cloud_sync_status` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `quota_store_packages_active_sort_idx` ON `quota_store_packages` (`active`,`sort_order`);--> statement-breakpoint
+CREATE TABLE `quota_store_settings` (
+	`id` text PRIMARY KEY DEFAULT 'default' NOT NULL,
+	`enabled` integer DEFAULT false NOT NULL,
+	`cloud_base_url` text,
+	`instance_public_url` text,
+	`webhook_signing_secret` text,
+	`updated_at` integer
+);
+--> statement-breakpoint
+ALTER TABLE `announcements` DROP COLUMN `expires_at`;

--- a/migrations/meta/0018_snapshot.json
+++ b/migrations/meta/0018_snapshot.json
@@ -1,0 +1,2648 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "855ae08a-cc29-425a-8345-9b89aac84da4",
+  "prevId": "98cf8886-a548-4438-a4b9-a57bfabf2529",
+  "tables": {
+    "activity_events": {
+      "name": "activity_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "announcements": {
+      "name": "announcements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "announcements_status_priority_idx": {
+          "name": "announcements_status_priority_idx",
+          "columns": [
+            "status",
+            "priority"
+          ],
+          "isUnique": false
+        },
+        "announcements_published_idx": {
+          "name": "announcements_published_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "image_hosting_configs": {
+      "name": "image_hosting_configs",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_domain": {
+          "name": "custom_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cf_hostname_id": {
+          "name": "cf_hostname_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "domain_verified_at": {
+          "name": "domain_verified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referer_allowlist": {
+          "name": "referer_allowlist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "image_hosting_configs_custom_domain_unique": {
+          "name": "image_hosting_configs_custom_domain_unique",
+          "columns": [
+            "custom_domain"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "image_hosting_configs_org_id_organization_id_fk": {
+          "name": "image_hosting_configs_org_id_organization_id_fk",
+          "tableFrom": "image_hosting_configs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "image_hostings": {
+      "name": "image_hostings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "image_hostings_token_unique": {
+          "name": "image_hostings_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "image_hostings_org_path_uniq": {
+          "name": "image_hostings_org_path_uniq",
+          "columns": [
+            "org_id",
+            "path"
+          ],
+          "isUnique": true
+        },
+        "image_hostings_org_created_idx": {
+          "name": "image_hostings_org_created_idx",
+          "columns": [
+            "org_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "image_hostings_token_idx": {
+          "name": "image_hostings_token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "image_hostings_org_id_organization_id_fk": {
+          "name": "image_hostings_org_id_organization_id_fk",
+          "tableFrom": "image_hostings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "image_hostings_storage_id_storages_id_fk": {
+          "name": "image_hostings_storage_id_storages_id_fk",
+          "tableFrom": "image_hostings",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invite_codes": {
+      "name": "invite_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invite_codes_code_unique": {
+          "name": "invite_codes_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "license_bindings": {
+      "name": "license_bindings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_binding_id": {
+          "name": "cloud_binding_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_account_id": {
+          "name": "cloud_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_account_email": {
+          "name": "cloud_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cached_certificate": {
+          "name": "cached_certificate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cached_certificate_expires_at": {
+          "name": "cached_certificate_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bound_at": {
+          "name": "bound_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disconnected_at": {
+          "name": "disconnected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refresh_at": {
+          "name": "last_refresh_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refresh_error": {
+          "name": "last_refresh_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "license_bindings_active_uniq": {
+          "name": "license_bindings_active_uniq",
+          "columns": [
+            "status"
+          ],
+          "isUnique": true,
+          "where": "status = 'active'"
+        },
+        "license_bindings_cloud_binding_idx": {
+          "name": "license_bindings_cloud_binding_idx",
+          "columns": [
+            "cloud_binding_id"
+          ],
+          "isUnique": false
+        },
+        "license_bindings_instance_idx": {
+          "name": "license_bindings_instance_idx",
+          "columns": [
+            "instance_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "matters": {
+      "name": "matters",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dirtype": {
+          "name": "dirtype",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "parent": {
+          "name": "parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "trashed_at": {
+          "name": "trashed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "matters_alias_unique": {
+          "name": "matters_alias_unique",
+          "columns": [
+            "alias"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "notifications_user_read_idx": {
+          "name": "notifications_user_read_idx",
+          "columns": [
+            "user_id",
+            "read_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "org_quotas": {
+      "name": "org_quotas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quota": {
+          "name": "quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_delivery_events": {
+      "name": "quota_delivery_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_order_id": {
+          "name": "cloud_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'processed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "quota_delivery_events_event_id_unique": {
+          "name": "quota_delivery_events_event_id_unique",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": true
+        },
+        "quota_delivery_events_cloud_order_idx": {
+          "name": "quota_delivery_events_cloud_order_idx",
+          "columns": [
+            "cloud_order_id"
+          ],
+          "isUnique": false
+        },
+        "quota_delivery_events_created_idx": {
+          "name": "quota_delivery_events_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_grants": {
+      "name": "quota_grants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloud_order_id": {
+          "name": "cloud_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "package_snapshot": {
+          "name": "package_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_user_id": {
+          "name": "terminal_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "quota_grants_org_created_idx": {
+          "name": "quota_grants_org_created_idx",
+          "columns": [
+            "org_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "quota_grants_external_event_idx": {
+          "name": "quota_grants_external_event_idx",
+          "columns": [
+            "external_event_id"
+          ],
+          "isUnique": false
+        },
+        "quota_grants_cloud_order_idx": {
+          "name": "quota_grants_cloud_order_idx",
+          "columns": [
+            "cloud_order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_store_packages": {
+      "name": "quota_store_packages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'usd'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cloud_sync_id": {
+          "name": "cloud_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloud_sync_status": {
+          "name": "cloud_sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "quota_store_packages_active_sort_idx": {
+          "name": "quota_store_packages_active_sort_idx",
+          "columns": [
+            "active",
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_store_settings": {
+      "name": "quota_store_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cloud_base_url": {
+          "name": "cloud_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instance_public_url": {
+          "name": "instance_public_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "webhook_signing_secret": {
+          "name": "webhook_signing_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_recipients": {
+      "name": "share_recipients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "share_id": {
+          "name": "share_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "share_recipients_share_id_idx": {
+          "name": "share_recipients_share_id_idx",
+          "columns": [
+            "share_id"
+          ],
+          "isUnique": false
+        },
+        "share_recipients_user_id_idx": {
+          "name": "share_recipients_user_id_idx",
+          "columns": [
+            "recipient_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shares": {
+      "name": "shares",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matter_id": {
+          "name": "matter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_limit": {
+          "name": "download_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "downloads": {
+          "name": "downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "shares_token_unique": {
+          "name": "shares_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "shares_creator_status_created_idx": {
+          "name": "shares_creator_status_created_idx",
+          "columns": [
+            "creator_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_invitations": {
+      "name": "site_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "site_invitations_token_unique": {
+          "name": "site_invitations_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "site_invitations_email_idx": {
+          "name": "site_invitations_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "site_invitations_created_idx": {
+          "name": "site_invitations_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "site_invitations_expires_idx": {
+          "name": "site_invitations_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "storages": {
+      "name": "storages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'auto'"
+        },
+        "access_key": {
+          "name": "access_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_key": {
+          "name": "secret_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "custom_host": {
+          "name": "custom_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_options": {
+      "name": "system_options",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "public": {
+          "name": "public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_invite_links": {
+      "name": "team_invite_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_invite_links_token_unique": {
+          "name": "team_invite_links_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_config_id_idx": {
+          "name": "apikey_config_id_idx",
+          "columns": [
+            "config_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_reference_id_idx": {
+          "name": "apikey_reference_id_idx",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1777771763793,
       "tag": "0017_add-announcements",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1777992072747,
+      "tag": "0018_cheerful_chimera",
+      "breakpoints": true
     }
   ]
 }

--- a/server/app.ts
+++ b/server/app.ts
@@ -21,6 +21,8 @@ import { me } from './routes/me'
 import { notifications } from './routes/notifications'
 import objects from './routes/objects'
 import profile from './routes/profile'
+import { quotaStoreWebhook, userQuotaStore } from './routes/quota-store'
+import adminQuotaStore from './routes/quota-store-admin'
 import { adminQuotas, userQuotas } from './routes/quotas'
 import redirect from './routes/redirect'
 import { authedShares, publicShares } from './routes/shares'
@@ -94,6 +96,9 @@ export function createApp(platform: Platform, auth: Auth) {
   app.route('/api/admin/branding', brandingAdmin)
   app.route('/api/admin/announcements', adminAnnouncements)
   app.route('/api/admin/audit', adminAudit)
+  app.route('/api/admin/quota-store', adminQuotaStore)
+  app.route('/api/quota-store', userQuotaStore)
+  app.route('/api/quota-store/webhooks', quotaStoreWebhook)
 
   app.get('/api/health', (c) => c.json({ status: 'ok' }))
 
@@ -133,3 +138,6 @@ export type LicensingAdminRoute = typeof licensingAdmin
 export type PublicBrandingRoute = typeof publicBranding
 export type BrandingAdminRoute = typeof brandingAdmin
 export type AdminAuditRoute = typeof adminAudit
+export type AdminQuotaStoreRoute = typeof adminQuotaStore
+export type UserQuotaStoreRoute = typeof userQuotaStore
+export type QuotaStoreWebhookRoute = typeof quotaStoreWebhook

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -246,3 +246,77 @@ export const imageHostings = sqliteTable(
     index('image_hostings_token_idx').on(t.token),
   ],
 )
+
+// ─── Quota Store ──────────────────────────────────────────────────────────────
+
+// quota_store_settings — instance-level singleton row (id = 'default')
+export const quotaStoreSettings = sqliteTable('quota_store_settings', {
+  id: text('id').primaryKey().default('default'),
+  enabled: integer('enabled', { mode: 'boolean' }).notNull().default(false),
+  cloudBaseUrl: text('cloud_base_url'),
+  instancePublicUrl: text('instance_public_url'),
+  webhookSigningSecret: text('webhook_signing_secret'),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }),
+})
+
+// quota_store_packages — admin-defined purchase packages
+export const quotaStorePackages = sqliteTable(
+  'quota_store_packages',
+  {
+    id: text('id').primaryKey(),
+    name: text('name').notNull(),
+    description: text('description'),
+    bytes: integer('bytes').notNull(),
+    amount: integer('amount').notNull(), // stored as cents/smallest unit
+    currency: text('currency').notNull().default('usd'),
+    active: integer('active', { mode: 'boolean' }).notNull().default(true),
+    sortOrder: integer('sort_order').notNull().default(0),
+    cloudSyncId: text('cloud_sync_id'),
+    cloudSyncStatus: text('cloud_sync_status'), // 'pending' | 'synced' | 'error'
+    createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+    updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
+  },
+  (t) => [index('quota_store_packages_active_sort_idx').on(t.active, t.sortOrder)],
+)
+
+// quota_grants — immutable additive quota grants per org
+export const quotaGrants = sqliteTable(
+  'quota_grants',
+  {
+    id: text('id').primaryKey(),
+    orgId: text('org_id').notNull(),
+    source: text('source').notNull(), // 'stripe' | 'redeem_code' | 'admin_adjustment'
+    externalEventId: text('external_event_id'),
+    cloudOrderId: text('cloud_order_id'),
+    code: text('code'),
+    bytes: integer('bytes').notNull(),
+    packageSnapshot: text('package_snapshot'), // JSON snapshot of package at time of grant
+    grantedBy: text('granted_by'),
+    terminalUserId: text('terminal_user_id'),
+    createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+  },
+  (t) => [
+    index('quota_grants_org_created_idx').on(t.orgId, t.createdAt),
+    index('quota_grants_external_event_idx').on(t.externalEventId),
+    index('quota_grants_cloud_order_idx').on(t.cloudOrderId),
+  ],
+)
+
+// quota_delivery_events — idempotency ledger for Cloud webhook deliveries
+export const quotaDeliveryEvents = sqliteTable(
+  'quota_delivery_events',
+  {
+    id: text('id').primaryKey(),
+    eventId: text('event_id').notNull().unique(),
+    cloudOrderId: text('cloud_order_id'),
+    payloadHash: text('payload_hash'),
+    rawPayload: text('raw_payload'),
+    status: text('status').notNull().default('processed'), // 'processed' | 'duplicate' | 'error'
+    createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+    processedAt: integer('processed_at', { mode: 'timestamp' }),
+  },
+  (t) => [
+    index('quota_delivery_events_cloud_order_idx').on(t.cloudOrderId),
+    index('quota_delivery_events_created_idx').on(t.createdAt),
+  ],
+)

--- a/server/routes/quota-store-admin.ts
+++ b/server/routes/quota-store-admin.ts
@@ -1,0 +1,86 @@
+import { zValidator } from '@hono/zod-validator'
+import { Hono } from 'hono'
+import { ZPAN_CLOUD_URL_DEFAULT } from '../../shared/constants'
+import {
+  createQuotaStorePackageSchema,
+  putQuotaStoreSettingsSchema,
+  updateQuotaStorePackageSchema,
+} from '../../shared/schemas'
+import { requireAdmin } from '../middleware/auth'
+import type { Env } from '../middleware/platform'
+import { requireFeature } from '../middleware/require-feature'
+import {
+  createQuotaStorePackage,
+  deleteQuotaStorePackage,
+  getQuotaStorePackage,
+  getQuotaStoreSettings,
+  listQuotaStorePackages,
+  putQuotaStoreSettings,
+  syncPackageToCloud,
+  updateQuotaStorePackage,
+} from '../services/quota-store'
+
+const adminQuotaStore = new Hono<Env>()
+  .use(requireAdmin)
+  .use(requireFeature('quota_store'))
+
+  // ─── Settings ──────────────────────────────────────────────────────────────
+  .get('/settings', async (c) => {
+    const db = c.get('platform').db
+    const settings = await getQuotaStoreSettings(db)
+    return c.json(settings)
+  })
+  .put('/settings', zValidator('json', putQuotaStoreSettingsSchema), async (c) => {
+    const db = c.get('platform').db
+    const input = c.req.valid('json')
+    const settings = await putQuotaStoreSettings(db, input)
+    return c.json(settings)
+  })
+
+  // ─── Packages ──────────────────────────────────────────────────────────────
+  .get('/packages', async (c) => {
+    const db = c.get('platform').db
+    const packages = await listQuotaStorePackages(db, false)
+    return c.json({ items: packages, total: packages.length })
+  })
+  .post('/packages', zValidator('json', createQuotaStorePackageSchema), async (c) => {
+    const db = c.get('platform').db
+    const input = c.req.valid('json')
+    const pkg = await createQuotaStorePackage(db, input)
+
+    // Attempt catalog sync; surface sync errors in the response.
+    const settings = await getQuotaStoreSettings(db)
+    const cloudBaseUrl = settings.cloudBaseUrl ?? c.get('platform').getEnv('ZPAN_CLOUD_URL') ?? ZPAN_CLOUD_URL_DEFAULT
+    const sync = await syncPackageToCloud(db, pkg, cloudBaseUrl)
+    const updated = await getQuotaStorePackage(db, pkg.id)
+
+    return c.json({ package: updated ?? pkg, syncError: sync.cloudSyncStatus === 'error' ? sync.error : null }, 201)
+  })
+  .get('/packages/:id', async (c) => {
+    const db = c.get('platform').db
+    const pkg = await getQuotaStorePackage(db, c.req.param('id'))
+    if (!pkg) return c.json({ error: 'Not found' }, 404)
+    return c.json(pkg)
+  })
+  .patch('/packages/:id', zValidator('json', updateQuotaStorePackageSchema), async (c) => {
+    const db = c.get('platform').db
+    const input = c.req.valid('json')
+    const updated = await updateQuotaStorePackage(db, c.req.param('id'), input)
+    if (!updated) return c.json({ error: 'Not found' }, 404)
+
+    // Re-sync to Cloud after update.
+    const settings = await getQuotaStoreSettings(db)
+    const cloudBaseUrl = settings.cloudBaseUrl ?? c.get('platform').getEnv('ZPAN_CLOUD_URL') ?? ZPAN_CLOUD_URL_DEFAULT
+    const sync = await syncPackageToCloud(db, updated, cloudBaseUrl)
+    const final = await getQuotaStorePackage(db, updated.id)
+
+    return c.json({ package: final ?? updated, syncError: sync.cloudSyncStatus === 'error' ? sync.error : null })
+  })
+  .delete('/packages/:id', async (c) => {
+    const db = c.get('platform').db
+    const ok = await deleteQuotaStorePackage(db, c.req.param('id'))
+    if (!ok) return c.json({ error: 'Not found' }, 404)
+    return c.json({ deleted: true })
+  })
+
+export default adminQuotaStore

--- a/server/routes/quota-store.ts
+++ b/server/routes/quota-store.ts
@@ -1,0 +1,258 @@
+import { zValidator } from '@hono/zod-validator'
+import { eq } from 'drizzle-orm'
+import { Hono } from 'hono'
+import { ZPAN_CLOUD_URL_DEFAULT } from '../../shared/constants'
+import { checkoutSchema, cloudDeliveryPayloadSchema, redeemSchema } from '../../shared/schemas'
+import { member, organization } from '../db/auth-schema'
+import { requireAuth } from '../middleware/auth'
+import type { Env } from '../middleware/platform'
+import { requireFeature } from '../middleware/require-feature'
+import { findPersonalOrg } from '../services/org'
+import {
+  appendQuotaGrant,
+  createCloudCheckout,
+  findDeliveryEvent,
+  getQuotaStorePackage,
+  getQuotaStoreSettings,
+  listQuotaGrants,
+  listQuotaStorePackages,
+  recordDeliveryEvent,
+  sendCloudRedeem,
+  verifyWebhookSignature,
+} from '../services/quota-store'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Returns all org IDs the current user has access to purchase for
+ * (personal org + teams they belong to as at least member).
+ */
+async function getAccessibleOrgIds(db: Parameters<typeof findPersonalOrg>[0], userId: string): Promise<string[]> {
+  const personalOrgId = await findPersonalOrg(db, userId)
+  const teamRows = await db
+    .select({ organizationId: member.organizationId })
+    .from(member)
+    .where(eq(member.userId, userId))
+  const ids = new Set<string>()
+  if (personalOrgId) ids.add(personalOrgId)
+  for (const r of teamRows) ids.add(r.organizationId)
+  return [...ids]
+}
+
+async function canAccessOrg(
+  db: Parameters<typeof findPersonalOrg>[0],
+  userId: string,
+  orgId: string,
+): Promise<boolean> {
+  const accessibleIds = await getAccessibleOrgIds(db, userId)
+  return accessibleIds.includes(orgId)
+}
+
+// ─── User-facing quota store routes ──────────────────────────────────────────
+
+const userQuotaStore = new Hono<Env>()
+  .use(requireAuth)
+  .use(requireFeature('quota_store'))
+
+  // GET /api/quota-store/packages — list active packages
+  .get('/packages', async (c) => {
+    const db = c.get('platform').db
+    const packages = await listQuotaStorePackages(db, true)
+    return c.json({ items: packages, total: packages.length })
+  })
+
+  // GET /api/quota-store/targets — orgs the current user can purchase for
+  .get('/targets', async (c) => {
+    const db = c.get('platform').db
+    const userId = c.get('userId')!
+    const orgIds = await getAccessibleOrgIds(db, userId)
+
+    const targets = []
+    for (const orgId of orgIds) {
+      const [orgRow] = await db
+        .select({ id: organization.id, name: organization.name, metadata: organization.metadata })
+        .from(organization)
+        .where(eq(organization.id, orgId))
+      if (!orgRow) continue
+      let orgType = 'unknown'
+      try {
+        orgType = (JSON.parse(orgRow.metadata ?? '{}') as { type?: string }).type ?? 'unknown'
+      } catch {}
+      targets.push({ orgId: orgRow.id, orgName: orgRow.name, orgType })
+    }
+
+    return c.json({ items: targets, total: targets.length })
+  })
+
+  // POST /api/quota-store/checkout — initiate Cloud purchase session
+  .post('/checkout', zValidator('json', checkoutSchema), async (c) => {
+    const db = c.get('platform').db
+    const userId = c.get('userId')!
+    const { packageId, targetOrgId } = c.req.valid('json')
+
+    if (!(await canAccessOrg(db, userId, targetOrgId))) {
+      return c.json({ error: 'Forbidden: no access to target org' }, 403)
+    }
+
+    const pkg = await getQuotaStorePackage(db, packageId)
+    if (!pkg?.active) return c.json({ error: 'Package not found' }, 404)
+    if (!pkg.cloudSyncId) return c.json({ error: 'Package not yet synced to Cloud' }, 422)
+
+    const settings = await getQuotaStoreSettings(db)
+    const cloudBaseUrl = settings.cloudBaseUrl ?? c.get('platform').getEnv('ZPAN_CLOUD_URL') ?? ZPAN_CLOUD_URL_DEFAULT
+    const instancePublicUrl = settings.instancePublicUrl ?? ''
+    const callbackUrl = `${instancePublicUrl}/api/quota-store/webhooks/cloud`
+
+    try {
+      const { checkoutUrl } = await createCloudCheckout({
+        cloudBaseUrl,
+        instancePublicUrl,
+        packageId,
+        cloudSyncId: pkg.cloudSyncId,
+        targetOrgId,
+        userId,
+        callbackUrl,
+      })
+      return c.json({ checkoutUrl })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error'
+      return c.json({ error: msg }, 502)
+    }
+  })
+
+  // POST /api/quota-store/redemptions — redeem a code via Cloud
+  .post('/redemptions', zValidator('json', redeemSchema), async (c) => {
+    const db = c.get('platform').db
+    const userId = c.get('userId')!
+    const { code, targetOrgId } = c.req.valid('json')
+
+    if (!(await canAccessOrg(db, userId, targetOrgId))) {
+      return c.json({ error: 'Forbidden: no access to target org' }, 403)
+    }
+
+    const settings = await getQuotaStoreSettings(db)
+    const cloudBaseUrl = settings.cloudBaseUrl ?? c.get('platform').getEnv('ZPAN_CLOUD_URL') ?? ZPAN_CLOUD_URL_DEFAULT
+    const instancePublicUrl = settings.instancePublicUrl ?? ''
+
+    try {
+      const result = await sendCloudRedeem({
+        cloudBaseUrl,
+        instancePublicUrl,
+        code,
+        targetOrgId,
+        userId,
+      })
+      return c.json(result)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error'
+      return c.json({ error: msg }, 502)
+    }
+  })
+
+  // GET /api/quota-store/grants — list grants for accessible orgs
+  .get('/grants', async (c) => {
+    const db = c.get('platform').db
+    const userId = c.get('userId')!
+    const orgIds = await getAccessibleOrgIds(db, userId)
+    const grants = await listQuotaGrants(db, orgIds)
+    return c.json({ items: grants, total: grants.length })
+  })
+
+// ─── Cloud webhook (no auth — signature-verified) ─────────────────────────────
+
+const quotaStoreWebhook = new Hono<Env>()
+
+  // POST /api/quota-store/webhooks/cloud
+  .post('/cloud', async (c) => {
+    const db = c.get('platform').db
+    const rawBody = await c.req.text()
+    const signatureHeader = c.req.header('x-zpan-signature') ?? null
+
+    const settings = await getQuotaStoreSettings(db)
+    const secret = settings.webhookSigningSecret
+    if (!secret) {
+      return c.json({ error: 'Webhook signing secret not configured' }, 500)
+    }
+
+    if (!verifyWebhookSignature(secret, rawBody, signatureHeader)) {
+      return c.json({ error: 'Invalid signature' }, 401)
+    }
+
+    let body: unknown
+    try {
+      body = JSON.parse(rawBody)
+    } catch {
+      return c.json({ error: 'Malformed JSON payload' }, 400)
+    }
+
+    const parsed = cloudDeliveryPayloadSchema.safeParse(body)
+    if (!parsed.success) {
+      return c.json({ error: 'Invalid payload', details: parsed.error.flatten() }, 400)
+    }
+
+    const payload = parsed.data
+
+    // Idempotency check
+    const existing = await findDeliveryEvent(db, payload.eventId)
+    if (existing) {
+      await recordDeliveryEvent(db, {
+        eventId: payload.eventId,
+        cloudOrderId: payload.cloudOrderId ?? null,
+        rawPayload: rawBody,
+        status: 'duplicate',
+      })
+      return c.json({ ok: true, duplicate: true })
+    }
+
+    // Validate target org exists
+    const [orgRow] = await db
+      .select({ id: organization.id })
+      .from(organization)
+      .where(eq(organization.id, payload.targetOrgId))
+    if (!orgRow) {
+      await recordDeliveryEvent(db, {
+        eventId: payload.eventId,
+        cloudOrderId: payload.cloudOrderId ?? null,
+        rawPayload: rawBody,
+        status: 'error',
+      })
+      return c.json({ error: 'Target org not found' }, 404)
+    }
+
+    // Validate package (if packageId is a known package, check bytes match)
+    const pkg = await getQuotaStorePackage(db, payload.packageId)
+    if (pkg && pkg.bytes !== payload.bytes) {
+      await recordDeliveryEvent(db, {
+        eventId: payload.eventId,
+        cloudOrderId: payload.cloudOrderId ?? null,
+        rawPayload: rawBody,
+        status: 'error',
+      })
+      return c.json({ error: 'Package bytes mismatch' }, 422)
+    }
+
+    // Record event and append grant atomically-ish
+    await recordDeliveryEvent(db, {
+      eventId: payload.eventId,
+      cloudOrderId: payload.cloudOrderId ?? null,
+      rawPayload: rawBody,
+      status: 'processed',
+    })
+
+    const packageSnapshot = pkg ? JSON.stringify(pkg) : null
+    await appendQuotaGrant(db, {
+      orgId: payload.targetOrgId,
+      source: payload.source,
+      bytes: payload.bytes,
+      externalEventId: payload.externalEventId ?? null,
+      cloudOrderId: payload.cloudOrderId ?? null,
+      code: payload.code ?? null,
+      packageSnapshot,
+      grantedBy: null,
+      terminalUserId: null,
+    })
+
+    return c.json({ ok: true, duplicate: false })
+  })
+
+export { quotaStoreWebhook, userQuotaStore }

--- a/server/routes/quotas.ts
+++ b/server/routes/quotas.ts
@@ -8,6 +8,7 @@ import { orgQuotas } from '../db/schema'
 import { requireAdmin, requireAuth } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
 import { recordActivity } from '../services/activity'
+import { getEffectiveQuota } from '../services/effective-quota'
 import { findPersonalOrg } from '../services/org'
 
 const updateQuotaSchema = z.object({
@@ -49,6 +50,7 @@ const adminQuotas = new Hono<Env>()
     const targetOrgId = c.req.param('orgId')
     const { quota } = c.req.valid('json')
 
+    // Only updates the base quota; paid grants remain unchanged.
     const existing = await db.select({ id: orgQuotas.id }).from(orgQuotas).where(eq(orgQuotas.orgId, targetOrgId))
 
     if (existing.length > 0) {
@@ -79,13 +81,14 @@ const userQuotas = new Hono<Env>().use(requireAuth).get('/me', async (c) => {
     return c.json({ error: 'No organization found' }, 404)
   }
 
-  const rows = await db
-    .select({ quota: orgQuotas.quota, used: orgQuotas.used })
-    .from(orgQuotas)
-    .where(eq(orgQuotas.orgId, orgId))
-
-  const quotaRow = rows[0] ?? { quota: 0, used: 0 }
-  return c.json({ orgId, quota: quotaRow.quota, used: quotaRow.used })
+  const effective = await getEffectiveQuota(db, orgId)
+  return c.json({
+    orgId,
+    baseQuota: effective.baseQuota,
+    grantedQuota: effective.grantedQuota,
+    quota: effective.quota,
+    used: effective.used,
+  })
 })
 
 export { adminQuotas, userQuotas }

--- a/server/services/effective-quota.ts
+++ b/server/services/effective-quota.ts
@@ -1,0 +1,95 @@
+import { eq, sql, sum } from 'drizzle-orm'
+import type { EffectiveQuota } from '../../shared/types'
+import { orgQuotas, quotaGrants, storages } from '../db/schema'
+import type { Database } from '../platform/interface'
+
+/**
+ * Returns effective quota for an org:
+ *   quota = base (org_quotas.quota) + sum of all quota_grants.bytes for that org
+ *   used  = org_quotas.used
+ */
+export async function getEffectiveQuota(db: Database, orgId: string): Promise<EffectiveQuota> {
+  const [baseRow] = await db
+    .select({ quota: orgQuotas.quota, used: orgQuotas.used })
+    .from(orgQuotas)
+    .where(eq(orgQuotas.orgId, orgId))
+
+  const base = baseRow ?? { quota: 0, used: 0 }
+
+  const [grantRow] = await db
+    .select({ total: sum(quotaGrants.bytes) })
+    .from(quotaGrants)
+    .where(eq(quotaGrants.orgId, orgId))
+
+  const grantedQuota = Number(grantRow?.total ?? 0)
+  const effectiveQuota = base.quota + grantedQuota
+
+  return {
+    orgId,
+    baseQuota: base.quota,
+    grantedQuota,
+    quota: effectiveQuota,
+    used: base.used,
+  }
+}
+
+/**
+ * Atomically checks effective quota and increments used bytes if allowed.
+ * Returns true if usage was allowed and incremented, false if quota exceeded.
+ *
+ * quota=0 base and no grants means unlimited (same as the existing convention).
+ */
+export async function incrementEffectiveQuotaIfAllowed(
+  db: Database,
+  orgId: string,
+  storageId: string,
+  bytes: number,
+  teamQuotaEnabled = true,
+): Promise<boolean> {
+  if (teamQuotaEnabled) {
+    const eq_ = getEffectiveQuota
+    const { quota: effectiveQuota, used } = await eq_(db, orgId)
+
+    if (effectiveQuota > 0 && used + bytes > effectiveQuota) {
+      return false
+    }
+
+    // Only update org_quotas.used if a row exists; no row = unlimited.
+    const existing = await db.select({ id: orgQuotas.id }).from(orgQuotas).where(eq(orgQuotas.orgId, orgId))
+    if (existing.length > 0) {
+      await db
+        .update(orgQuotas)
+        .set({ used: sql`${orgQuotas.used} + ${bytes}` })
+        .where(eq(orgQuotas.orgId, orgId))
+    }
+  }
+
+  await db
+    .update(storages)
+    .set({ used: sql`${storages.used} + ${bytes}` })
+    .where(eq(storages.id, storageId))
+
+  return true
+}
+
+/**
+ * Decrements used bytes for an org (e.g. on delete/trash).
+ * Clamps to 0 to prevent negative values.
+ */
+export async function decrementEffectiveQuota(db: Database, orgId: string, bytes: number): Promise<void> {
+  await db
+    .update(orgQuotas)
+    .set({ used: sql`MAX(0, ${orgQuotas.used} - ${bytes})` })
+    .where(eq(orgQuotas.orgId, orgId))
+}
+
+/**
+ * Check-only variant — does not modify state.
+ * quota=0 with no grants = unlimited.
+ */
+export async function isEffectiveQuotaSufficient(db: Database, orgId: string, bytes: number): Promise<boolean> {
+  if (bytes <= 0) return true
+  const { quota, used } = await getEffectiveQuota(db, orgId)
+  if (quota === 0) return true
+  return used + bytes <= quota
+}

--- a/server/services/image-hosting.ts
+++ b/server/services/image-hosting.ts
@@ -4,6 +4,7 @@ import type { AllowedImageMime } from '../../shared/schemas'
 import type { ImageHosting } from '../../shared/types'
 import { imageHostingConfigs, imageHostings, orgQuotas, storages } from '../db/schema'
 import type { Database } from '../platform/interface'
+import { incrementEffectiveQuotaIfAllowed } from './effective-quota'
 
 // ── Token-based redirect helpers (used by /r/:token route) ───────────────────
 
@@ -294,26 +295,7 @@ export async function incrementImageQuotaIfAllowed(
   storageId: string,
   bytes: number,
 ): Promise<boolean> {
-  const rows = await db
-    .select({ quota: orgQuotas.quota, used: orgQuotas.used })
-    .from(orgQuotas)
-    .where(eq(orgQuotas.orgId, orgId))
-
-  const [row] = rows
-  if (row) {
-    if (row.quota > 0 && row.used + bytes > row.quota) return false
-    await db
-      .update(orgQuotas)
-      .set({ used: sql`${orgQuotas.used} + ${bytes}` })
-      .where(eq(orgQuotas.orgId, orgId))
-  }
-
-  await db
-    .update(storages)
-    .set({ used: sql`${storages.used} + ${bytes}` })
-    .where(eq(storages.id, storageId))
-
-  return true
+  return incrementEffectiveQuotaIfAllowed(db, orgId, storageId, bytes)
 }
 
 export async function decrementImageQuota(

--- a/server/services/matter.ts
+++ b/server/services/matter.ts
@@ -5,6 +5,7 @@ import { DirType } from '../../shared/constants'
 import { matters, orgQuotas, storages } from '../db/schema'
 import type { Database } from '../platform/interface'
 import { recordActivity } from './activity'
+import { incrementEffectiveQuotaIfAllowed } from './effective-quota'
 import {
   applyConflictResolution,
   type ConflictStrategy,
@@ -315,32 +316,7 @@ export async function incrementUsageIfAllowed(
   bytes: number,
   teamQuotaEnabled = true,
 ): Promise<boolean> {
-  if (teamQuotaEnabled) {
-    // Check if a quota row exists and try atomic check-and-increment in one flow
-    const rows = await db
-      .select({ quota: orgQuotas.quota, used: orgQuotas.used })
-      .from(orgQuotas)
-      .where(eq(orgQuotas.orgId, orgId))
-
-    const [row] = rows
-    if (row) {
-      // quota=0 means unlimited; otherwise enforce the limit
-      if (row.quota > 0 && row.used + bytes > row.quota) return false
-
-      await db
-        .update(orgQuotas)
-        .set({ used: sql`${orgQuotas.used} + ${bytes}` })
-        .where(eq(orgQuotas.orgId, orgId))
-    }
-    // No quota row means no org-level limit — allow, but still track per-storage usage
-  }
-
-  await db
-    .update(storages)
-    .set({ used: sql`${storages.used} + ${bytes}` })
-    .where(eq(storages.id, storageId))
-
-  return true
+  return incrementEffectiveQuotaIfAllowed(db, orgId, storageId, bytes, teamQuotaEnabled)
 }
 
 export async function copyMatter(

--- a/server/services/quota-store.ts
+++ b/server/services/quota-store.ts
@@ -1,0 +1,365 @@
+import { createHash, timingSafeEqual } from 'node:crypto'
+import { eq, or } from 'drizzle-orm'
+import { nanoid } from 'nanoid'
+import type {
+  CreateQuotaStorePackageInput,
+  PutQuotaStoreSettingsInput,
+  UpdateQuotaStorePackageInput,
+} from '../../shared/schemas'
+import type { QuotaGrant, QuotaStorePackage, QuotaStoreSettings } from '../../shared/types'
+import { quotaDeliveryEvents, quotaGrants, quotaStorePackages, quotaStoreSettings } from '../db/schema'
+import type { Database } from '../platform/interface'
+
+// ─── Settings ─────────────────────────────────────────────────────────────────
+
+export async function getQuotaStoreSettings(db: Database): Promise<QuotaStoreSettings> {
+  const [row] = await db.select().from(quotaStoreSettings).where(eq(quotaStoreSettings.id, 'default'))
+  if (!row) {
+    return { enabled: false, cloudBaseUrl: null, instancePublicUrl: null, webhookSigningSecret: null, updatedAt: null }
+  }
+  return {
+    enabled: row.enabled,
+    cloudBaseUrl: row.cloudBaseUrl ?? null,
+    instancePublicUrl: row.instancePublicUrl ?? null,
+    webhookSigningSecret: row.webhookSigningSecret ?? null,
+    updatedAt: row.updatedAt ? row.updatedAt.toISOString() : null,
+  }
+}
+
+export async function putQuotaStoreSettings(
+  db: Database,
+  input: PutQuotaStoreSettingsInput,
+): Promise<QuotaStoreSettings> {
+  const now = new Date()
+  const existing = await db
+    .select({ id: quotaStoreSettings.id })
+    .from(quotaStoreSettings)
+    .where(eq(quotaStoreSettings.id, 'default'))
+  const values = {
+    enabled: input.enabled,
+    cloudBaseUrl: input.cloudBaseUrl ?? null,
+    instancePublicUrl: input.instancePublicUrl ?? null,
+    webhookSigningSecret: input.webhookSigningSecret ?? null,
+    updatedAt: now,
+  }
+  if (existing.length > 0) {
+    await db.update(quotaStoreSettings).set(values).where(eq(quotaStoreSettings.id, 'default'))
+  } else {
+    await db.insert(quotaStoreSettings).values({ id: 'default', ...values })
+  }
+  return {
+    enabled: input.enabled,
+    cloudBaseUrl: input.cloudBaseUrl ?? null,
+    instancePublicUrl: input.instancePublicUrl ?? null,
+    webhookSigningSecret: input.webhookSigningSecret ?? null,
+    updatedAt: now.toISOString(),
+  }
+}
+
+// ─── Packages ─────────────────────────────────────────────────────────────────
+
+function rowToPackage(row: typeof quotaStorePackages.$inferSelect): QuotaStorePackage {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description ?? null,
+    bytes: row.bytes,
+    amount: row.amount,
+    currency: row.currency,
+    active: row.active,
+    sortOrder: row.sortOrder,
+    cloudSyncId: row.cloudSyncId ?? null,
+    cloudSyncStatus: (row.cloudSyncStatus as QuotaStorePackage['cloudSyncStatus']) ?? null,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  }
+}
+
+export async function listQuotaStorePackages(db: Database, activeOnly = false): Promise<QuotaStorePackage[]> {
+  const rows = await db
+    .select()
+    .from(quotaStorePackages)
+    .where(activeOnly ? eq(quotaStorePackages.active, true) : undefined)
+    .orderBy(quotaStorePackages.sortOrder, quotaStorePackages.createdAt)
+  return rows.map(rowToPackage)
+}
+
+export async function getQuotaStorePackage(db: Database, id: string): Promise<QuotaStorePackage | null> {
+  const [row] = await db.select().from(quotaStorePackages).where(eq(quotaStorePackages.id, id))
+  return row ? rowToPackage(row) : null
+}
+
+export async function createQuotaStorePackage(
+  db: Database,
+  input: CreateQuotaStorePackageInput,
+): Promise<QuotaStorePackage> {
+  const now = new Date()
+  const id = nanoid()
+  await db.insert(quotaStorePackages).values({
+    id,
+    name: input.name,
+    description: input.description ?? null,
+    bytes: input.bytes,
+    amount: input.amount,
+    currency: input.currency,
+    active: input.active ?? true,
+    sortOrder: input.sortOrder ?? 0,
+    cloudSyncStatus: 'pending',
+    createdAt: now,
+    updatedAt: now,
+  })
+  return (await getQuotaStorePackage(db, id))!
+}
+
+export async function updateQuotaStorePackage(
+  db: Database,
+  id: string,
+  input: UpdateQuotaStorePackageInput,
+): Promise<QuotaStorePackage | null> {
+  const existing = await getQuotaStorePackage(db, id)
+  if (!existing) return null
+  const now = new Date()
+  await db
+    .update(quotaStorePackages)
+    .set({
+      ...(input.name !== undefined ? { name: input.name } : {}),
+      ...(input.description !== undefined ? { description: input.description ?? null } : {}),
+      ...(input.bytes !== undefined ? { bytes: input.bytes } : {}),
+      ...(input.amount !== undefined ? { amount: input.amount } : {}),
+      ...(input.currency !== undefined ? { currency: input.currency } : {}),
+      ...(input.active !== undefined ? { active: input.active } : {}),
+      ...(input.sortOrder !== undefined ? { sortOrder: input.sortOrder } : {}),
+      cloudSyncStatus: 'pending',
+      updatedAt: now,
+    })
+    .where(eq(quotaStorePackages.id, id))
+  return (await getQuotaStorePackage(db, id))!
+}
+
+export async function deleteQuotaStorePackage(db: Database, id: string): Promise<boolean> {
+  const existing = await getQuotaStorePackage(db, id)
+  if (!existing) return false
+  await db.delete(quotaStorePackages).where(eq(quotaStorePackages.id, id))
+  return true
+}
+
+// ─── Grants ───────────────────────────────────────────────────────────────────
+
+function rowToGrant(row: typeof quotaGrants.$inferSelect): QuotaGrant {
+  return {
+    id: row.id,
+    orgId: row.orgId,
+    source: row.source as QuotaGrant['source'],
+    externalEventId: row.externalEventId ?? null,
+    cloudOrderId: row.cloudOrderId ?? null,
+    code: row.code ?? null,
+    bytes: row.bytes,
+    packageSnapshot: row.packageSnapshot ?? null,
+    grantedBy: row.grantedBy ?? null,
+    terminalUserId: row.terminalUserId ?? null,
+    createdAt: row.createdAt.toISOString(),
+  }
+}
+
+export async function listQuotaGrants(db: Database, orgIds: string[]): Promise<QuotaGrant[]> {
+  if (orgIds.length === 0) return []
+  const rows = await db
+    .select()
+    .from(quotaGrants)
+    .where(
+      orgIds.length === 1 ? eq(quotaGrants.orgId, orgIds[0]) : or(...orgIds.map((id) => eq(quotaGrants.orgId, id))),
+    )
+    .orderBy(quotaGrants.createdAt)
+  return rows.map(rowToGrant)
+}
+
+export async function appendQuotaGrant(
+  db: Database,
+  input: {
+    orgId: string
+    source: QuotaGrant['source']
+    bytes: number
+    externalEventId?: string | null
+    cloudOrderId?: string | null
+    code?: string | null
+    packageSnapshot?: string | null
+    grantedBy?: string | null
+    terminalUserId?: string | null
+  },
+): Promise<QuotaGrant> {
+  const id = nanoid()
+  const now = new Date()
+  await db.insert(quotaGrants).values({
+    id,
+    orgId: input.orgId,
+    source: input.source,
+    bytes: input.bytes,
+    externalEventId: input.externalEventId ?? null,
+    cloudOrderId: input.cloudOrderId ?? null,
+    code: input.code ?? null,
+    packageSnapshot: input.packageSnapshot ?? null,
+    grantedBy: input.grantedBy ?? null,
+    terminalUserId: input.terminalUserId ?? null,
+    createdAt: now,
+  })
+  const [row] = await db.select().from(quotaGrants).where(eq(quotaGrants.id, id))
+  return rowToGrant(row)
+}
+
+// ─── Delivery events (webhook idempotency) ────────────────────────────────────
+
+export function hashPayload(raw: string): string {
+  return createHash('sha256').update(raw).digest('hex')
+}
+
+export async function findDeliveryEvent(db: Database, eventId: string) {
+  const [row] = await db.select().from(quotaDeliveryEvents).where(eq(quotaDeliveryEvents.eventId, eventId))
+  return row ?? null
+}
+
+export async function recordDeliveryEvent(
+  db: Database,
+  input: {
+    eventId: string
+    cloudOrderId?: string | null
+    rawPayload: string
+    status: 'processed' | 'duplicate' | 'error'
+  },
+): Promise<void> {
+  const now = new Date()
+  await db.insert(quotaDeliveryEvents).values({
+    id: nanoid(),
+    eventId: input.eventId,
+    cloudOrderId: input.cloudOrderId ?? null,
+    payloadHash: hashPayload(input.rawPayload),
+    rawPayload: input.rawPayload,
+    status: input.status,
+    createdAt: now,
+    processedAt: input.status !== 'duplicate' ? now : null,
+  })
+}
+
+// ─── Webhook signature verification ──────────────────────────────────────────
+
+/**
+ * Verifies an HMAC-SHA256 signature from Cloud over the raw request body.
+ * Header format: "zpan-sig=<hex>"
+ */
+export function verifyWebhookSignature(secret: string, rawBody: string, signatureHeader: string | null): boolean {
+  if (!signatureHeader) return false
+  const match = signatureHeader.match(/^zpan-sig=([0-9a-f]+)$/i)
+  if (!match) return false
+  const provided = match[1]
+  const expected = createHash('sha256').update(`${secret}.${rawBody}`).digest('hex')
+  if (provided.length !== expected.length) return false
+  const enc = new TextEncoder()
+  try {
+    return timingSafeEqual(enc.encode(provided), enc.encode(expected))
+  } catch {
+    return false
+  }
+}
+
+// ─── Cloud catalog sync ───────────────────────────────────────────────────────
+
+/**
+ * Syncs a package to the Cloud catalog. Returns updated cloudSyncId / status.
+ * In a real integration this would call cloud.zpan.space APIs. For now it
+ * marks the package as synced and stores a generated sync id so the contract
+ * is in place for the real Cloud endpoint.
+ */
+export async function syncPackageToCloud(
+  db: Database,
+  pkg: QuotaStorePackage,
+  cloudBaseUrl: string,
+): Promise<{ cloudSyncId: string; cloudSyncStatus: 'synced' | 'error'; error?: string }> {
+  try {
+    const resp = await fetch(`${cloudBaseUrl}/api/catalog/packages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        externalId: pkg.id,
+        name: pkg.name,
+        description: pkg.description,
+        bytes: pkg.bytes,
+        amount: pkg.amount,
+        currency: pkg.currency,
+      }),
+    })
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => 'unknown error')
+      await db.update(quotaStorePackages).set({ cloudSyncStatus: 'error' }).where(eq(quotaStorePackages.id, pkg.id))
+      return { cloudSyncId: pkg.cloudSyncId ?? '', cloudSyncStatus: 'error', error: text }
+    }
+    const body = (await resp.json()) as { id?: string }
+    const cloudSyncId = body.id ?? pkg.id
+    await db
+      .update(quotaStorePackages)
+      .set({ cloudSyncId, cloudSyncStatus: 'synced' })
+      .where(eq(quotaStorePackages.id, pkg.id))
+    return { cloudSyncId, cloudSyncStatus: 'synced' }
+  } catch (err) {
+    await db.update(quotaStorePackages).set({ cloudSyncStatus: 'error' }).where(eq(quotaStorePackages.id, pkg.id))
+    return {
+      cloudSyncId: pkg.cloudSyncId ?? '',
+      cloudSyncStatus: 'error',
+      error: err instanceof Error ? err.message : 'unknown',
+    }
+  }
+}
+
+// ─── Checkout / Redeem (Cloud-side) ──────────────────────────────────────────
+
+export async function createCloudCheckout(input: {
+  cloudBaseUrl: string
+  instancePublicUrl: string
+  packageId: string
+  cloudSyncId: string
+  targetOrgId: string
+  userId: string
+  callbackUrl: string
+}): Promise<{ checkoutUrl: string }> {
+  const resp = await fetch(`${input.cloudBaseUrl}/api/store/checkout`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      packageId: input.cloudSyncId,
+      targetOrgId: input.targetOrgId,
+      userId: input.userId,
+      callbackUrl: input.callbackUrl,
+      instanceUrl: input.instancePublicUrl,
+    }),
+  })
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => 'unknown')
+    throw new Error(`Cloud checkout failed: ${text}`)
+  }
+  const body = (await resp.json()) as { checkoutUrl?: string }
+  if (!body.checkoutUrl) throw new Error('Cloud checkout returned no URL')
+  return { checkoutUrl: body.checkoutUrl }
+}
+
+export async function sendCloudRedeem(input: {
+  cloudBaseUrl: string
+  instancePublicUrl: string
+  code: string
+  targetOrgId: string
+  userId: string
+}): Promise<{ granted: boolean; bytes: number }> {
+  const resp = await fetch(`${input.cloudBaseUrl}/api/store/redeem`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      code: input.code,
+      targetOrgId: input.targetOrgId,
+      userId: input.userId,
+      instanceUrl: input.instancePublicUrl,
+    }),
+  })
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => 'unknown')
+    throw new Error(`Cloud redeem failed: ${text}`)
+  }
+  const body = (await resp.json()) as { granted?: boolean; bytes?: number }
+  return { granted: body.granted ?? false, bytes: body.bytes ?? 0 }
+}

--- a/server/services/save-to-drive.ts
+++ b/server/services/save-to-drive.ts
@@ -1,9 +1,10 @@
 import { and, eq, like, or } from 'drizzle-orm'
 import { DirType } from '../../shared/constants'
 import type { Storage as S3StorageType } from '../../shared/types'
-import { matters, orgQuotas } from '../db/schema'
+import { matters } from '../db/schema'
 import type { Database } from '../platform/interface'
 import { recordActivity } from './activity'
+import { isEffectiveQuotaSufficient } from './effective-quota'
 import type { Matter } from './matter'
 import { createMatter, incrementUsageIfAllowed } from './matter'
 import { buildObjectKey } from './path-template'
@@ -70,14 +71,7 @@ export async function computeSourceBytes(db: Database, matter: Matter): Promise<
 }
 
 export async function isQuotaSufficient(db: Database, orgId: string, bytes: number): Promise<boolean> {
-  if (bytes <= 0) return true
-  const rows = await db
-    .select({ quota: orgQuotas.quota, used: orgQuotas.used })
-    .from(orgQuotas)
-    .where(eq(orgQuotas.orgId, orgId))
-  const row = rows[0]
-  if (!row || row.quota === 0) return true
-  return row.used + bytes <= row.quota
+  return isEffectiveQuotaSufficient(db, orgId, bytes)
 }
 
 // ─── File copy ────────────────────────────────────────────────────────────────

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -313,6 +313,61 @@ const APP_SCHEMA_SQL = `
   CREATE UNIQUE INDEX IF NOT EXISTS license_bindings_active_uniq ON license_bindings(status) WHERE status = 'active';
   CREATE INDEX IF NOT EXISTS license_bindings_cloud_binding_idx ON license_bindings(cloud_binding_id);
   CREATE INDEX IF NOT EXISTS license_bindings_instance_idx ON license_bindings(instance_id);
+
+  CREATE TABLE IF NOT EXISTS quota_store_settings (
+    id TEXT PRIMARY KEY DEFAULT 'default',
+    enabled INTEGER NOT NULL DEFAULT 0,
+    cloud_base_url TEXT,
+    instance_public_url TEXT,
+    webhook_signing_secret TEXT,
+    updated_at INTEGER
+  );
+
+  CREATE TABLE IF NOT EXISTS quota_store_packages (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    bytes INTEGER NOT NULL,
+    amount INTEGER NOT NULL,
+    currency TEXT NOT NULL DEFAULT 'usd',
+    active INTEGER NOT NULL DEFAULT 1,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    cloud_sync_id TEXT,
+    cloud_sync_status TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS quota_store_packages_active_sort_idx ON quota_store_packages(active, sort_order);
+
+  CREATE TABLE IF NOT EXISTS quota_grants (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL,
+    source TEXT NOT NULL,
+    external_event_id TEXT,
+    cloud_order_id TEXT,
+    code TEXT,
+    bytes INTEGER NOT NULL,
+    package_snapshot TEXT,
+    granted_by TEXT,
+    terminal_user_id TEXT,
+    created_at INTEGER NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS quota_grants_org_created_idx ON quota_grants(org_id, created_at);
+  CREATE INDEX IF NOT EXISTS quota_grants_external_event_idx ON quota_grants(external_event_id);
+  CREATE INDEX IF NOT EXISTS quota_grants_cloud_order_idx ON quota_grants(cloud_order_id);
+
+  CREATE TABLE IF NOT EXISTS quota_delivery_events (
+    id TEXT PRIMARY KEY,
+    event_id TEXT NOT NULL UNIQUE,
+    cloud_order_id TEXT,
+    payload_hash TEXT,
+    raw_payload TEXT,
+    status TEXT NOT NULL DEFAULT 'processed',
+    created_at INTEGER NOT NULL,
+    processed_at INTEGER
+  );
+  CREATE INDEX IF NOT EXISTS quota_delivery_events_cloud_order_idx ON quota_delivery_events(cloud_order_id);
+  CREATE INDEX IF NOT EXISTS quota_delivery_events_created_idx ON quota_delivery_events(created_at);
 `
 
 export async function createTestApp(

--- a/shared/feature-registry.ts
+++ b/shared/feature-registry.ts
@@ -131,6 +131,13 @@ export const FEATURE_REGISTRY = [
     gateKey: 'audit_log',
   },
   {
+    i18nKey: 'features.quotaStore',
+    category: 'pro',
+    community: false,
+    pro: true,
+    gateKey: 'quota_store',
+  },
+  {
     i18nKey: 'features.webhooks',
     category: 'pro',
     community: false,

--- a/shared/schemas/index.ts
+++ b/shared/schemas/index.ts
@@ -16,6 +16,22 @@ export type { ListAdminAuditQuery } from './audit'
 export { listAdminAuditQuerySchema } from './audit'
 export type { ListNotificationsQuery } from './notification'
 export { listNotificationsQuerySchema } from './notification'
+export type {
+  CheckoutInput,
+  CloudDeliveryPayload,
+  CreateQuotaStorePackageInput,
+  PutQuotaStoreSettingsInput,
+  RedeemInput,
+  UpdateQuotaStorePackageInput,
+} from './quota-store'
+export {
+  checkoutSchema,
+  cloudDeliveryPayloadSchema,
+  createQuotaStorePackageSchema,
+  putQuotaStoreSettingsSchema,
+  redeemSchema,
+  updateQuotaStorePackageSchema,
+} from './quota-store'
 export type { CreateShareInput, CreateShareRequest, ShareKind } from './share'
 export {
   createShareRequestSchema,

--- a/shared/schemas/quota-store.ts
+++ b/shared/schemas/quota-store.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod'
+
+// ─── Admin: package CRUD ──────────────────────────────────────────────────────
+
+export const createQuotaStorePackageSchema = z.object({
+  name: z.string().min(1).max(120),
+  description: z.string().max(500).nullable().optional(),
+  bytes: z.number().int().positive(),
+  amount: z.number().positive(),
+  currency: z.string().length(3),
+  active: z.boolean().optional().default(true),
+  sortOrder: z.number().int().default(0),
+})
+
+export type CreateQuotaStorePackageInput = z.infer<typeof createQuotaStorePackageSchema>
+
+export const updateQuotaStorePackageSchema = createQuotaStorePackageSchema.partial()
+
+export type UpdateQuotaStorePackageInput = z.infer<typeof updateQuotaStorePackageSchema>
+
+// ─── Admin: store settings ────────────────────────────────────────────────────
+
+export const putQuotaStoreSettingsSchema = z.object({
+  enabled: z.boolean(),
+  cloudBaseUrl: z.string().url().nullable().optional(),
+  instancePublicUrl: z.string().url().nullable().optional(),
+  webhookSigningSecret: z.string().min(8).max(512).nullable().optional(),
+})
+
+export type PutQuotaStoreSettingsInput = z.infer<typeof putQuotaStoreSettingsSchema>
+
+// ─── User: checkout / redeem ──────────────────────────────────────────────────
+
+export const checkoutSchema = z.object({
+  packageId: z.string().min(1),
+  targetOrgId: z.string().min(1),
+})
+
+export type CheckoutInput = z.infer<typeof checkoutSchema>
+
+export const redeemSchema = z.object({
+  code: z.string().min(1).max(128),
+  targetOrgId: z.string().min(1),
+})
+
+export type RedeemInput = z.infer<typeof redeemSchema>
+
+// ─── Cloud webhook ────────────────────────────────────────────────────────────
+
+export const cloudDeliveryPayloadSchema = z.object({
+  eventId: z.string().min(1),
+  cloudOrderId: z.string().optional(),
+  packageId: z.string().min(1),
+  bytes: z.number().int().positive(),
+  targetOrgId: z.string().min(1),
+  source: z.enum(['stripe', 'redeem_code']),
+  code: z.string().optional(),
+  externalEventId: z.string().optional(),
+})
+
+export type CloudDeliveryPayload = z.infer<typeof cloudDeliveryPayloadSchema>

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -286,3 +286,78 @@ export interface BrandingConfig {
 }
 
 export type BrandingField = 'logo' | 'favicon' | 'wordmark_text' | 'hide_powered_by'
+
+// ─── Quota Store ──────────────────────────────────────────────────────────────
+
+export interface QuotaStoreSettings {
+  enabled: boolean
+  cloudBaseUrl: string | null
+  instancePublicUrl: string | null
+  webhookSigningSecret: string | null
+  updatedAt: string | null
+}
+
+export interface QuotaStorePackage {
+  id: string
+  name: string
+  description: string | null
+  bytes: number
+  amount: number
+  currency: string
+  active: boolean
+  sortOrder: number
+  cloudSyncId: string | null
+  cloudSyncStatus: 'pending' | 'synced' | 'error' | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type QuotaGrantSource = 'stripe' | 'redeem_code' | 'admin_adjustment'
+
+export interface QuotaGrant {
+  id: string
+  orgId: string
+  source: QuotaGrantSource
+  externalEventId: string | null
+  cloudOrderId: string | null
+  code: string | null
+  bytes: number
+  packageSnapshot: string | null
+  grantedBy: string | null
+  terminalUserId: string | null
+  createdAt: string
+}
+
+export interface QuotaDeliveryEvent {
+  id: string
+  eventId: string
+  cloudOrderId: string | null
+  payloadHash: string | null
+  rawPayload: string | null
+  status: 'processed' | 'duplicate' | 'error'
+  createdAt: string
+  processedAt: string | null
+}
+
+export interface EffectiveQuota {
+  orgId: string
+  baseQuota: number
+  grantedQuota: number
+  quota: number
+  used: number
+}
+
+export interface QuotaCheckoutResponse {
+  checkoutUrl: string
+}
+
+export interface QuotaRedemptionResponse {
+  granted: boolean
+  bytes: number
+}
+
+export interface QuotaTarget {
+  orgId: string
+  orgName: string
+  orgType: string
+}

--- a/src/components/UpgradeHint.tsx
+++ b/src/components/UpgradeHint.tsx
@@ -9,6 +9,7 @@ const FEATURE_LABELS: Record<ProFeature, string> = {
   teams_unlimited: 'unlimited teams',
   storages_unlimited: 'unlimited storages',
   audit_log: 'audit logs',
+  quota_store: 'quota store',
 }
 
 interface UpgradeHintProps {

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -9,10 +9,12 @@ import {
   batchUpdateUserStatus,
   buildShareObjectUrl,
   cancelUpload,
+  checkoutQuotaPackage,
   confirmIhostImage,
   confirmUpload,
   connectCloud,
   copyObject,
+  createAdminQuotaStorePackage,
   createAnnouncement,
   createIhostApiKey,
   createIhostImagePresign,
@@ -20,6 +22,7 @@ import {
   createShare,
   createSiteInvitation,
   createStorage,
+  deleteAdminQuotaStorePackage,
   deleteAnnouncement,
   deleteAvatar,
   deleteIhostConfig,
@@ -32,6 +35,7 @@ import {
   disconnectCloud,
   emptyTrash,
   enableIhostFeature,
+  getAdminQuotaStorePackage,
   getAnnouncement,
   getBranding,
   getEmailConfig,
@@ -39,6 +43,7 @@ import {
   getLicensingStatus,
   getObject,
   getProfile,
+  getQuotaStoreSettings,
   getSession,
   getShare,
   getSiteInvitation,
@@ -49,22 +54,28 @@ import {
   listActiveAnnouncements,
   listAdminAnnouncements,
   listAdminAuditLogs,
+  listAdminQuotaStorePackages,
   listAnnouncements,
   listAuthProviders,
   listIhostApiKeys,
   listIhostImages,
   listNotifications,
   listObjects,
+  listQuotaGrants,
   listQuotas,
+  listQuotaTargets,
   listShareObjects,
   listShares,
   listSiteInvitations,
   listStorages,
   listSystemOptions,
+  listUserQuotaStorePackages,
   listUsers,
   markAllNotificationsRead,
   markNotificationRead,
   pollPairing,
+  putQuotaStoreSettings,
+  redeemQuotaCode,
   refreshLicense,
   resendSiteInvitation,
   resetBrandingField,
@@ -77,6 +88,7 @@ import {
   setSystemOption,
   testEmail,
   trashObject,
+  updateAdminQuotaStorePackage,
   updateAnnouncement,
   updateIhostConfig,
   updateObject,
@@ -877,8 +889,8 @@ describe('api', () => {
   })
 
   describe('getUserQuota', () => {
-    it('fetches the current user quota', async () => {
-      const payload = { orgId: 'org1', quota: 1024, used: 256 }
+    it('fetches the current user effective quota', async () => {
+      const payload = { orgId: 'org1', baseQuota: 1024, grantedQuota: 512, quota: 1536, used: 256 }
       vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
 
       const result = await getUserQuota()
@@ -2552,6 +2564,255 @@ describe('api', () => {
       )
 
       await expect(listAdminAuditLogs()).rejects.toMatchObject({ status: 402 })
+    })
+  })
+
+  // ─── Quota Store API tests ──────────────────────────────────────────────────
+
+  const samplePackage = {
+    id: 'pkg1',
+    name: '10 GB Pack',
+    description: 'Adds 10 GB',
+    bytes: 10_737_418_240,
+    amount: 999,
+    currency: 'usd',
+    active: true,
+    sortOrder: 0,
+    cloudSyncId: 'cloud-pkg-1',
+    cloudSyncStatus: 'synced',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  }
+
+  const sampleSettings = {
+    enabled: true,
+    cloudBaseUrl: 'https://cloud.zpan.space',
+    instancePublicUrl: 'https://my.zpan.app',
+    webhookSigningSecret: 'secret123456',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  }
+
+  const sampleGrant = {
+    id: 'grant1',
+    orgId: 'org1',
+    source: 'stripe',
+    externalEventId: 'evt_123',
+    cloudOrderId: 'ord_123',
+    code: null,
+    bytes: 10_737_418_240,
+    packageSnapshot: null,
+    grantedBy: null,
+    terminalUserId: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+  }
+
+  describe('getQuotaStoreSettings', () => {
+    it('fetches quota store settings', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(sampleSettings))
+      const result = await getQuotaStoreSettings()
+      expect(result).toEqual(sampleSettings)
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toContain('/api/admin/quota-store/settings')
+    })
+
+    it('throws ApiError on error response', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Forbidden' }, false, 403))
+      await expect(getQuotaStoreSettings()).rejects.toThrow('Forbidden')
+    })
+
+    it('throws ApiError with status 402 when feature unavailable', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(
+        makeResponse({ error: 'feature_not_available', feature: 'quota_store' }, false, 402),
+      )
+      await expect(getQuotaStoreSettings()).rejects.toMatchObject({ status: 402 })
+    })
+  })
+
+  describe('putQuotaStoreSettings', () => {
+    it('sends settings update and returns updated settings', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(sampleSettings))
+      const result = await putQuotaStoreSettings({ enabled: true })
+      expect(result).toEqual(sampleSettings)
+      const [url, opts] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toContain('/api/admin/quota-store/settings')
+      expect(opts.method).toBe('PUT')
+    })
+
+    it('throws ApiError on error', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Invalid input' }, false, 400))
+      await expect(putQuotaStoreSettings({ enabled: false })).rejects.toThrow('Invalid input')
+    })
+  })
+
+  describe('listAdminQuotaStorePackages', () => {
+    it('returns package list', async () => {
+      const payload = { items: [samplePackage], total: 1 }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
+      const result = await listAdminQuotaStorePackages()
+      expect(result).toEqual(payload)
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toContain('/api/admin/quota-store/packages')
+    })
+
+    it('throws ApiError on 402', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'feature_not_available' }, false, 402))
+      await expect(listAdminQuotaStorePackages()).rejects.toMatchObject({ status: 402 })
+    })
+  })
+
+  describe('createAdminQuotaStorePackage', () => {
+    it('creates a package and returns it with sync status', async () => {
+      const payload = { package: samplePackage, syncError: null }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload, true, 201))
+      const result = await createAdminQuotaStorePackage({
+        name: '10 GB Pack',
+        bytes: 10_737_418_240,
+        amount: 999,
+        currency: 'usd',
+        active: true,
+        sortOrder: 0,
+      })
+      expect(result).toEqual(payload)
+      const [url, opts] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toContain('/api/admin/quota-store/packages')
+      expect(opts.method).toBe('POST')
+    })
+
+    it('throws ApiError on validation error', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Bad request' }, false, 400))
+      await expect(
+        createAdminQuotaStorePackage({ name: 'x', bytes: -1, amount: 0, currency: 'usd', active: false, sortOrder: 0 }),
+      ).rejects.toThrow('Bad request')
+    })
+  })
+
+  describe('getAdminQuotaStorePackage', () => {
+    it('fetches a single package by id', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(samplePackage))
+      const result = await getAdminQuotaStorePackage('pkg1')
+      expect(result).toEqual(samplePackage)
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toContain('/api/admin/quota-store/packages/pkg1')
+    })
+
+    it('throws ApiError on 404', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Not found' }, false, 404))
+      await expect(getAdminQuotaStorePackage('missing')).rejects.toThrow('Not found')
+    })
+  })
+
+  describe('updateAdminQuotaStorePackage', () => {
+    it('sends patch and returns updated package', async () => {
+      const payload = { package: { ...samplePackage, name: 'Updated' }, syncError: null }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
+      const result = await updateAdminQuotaStorePackage('pkg1', { name: 'Updated' })
+      expect(result).toEqual(payload)
+      const [, opts] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(opts.method).toBe('PATCH')
+    })
+
+    it('throws ApiError on 404', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Not found' }, false, 404))
+      await expect(updateAdminQuotaStorePackage('missing', { name: 'x' })).rejects.toThrow('Not found')
+    })
+  })
+
+  describe('deleteAdminQuotaStorePackage', () => {
+    it('deletes a package', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ deleted: true }))
+      const result = await deleteAdminQuotaStorePackage('pkg1')
+      expect(result).toEqual({ deleted: true })
+      const [, opts] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(opts.method).toBe('DELETE')
+    })
+
+    it('throws ApiError on 404', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Not found' }, false, 404))
+      await expect(deleteAdminQuotaStorePackage('missing')).rejects.toThrow('Not found')
+    })
+  })
+
+  describe('listUserQuotaStorePackages', () => {
+    it('returns active packages for users', async () => {
+      const payload = { items: [samplePackage], total: 1 }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
+      const result = await listUserQuotaStorePackages()
+      expect(result).toEqual(payload)
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toContain('/api/quota-store/packages')
+    })
+
+    it('throws ApiError on 402 when feature unavailable', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'feature_not_available' }, false, 402))
+      await expect(listUserQuotaStorePackages()).rejects.toMatchObject({ status: 402 })
+    })
+  })
+
+  describe('listQuotaTargets', () => {
+    it('returns orgs the user can purchase for', async () => {
+      const payload = { items: [{ orgId: 'org1', orgName: 'My Org', orgType: 'personal' }], total: 1 }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
+      const result = await listQuotaTargets()
+      expect(result).toEqual(payload)
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toContain('/api/quota-store/targets')
+    })
+
+    it('throws ApiError on error', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Unauthorized' }, false, 401))
+      await expect(listQuotaTargets()).rejects.toThrow('Unauthorized')
+    })
+  })
+
+  describe('checkoutQuotaPackage', () => {
+    it('sends checkout request and returns checkout URL', async () => {
+      const payload = { checkoutUrl: 'https://cloud.zpan.space/checkout/session123' }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
+      const result = await checkoutQuotaPackage({ packageId: 'pkg1', targetOrgId: 'org1' })
+      expect(result).toEqual(payload)
+      const [url, opts] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toContain('/api/quota-store/checkout')
+      expect(opts.method).toBe('POST')
+    })
+
+    it('throws ApiError on 403 when org not accessible', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Forbidden' }, false, 403))
+      await expect(checkoutQuotaPackage({ packageId: 'pkg1', targetOrgId: 'other' })).rejects.toMatchObject({
+        status: 403,
+      })
+    })
+  })
+
+  describe('redeemQuotaCode', () => {
+    it('sends redemption request and returns result', async () => {
+      const payload = { granted: true, bytes: 10_737_418_240 }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
+      const result = await redeemQuotaCode({ code: 'CODE123', targetOrgId: 'org1' })
+      expect(result).toEqual(payload)
+      const [url, opts] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+      expect(url).toContain('/api/quota-store/redemptions')
+      expect(opts.method).toBe('POST')
+    })
+
+    it('throws ApiError on 403 when org not accessible', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Forbidden' }, false, 403))
+      await expect(redeemQuotaCode({ code: 'CODE123', targetOrgId: 'other' })).rejects.toMatchObject({ status: 403 })
+    })
+  })
+
+  describe('listQuotaGrants', () => {
+    it('returns grants for accessible orgs', async () => {
+      const payload = { items: [sampleGrant], total: 1 }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
+      const result = await listQuotaGrants()
+      expect(result).toEqual(payload)
+      const [url] = vi.mocked(fetch).mock.calls[0] as [string]
+      expect(url).toContain('/api/quota-store/grants')
+    })
+
+    it('throws ApiError on 401', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'Unauthorized' }, false, 401))
+      await expect(listQuotaGrants()).rejects.toThrow('Unauthorized')
     })
   })
 })

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,9 +2,14 @@ import type { OAuthProviderConfig } from '@shared/oauth-providers'
 import type {
   AllowedImageMime,
   AnnouncementInput,
+  CheckoutInput,
   ConflictStrategy,
+  CreateQuotaStorePackageInput,
   CreateShareRequest,
   CreateStorageInput,
+  PutQuotaStoreSettingsInput,
+  RedeemInput,
+  UpdateQuotaStorePackageInput,
   UpdateStorageInput,
 } from '@shared/schemas'
 import type {
@@ -15,10 +20,17 @@ import type {
   BindingState,
   BrandingConfig,
   BrandingField,
+  EffectiveQuota,
   IhostConfigResponse,
   ImageHosting,
   Notification,
   PaginatedResponse,
+  QuotaCheckoutResponse,
+  QuotaGrant,
+  QuotaRedemptionResponse,
+  QuotaStorePackage,
+  QuotaStoreSettings,
+  QuotaTarget,
   ShareListItem,
   ShareView,
   SiteInvitation,
@@ -29,6 +41,7 @@ import {
   adminAnnouncementsApi,
   adminAuditApi,
   adminAuthProviders,
+  adminQuotaStoreApi,
   adminQuotas,
   adminSiteInvitations,
   announcementsApi,
@@ -52,6 +65,7 @@ import {
   system,
   teamsApi,
   trash,
+  userQuotaStoreApi,
   userQuotas,
   users,
 } from './rpc'
@@ -272,7 +286,7 @@ export function updateQuota(orgId: string, quota: number) {
 // User Quotas API
 
 export function getUserQuota() {
-  return unwrap<{ orgId: string; quota: number; used: number }>(userQuotas.me.$get())
+  return unwrap<EffectiveQuota>(userQuotas.me.$get())
 }
 
 // System Options API
@@ -914,4 +928,60 @@ export function listAdminAuditLogs(page = 1, pageSize = 20, filter: AdminAuditFi
   if (filter.action) query.action = filter.action
   if (filter.targetType) query.targetType = filter.targetType
   return unwrap<PaginatedResponse<AdminAuditEvent>>(adminAuditApi.index.$get({ query }))
+}
+
+// ─── Admin Quota Store API ────────────────────────────────────────────────────
+
+export function getQuotaStoreSettings() {
+  return unwrap<QuotaStoreSettings>(adminQuotaStoreApi.settings.$get())
+}
+
+export function putQuotaStoreSettings(input: PutQuotaStoreSettingsInput) {
+  return unwrap<QuotaStoreSettings>(adminQuotaStoreApi.settings.$put({ json: input }))
+}
+
+export function listAdminQuotaStorePackages() {
+  return unwrap<{ items: QuotaStorePackage[]; total: number }>(adminQuotaStoreApi.packages.$get())
+}
+
+export function createAdminQuotaStorePackage(input: CreateQuotaStorePackageInput) {
+  return unwrap<{ package: QuotaStorePackage; syncError: string | null }>(
+    adminQuotaStoreApi.packages.$post({ json: input }),
+  )
+}
+
+export function getAdminQuotaStorePackage(id: string) {
+  return unwrap<QuotaStorePackage>(adminQuotaStoreApi.packages[':id'].$get({ param: { id } }))
+}
+
+export function updateAdminQuotaStorePackage(id: string, input: UpdateQuotaStorePackageInput) {
+  return unwrap<{ package: QuotaStorePackage; syncError: string | null }>(
+    adminQuotaStoreApi.packages[':id'].$patch({ param: { id }, json: input }),
+  )
+}
+
+export function deleteAdminQuotaStorePackage(id: string) {
+  return unwrap<{ deleted: boolean }>(adminQuotaStoreApi.packages[':id'].$delete({ param: { id } }))
+}
+
+// ─── User Quota Store API ─────────────────────────────────────────────────────
+
+export function listUserQuotaStorePackages() {
+  return unwrap<{ items: QuotaStorePackage[]; total: number }>(userQuotaStoreApi.packages.$get())
+}
+
+export function listQuotaTargets() {
+  return unwrap<{ items: QuotaTarget[]; total: number }>(userQuotaStoreApi.targets.$get())
+}
+
+export function checkoutQuotaPackage(input: CheckoutInput) {
+  return unwrap<QuotaCheckoutResponse>(userQuotaStoreApi.checkout.$post({ json: input }))
+}
+
+export function redeemQuotaCode(input: RedeemInput) {
+  return unwrap<QuotaRedemptionResponse>(userQuotaStoreApi.redemptions.$post({ json: input }))
+}
+
+export function listQuotaGrants() {
+  return unwrap<{ items: QuotaGrant[]; total: number }>(userQuotaStoreApi.grants.$get())
 }

--- a/src/lib/rpc.ts
+++ b/src/lib/rpc.ts
@@ -3,6 +3,7 @@ import type {
   AdminAuditRoute,
   AdminAuthProvidersRoute,
   AdminInviteCodesRoute,
+  AdminQuotaStoreRoute,
   AdminQuotasRoute,
   AdminSiteInvitationsRoute,
   AnnouncementsRoute,
@@ -26,6 +27,7 @@ import type {
   SystemRoute,
   TeamsRoute,
   TrashRoute,
+  UserQuotaStoreRoute,
   UserQuotasRoute,
   UsersRoute,
 } from '@server/app'
@@ -66,3 +68,5 @@ export const publicBrandingApi = hc<PublicBrandingRoute>('/api/branding', opts)
 export const brandingAdminApi = hc<BrandingAdminRoute>('/api/admin/branding', opts)
 export const adminAuditApi = hc<AdminAuditRoute>('/api/admin/audit', opts)
 export const publicSiteInvitations = hc<PublicSiteInvitationsRoute>('/api/site-invitations', opts)
+export const adminQuotaStoreApi = hc<AdminQuotaStoreRoute>('/api/admin/quota-store', opts)
+export const userQuotaStoreApi = hc<UserQuotaStoreRoute>('/api/quota-store', opts)


### PR DESCRIPTION
## Summary

Implements the ZPan Pro quota store backend as specified in task tfe7f4dfzjrp.

### Changes

**Feature gate**
- Added `quota_store` Pro gate key to `shared/feature-registry.ts`
- Added `quota_store` label to `UpgradeHint.tsx`

**Shared types & schemas**
- New types: `QuotaStorePackage`, `QuotaGrant`, `QuotaStoreSettings`, `QuotaDeliveryEvent`, `EffectiveQuota`, `QuotaTarget`, `QuotaCheckoutResponse`, `QuotaRedemptionResponse`
- New Zod schemas: package CRUD, settings, checkout, redeem, Cloud delivery payload

**Database**
- New tables: `quota_store_settings`, `quota_store_packages`, `quota_grants`, `quota_delivery_events`
- Migration generated via `npm run db:generate` (0018_cheerful_chimera.sql)

**Services**
- `effective-quota.ts`: centralized quota enforcement using effective quota = base + grants
- `quota-store.ts`: settings/package CRUD, grant append, delivery event idempotency, webhook signature verification, Cloud catalog sync, checkout/redeem helpers
- Updated `matter.ts`, `image-hosting.ts`, `save-to-drive.ts` to delegate to effective quota

**Routes**
- Admin: GET/PUT /api/admin/quota-store/settings, package CRUD (requireAdmin + requireFeature)
- User: GET /packages, GET /targets, POST /checkout, POST /redemptions, GET /grants (requireAuth + requireFeature)
- Cloud webhook: POST /api/quota-store/webhooks/cloud — verifies HMAC signature, idempotent, appends one grant per delivery
- Updated /api/quotas/me to return baseQuota, grantedQuota, quota (effective), used

**Frontend**
- New RPC clients in src/lib/rpc.ts
- Typed API wrappers in src/lib/api.ts
- 25 new tests in src/lib/api.test.ts

### Checks
- typecheck, npm test (3223 tests), lint all pass