### PR TITLE
fix(deploy): publish Worker before D1 migrations

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -138,12 +138,6 @@ jobs:
       - name: Patch wrangler.toml with D1 database ID
         run: sed -i "s/database_id = \"[^\"]*\"/database_id = \"${{ steps.d1.outputs.id }}\"/" wrangler.toml
 
-      - name: Apply D1 migrations
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx wrangler d1 migrations apply DB --remote
-
       - name: Build
         run: npx vite build
 
@@ -157,6 +151,12 @@ jobs:
         # causes wrangler 4.x to error on conflicting base paths between the
         # two configs.
         run: npx wrangler deploy
+
+      - name: Apply D1 migrations
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler d1 migrations apply DB --remote
 
       - name: Set BETTER_AUTH_SECRET (first deploy only)
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,9 @@ npm run build            # Build frontend to dist/
 npm run deploy           # Build + deploy to Cloudflare Workers
 ```
 
+Cloudflare deploys publish Worker code before applying D1 production migrations. Do not ship destructive D1
+migrations unless the already-deployed Worker no longer reads the removed schema.
+
 ## Project Structure
 
 ```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:vercel": "vite build --mode node && tsup server/entry-vercel.ts --format esm --outDir api --external @libsql/client",
     "build:netlify": "tsup server/entry-netlify.ts --format esm --outDir netlify/functions --external @libsql/client",
     "build:azure": "vite build && tsup server/entry-azure.ts --format esm --outDir azure-functions --external @azure/functions --external @libsql/client && cp server/azure-host.json azure-functions/host.json && cp -r dist azure-functions/dist",
-    "deploy": "npm run db:migrate:d1:prod && wrangler deploy",
+    "deploy": "wrangler deploy && npm run db:migrate:d1:prod",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:migrate:d1": "wrangler d1 migrations apply zpan-db-staging --local --env staging",


### PR DESCRIPTION
## Summary
- Deploy Cloudflare Worker code before applying production D1 migrations
- Update `npm run deploy` to match the safer order
- Document that destructive D1 migrations must only ship after deployed code no longer reads removed schema

## Why
A production D1 migration dropped `license_bindings.store_key` before the Worker running on zpan.space had been updated. Authenticated admin quota-store settings requests could then hit old Worker code reading a removed column and return 500.

## Verification
- Hotfixed production by running `npx wrangler deploy` from current master without re-running migrations
- `https://zpan.space/api/health` returns 200
- Unauthenticated `https://zpan.space/api/admin/quota-store/settings` returns 401, confirming the Worker is alive and admin auth guard is reached
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy-cloudflare.yml')"`
- `git diff --check`
- commit hook ran `npm run typecheck` and lint-staged successfully