### PR TITLE
feat: add monthly traffic quotas

### DIFF
--- a/migrations/0022_kind_storm.sql
+++ b/migrations/0022_kind_storm.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `org_quotas` ADD `traffic_quota` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE `org_quotas` ADD `traffic_used` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE `org_quotas` ADD `traffic_period` text DEFAULT '1970-01' NOT NULL;--> statement-breakpoint
+INSERT INTO `org_quotas` (`id`, `org_id`, `quota`, `used`, `traffic_quota`, `traffic_used`, `traffic_period`)
+SELECT 'quota_' || `organization`.`id`, `organization`.`id`, 0, 0, 0, 0, strftime('%Y-%m', 'now')
+FROM `organization`
+LEFT JOIN `org_quotas` ON `org_quotas`.`org_id` = `organization`.`id`
+WHERE `org_quotas`.`org_id` IS NULL;

--- a/migrations/meta/0022_snapshot.json
+++ b/migrations/meta/0022_snapshot.json
@@ -1,0 +1,2721 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e7b76ac5-55b0-4df8-a4f1-95ef32172d6d",
+  "prevId": "4520be08-4478-4e9d-940e-cd4bbb947718",
+  "tables": {
+    "activity_events": {
+      "name": "activity_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "announcements": {
+      "name": "announcements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "announcements_status_priority_idx": {
+          "name": "announcements_status_priority_idx",
+          "columns": [
+            "status",
+            "priority"
+          ],
+          "isUnique": false
+        },
+        "announcements_published_idx": {
+          "name": "announcements_published_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "image_hosting_configs": {
+      "name": "image_hosting_configs",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_domain": {
+          "name": "custom_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cf_hostname_id": {
+          "name": "cf_hostname_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "domain_verified_at": {
+          "name": "domain_verified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referer_allowlist": {
+          "name": "referer_allowlist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "image_hosting_configs_custom_domain_unique": {
+          "name": "image_hosting_configs_custom_domain_unique",
+          "columns": [
+            "custom_domain"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "image_hosting_configs_org_id_organization_id_fk": {
+          "name": "image_hosting_configs_org_id_organization_id_fk",
+          "tableFrom": "image_hosting_configs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "image_hostings": {
+      "name": "image_hostings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "image_hostings_token_unique": {
+          "name": "image_hostings_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "image_hostings_org_path_uniq": {
+          "name": "image_hostings_org_path_uniq",
+          "columns": [
+            "org_id",
+            "path"
+          ],
+          "isUnique": true
+        },
+        "image_hostings_org_created_idx": {
+          "name": "image_hostings_org_created_idx",
+          "columns": [
+            "org_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "image_hostings_token_idx": {
+          "name": "image_hostings_token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "image_hostings_org_id_organization_id_fk": {
+          "name": "image_hostings_org_id_organization_id_fk",
+          "tableFrom": "image_hostings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "image_hostings_storage_id_storages_id_fk": {
+          "name": "image_hostings_storage_id_storages_id_fk",
+          "tableFrom": "image_hostings",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invite_codes": {
+      "name": "invite_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invite_codes_code_unique": {
+          "name": "invite_codes_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "license_bindings": {
+      "name": "license_bindings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_binding_id": {
+          "name": "cloud_binding_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_account_id": {
+          "name": "cloud_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_account_email": {
+          "name": "cloud_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cached_certificate": {
+          "name": "cached_certificate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cached_certificate_expires_at": {
+          "name": "cached_certificate_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bound_at": {
+          "name": "bound_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disconnected_at": {
+          "name": "disconnected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refresh_at": {
+          "name": "last_refresh_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refresh_error": {
+          "name": "last_refresh_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "license_bindings_active_uniq": {
+          "name": "license_bindings_active_uniq",
+          "columns": [
+            "status"
+          ],
+          "isUnique": true,
+          "where": "status = 'active'"
+        },
+        "license_bindings_cloud_binding_idx": {
+          "name": "license_bindings_cloud_binding_idx",
+          "columns": [
+            "cloud_binding_id"
+          ],
+          "isUnique": false
+        },
+        "license_bindings_instance_idx": {
+          "name": "license_bindings_instance_idx",
+          "columns": [
+            "instance_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "matters": {
+      "name": "matters",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dirtype": {
+          "name": "dirtype",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "parent": {
+          "name": "parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "trashed_at": {
+          "name": "trashed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "matters_alias_unique": {
+          "name": "matters_alias_unique",
+          "columns": [
+            "alias"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "notifications_user_read_idx": {
+          "name": "notifications_user_read_idx",
+          "columns": [
+            "user_id",
+            "read_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "org_quotas": {
+      "name": "org_quotas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quota": {
+          "name": "quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "traffic_quota": {
+          "name": "traffic_quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "traffic_used": {
+          "name": "traffic_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "traffic_period": {
+          "name": "traffic_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1970-01'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_delivery_events": {
+      "name": "quota_delivery_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_order_id": {
+          "name": "cloud_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloud_redemption_id": {
+          "name": "cloud_redemption_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "quota_delivery_events_event_uniq": {
+          "name": "quota_delivery_events_event_uniq",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": true
+        },
+        "quota_delivery_events_order_uniq": {
+          "name": "quota_delivery_events_order_uniq",
+          "columns": [
+            "cloud_order_id"
+          ],
+          "isUnique": true
+        },
+        "quota_delivery_events_redemption_uniq": {
+          "name": "quota_delivery_events_redemption_uniq",
+          "columns": [
+            "cloud_redemption_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_grants": {
+      "name": "quota_grants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloud_order_id": {
+          "name": "cloud_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloud_redemption_id": {
+          "name": "cloud_redemption_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "package_snapshot": {
+          "name": "package_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_user_id": {
+          "name": "terminal_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_user_email": {
+          "name": "terminal_user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "quota_grants_org_created_idx": {
+          "name": "quota_grants_org_created_idx",
+          "columns": [
+            "org_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "quota_grants_external_event_uniq": {
+          "name": "quota_grants_external_event_uniq",
+          "columns": [
+            "external_event_id"
+          ],
+          "isUnique": true
+        },
+        "quota_grants_cloud_order_uniq": {
+          "name": "quota_grants_cloud_order_uniq",
+          "columns": [
+            "cloud_order_id"
+          ],
+          "isUnique": true
+        },
+        "quota_grants_cloud_redemption_uniq": {
+          "name": "quota_grants_cloud_redemption_uniq",
+          "columns": [
+            "cloud_redemption_id"
+          ],
+          "isUnique": true
+        },
+        "quota_grants_code_uniq": {
+          "name": "quota_grants_code_uniq",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_store_packages": {
+      "name": "quota_store_packages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cloud_package_id": {
+          "name": "cloud_package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "quota_store_packages_active_sort_idx": {
+          "name": "quota_store_packages_active_sort_idx",
+          "columns": [
+            "active",
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_store_settings": {
+      "name": "quota_store_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_recipients": {
+      "name": "share_recipients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "share_id": {
+          "name": "share_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "share_recipients_share_id_idx": {
+          "name": "share_recipients_share_id_idx",
+          "columns": [
+            "share_id"
+          ],
+          "isUnique": false
+        },
+        "share_recipients_user_id_idx": {
+          "name": "share_recipients_user_id_idx",
+          "columns": [
+            "recipient_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shares": {
+      "name": "shares",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matter_id": {
+          "name": "matter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_limit": {
+          "name": "download_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "downloads": {
+          "name": "downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "shares_token_unique": {
+          "name": "shares_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "shares_creator_status_created_idx": {
+          "name": "shares_creator_status_created_idx",
+          "columns": [
+            "creator_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_invitations": {
+      "name": "site_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "site_invitations_token_unique": {
+          "name": "site_invitations_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "site_invitations_email_idx": {
+          "name": "site_invitations_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "site_invitations_created_idx": {
+          "name": "site_invitations_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "site_invitations_expires_idx": {
+          "name": "site_invitations_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "storages": {
+      "name": "storages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'auto'"
+        },
+        "access_key": {
+          "name": "access_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_key": {
+          "name": "secret_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "custom_host": {
+          "name": "custom_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_options": {
+      "name": "system_options",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "public": {
+          "name": "public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_invite_links": {
+      "name": "team_invite_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_invite_links_token_unique": {
+          "name": "team_invite_links_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_config_id_idx": {
+          "name": "apikey_config_id_idx",
+          "columns": [
+            "config_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_reference_id_idx": {
+          "name": "apikey_reference_id_idx",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1778038099075,
       "tag": "0021_drop-license-store-key",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1778081855257,
+      "tag": "0022_kind_storm",
+      "breakpoints": true
     }
   ]
 }

--- a/server/auth.integration.test.ts
+++ b/server/auth.integration.test.ts
@@ -470,6 +470,9 @@ describe('createPersonalOrg — org name and quota edge cases', () => {
     const quotas = await ctx.db.select().from(schema.orgQuotas)
     expect(quotas).toHaveLength(1)
     expect(quotas[0].quota).toBe(10485760)
+    expect(quotas[0].trafficQuota).toBe(0)
+    expect(quotas[0].trafficUsed).toBe(0)
+    expect(quotas[0].trafficPeriod).toMatch(/^\d{4}-\d{2}$/)
   })
 })
 

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -6,7 +6,7 @@ import { genericOAuth } from 'better-auth/plugins/generic-oauth'
 import { adminAc, memberAc, ownerAc } from 'better-auth/plugins/organization/access'
 import { count, eq, like } from 'drizzle-orm'
 import { customAlphabet, nanoid } from 'nanoid'
-import { DEFAULT_ORG_QUOTA, SignupMode } from '../shared/constants'
+import { DEFAULT_ORG_QUOTA, DEFAULT_ORG_TRAFFIC_QUOTA, SignupMode } from '../shared/constants'
 import {
   BUILTIN_PROVIDER_IDS,
   OAUTH_PROVIDER_KEY_PATTERN,
@@ -18,6 +18,7 @@ import { orgQuotas, systemOptions } from './db/schema'
 import { hashPassword, verifyPassword as verifyPasswordHash } from './lib/password'
 import type { Database, Platform } from './platform/interface'
 import { recordActivity } from './services/activity'
+import { currentTrafficPeriod } from './services/effective-quota'
 import { isEmailConfigured, sendEmail } from './services/email'
 import { redeemInviteCode, validateInviteCode } from './services/invite'
 import { findPersonalOrg } from './services/org'
@@ -184,6 +185,9 @@ export async function createAuth(
                 limit,
               })
             }
+          },
+          afterCreateOrganization: async ({ organization }) => {
+            await createOrgQuota(db, organization.id, new Date())
           },
           afterAcceptInvitation: async ({ member, user, organization }) => {
             await recordActivity(db, {
@@ -441,7 +445,6 @@ async function createPersonalOrg(
   const now = new Date()
   const displayName = user.name || user.username
   const orgName = displayName ? `${displayName}'s Space` : 'Personal Space'
-  const defaultQuota = await getDefaultOrgQuota(db)
 
   await db.insert(authSchema.organization).values({
     id: orgId,
@@ -459,9 +462,24 @@ async function createPersonalOrg(
     createdAt: now,
   })
 
-  await db.insert(orgQuotas).values({ id: nanoid(), orgId, quota: defaultQuota, used: 0 })
+  await createOrgQuota(db, orgId, now)
 
   return orgId
+}
+
+async function createOrgQuota(db: Database, orgId: string, now: Date): Promise<void> {
+  const defaultQuota = await getDefaultOrgQuota(db)
+  const defaultTrafficQuota = await getDefaultOrgTrafficQuota(db)
+
+  await db.insert(orgQuotas).values({
+    id: nanoid(),
+    orgId,
+    quota: defaultQuota,
+    used: 0,
+    trafficQuota: defaultTrafficQuota,
+    trafficUsed: 0,
+    trafficPeriod: currentTrafficPeriod(now),
+  })
 }
 
 async function getDefaultOrgQuota(db: Database): Promise<number> {
@@ -473,4 +491,18 @@ async function getDefaultOrgQuota(db: Database): Promise<number> {
   if (raw == null) return DEFAULT_ORG_QUOTA
   const n = Number(raw)
   return Number.isFinite(n) && n > 0 ? n : DEFAULT_ORG_QUOTA
+}
+
+async function getDefaultOrgTrafficQuota(db: Database): Promise<number> {
+  const rows = await db
+    .select({ value: systemOptions.value })
+    .from(systemOptions)
+    .where(eq(systemOptions.key, 'default_org_monthly_traffic_quota'))
+  const raw = rows[0]?.value
+  if (raw == null) return DEFAULT_ORG_TRAFFIC_QUOTA
+  const value = raw.trim()
+  const n = Number(value)
+  if (value === '' || !Number.isInteger(n) || n < 0)
+    throw new Error('default_org_monthly_traffic_quota must be a non-negative integer')
+  return n
 }

--- a/server/db/migrations.test.ts
+++ b/server/db/migrations.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import Database from 'better-sqlite3'
+import { describe, expect, it } from 'vitest'
+
+type OrgQuotaRow = {
+  id: string
+  orgId: string
+  quota: number
+  used: number
+  trafficQuota: number
+  trafficUsed: number
+  trafficPeriod: string
+}
+
+describe('migration 0022_kind_storm.sql', () => {
+  const migrationPath = join(process.cwd(), 'migrations/0022_kind_storm.sql')
+  const migration = readFileSync(migrationPath, 'utf-8')
+
+  it('backfills org_quotas for organizations missing quota rows', () => {
+    const db = new Database(':memory:')
+
+    try {
+      db.exec(`
+        CREATE TABLE organization (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          slug TEXT NOT NULL UNIQUE,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER
+        );
+        CREATE TABLE org_quotas (
+          id TEXT PRIMARY KEY,
+          org_id TEXT NOT NULL,
+          quota INTEGER NOT NULL DEFAULT 0,
+          used INTEGER NOT NULL DEFAULT 0
+        );
+        INSERT INTO organization (id, name, slug, created_at, updated_at)
+        VALUES ('org-existing', 'Existing', 'existing', 1, 1),
+               ('org-missing', 'Missing', 'missing', 1, 1);
+        INSERT INTO org_quotas (id, org_id, quota, used)
+        VALUES ('quota-existing', 'org-existing', 1024, 128);
+      `)
+
+      for (const statement of migration.split('--> statement-breakpoint')) {
+        db.exec(statement)
+      }
+
+      const rows = db
+        .prepare(
+          `
+            SELECT id, org_id AS orgId, quota, used, traffic_quota AS trafficQuota,
+                   traffic_used AS trafficUsed, traffic_period AS trafficPeriod
+            FROM org_quotas
+            ORDER BY org_id
+          `,
+        )
+        .all() as OrgQuotaRow[]
+
+      expect(rows).toHaveLength(2)
+      expect(rows[0]).toEqual({
+        id: 'quota-existing',
+        orgId: 'org-existing',
+        quota: 1024,
+        used: 128,
+        trafficQuota: 0,
+        trafficUsed: 0,
+        trafficPeriod: '1970-01',
+      })
+      expect(rows[1]).toMatchObject({
+        id: 'quota_org-missing',
+        orgId: 'org-missing',
+        quota: 0,
+        used: 0,
+        trafficQuota: 0,
+        trafficUsed: 0,
+      })
+      expect(rows[1].trafficPeriod).toMatch(/^\d{4}-\d{2}$/)
+    } finally {
+      db.close()
+    }
+  })
+})

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -42,6 +42,9 @@ export const orgQuotas = sqliteTable('org_quotas', {
   orgId: text('org_id').notNull(),
   quota: integer('quota').notNull().default(0),
   used: integer('used').notNull().default(0),
+  trafficQuota: integer('traffic_quota').notNull().default(0),
+  trafficUsed: integer('traffic_used').notNull().default(0),
+  trafficPeriod: text('traffic_period').notNull().default('1970-01'),
 })
 
 export const quotaStoreSettings = sqliteTable('quota_store_settings', {

--- a/server/routes/auth.integration.test.ts
+++ b/server/routes/auth.integration.test.ts
@@ -171,11 +171,15 @@ describe('Auth API', () => {
     expect(rows).toHaveLength(1)
     expect(rows[0].quota).toBe(10485760)
     expect(rows[0].used).toBe(0)
+    expect(rows[0].trafficQuota).toBe(0)
+    expect(rows[0].trafficUsed).toBe(0)
+    expect(rows[0].trafficPeriod).toMatch(/^\d{4}-\d{2}$/)
   })
 
-  it('signup with default_org_quota set to 1073741824 creates an org_quotas row with quota=1073741824 and used=0', async () => {
+  it('signup with default quotas set creates an org_quotas row with storage and monthly traffic quotas', async () => {
     const { app, db } = await createTestApp()
     await db.insert(schema.systemOptions).values({ key: 'default_org_quota', value: '1073741824' })
+    await db.insert(schema.systemOptions).values({ key: 'default_org_monthly_traffic_quota', value: '2147483648' })
     const signUpRes = await app.request('/api/auth/sign-up/email', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -194,6 +198,50 @@ describe('Auth API', () => {
     expect(rows).toHaveLength(1)
     expect(rows[0].quota).toBe(1073741824)
     expect(rows[0].used).toBe(0)
+    expect(rows[0].trafficQuota).toBe(2147483648)
+    expect(rows[0].trafficUsed).toBe(0)
+    expect(rows[0].trafficPeriod).toMatch(/^\d{4}-\d{2}$/)
+  })
+
+  it('team org creation initializes storage and monthly traffic quotas from defaults', async () => {
+    const { app, db } = await createTestApp()
+    await db.insert(schema.systemOptions).values({ key: 'default_org_quota', value: '1073741824' })
+    await db.insert(schema.systemOptions).values({ key: 'default_org_monthly_traffic_quota', value: '2147483648' })
+    const signUpRes = await app.request('/api/auth/sign-up/email', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Test', email: 'team-quota@example.com', password: 'password123456' }),
+    })
+    const cookie = signUpRes.headers.getSetCookie().join('; ')
+
+    const createRes = await app.request('/api/auth/organization/create', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: cookie },
+      body: JSON.stringify({ name: 'Team Quota', slug: 'team-quota' }),
+    })
+    expect(createRes.status).toBe(200)
+    const org = (await createRes.json()) as { id: string }
+
+    const rows = await db.select().from(schema.orgQuotas).where(eq(schema.orgQuotas.orgId, org.id))
+    expect(rows).toHaveLength(1)
+    expect(rows[0].quota).toBe(1073741824)
+    expect(rows[0].used).toBe(0)
+    expect(rows[0].trafficQuota).toBe(2147483648)
+    expect(rows[0].trafficUsed).toBe(0)
+    expect(rows[0].trafficPeriod).toMatch(/^\d{4}-\d{2}$/)
+  })
+
+  it('signup fails when stored default monthly traffic quota is invalid', async () => {
+    const { app, db } = await createTestApp()
+    await db.insert(schema.systemOptions).values({ key: 'default_org_monthly_traffic_quota', value: '-1' })
+
+    const res = await app.request('/api/auth/sign-up/email', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Test', email: 'bad-traffic-default@example.com', password: 'password123456' }),
+    })
+
+    expect(res.status).not.toBe(200)
   })
 
   it('signup with default_org_quota set to 0 creates a built-in default org_quotas row', async () => {

--- a/server/routes/objects-quota.integration.test.ts
+++ b/server/routes/objects-quota.integration.test.ts
@@ -2,6 +2,7 @@ import { eq, sql } from 'drizzle-orm'
 import { nanoid } from 'nanoid'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { orgQuotas } from '../db/schema.js'
+import { currentTrafficPeriod } from '../services/effective-quota.js'
 import { S3Service } from '../services/s3.js'
 import { authedHeaders, createTestApp, seedProLicense } from '../test/setup.js'
 
@@ -67,7 +68,15 @@ async function setOrgQuota(
   if (existing.length > 0) {
     await db.update(orgQuotas).set({ quota, used }).where(eq(orgQuotas.orgId, orgId))
   } else {
-    await db.insert(orgQuotas).values({ id: nanoid(), orgId, quota, used })
+    await db.insert(orgQuotas).values({
+      id: nanoid(),
+      orgId,
+      quota,
+      used,
+      trafficQuota: 0,
+      trafficUsed: 0,
+      trafficPeriod: currentTrafficPeriod(),
+    })
   }
 }
 
@@ -198,6 +207,56 @@ describe('POST /api/objects/copy — quota enforcement', () => {
       body: JSON.stringify({ copyFrom: 'nonexistent', parent: '' }),
     })
     expect(res.status).toBe(404)
+  })
+})
+
+describe('GET /api/objects/:id — traffic quota enforcement', () => {
+  it('returns download URL and consumes traffic quota when allowed', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    await insertFile(db, orgId, { id: 'm-download-ok', name: 'download.txt', size: 100 })
+    const trafficPeriod = currentTrafficPeriod()
+    await db.run(sql`
+      UPDATE org_quotas
+      SET traffic_quota = 500, traffic_used = 25, traffic_period = ${trafficPeriod}
+      WHERE org_id = ${orgId}
+    `)
+
+    const res = await app.request('/api/objects/m-download-ok', { headers })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.downloadUrl).toBe('https://presigned-download.example.com')
+
+    const rows = await db.all<{ trafficUsed: number }>(
+      sql`SELECT traffic_used AS trafficUsed FROM org_quotas WHERE org_id = ${orgId}`,
+    )
+    expect(rows[0].trafficUsed).toBe(125)
+  })
+
+  it('returns 422 when download traffic quota is exhausted', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    await insertFile(db, orgId, { id: 'm-download-over', name: 'download.txt', size: 100 })
+    const trafficPeriod = currentTrafficPeriod()
+    await db.run(sql`
+      UPDATE org_quotas
+      SET traffic_quota = 50, traffic_used = 0, traffic_period = ${trafficPeriod}
+      WHERE org_id = ${orgId}
+    `)
+
+    const res = await app.request('/api/objects/m-download-over', { headers })
+    expect(res.status).toBe(422)
+    await expect(res.json()).resolves.toEqual({ error: 'Traffic quota exceeded' })
+    expect(S3Service.prototype.presignDownload).not.toHaveBeenCalled()
+
+    const rows = await db.all<{ trafficUsed: number }>(
+      sql`SELECT traffic_used AS trafficUsed FROM org_quotas WHERE org_id = ${orgId}`,
+    )
+    expect(rows[0].trafficUsed).toBe(0)
   })
 })
 

--- a/server/routes/objects.ts
+++ b/server/routes/objects.ts
@@ -12,6 +12,7 @@ import type { Storage as S3Storage } from '../../shared/types'
 import { requireAuth, requireTeamRole } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
 import { recordActivity } from '../services/activity'
+import { consumeTrafficIfQuotaAllows, hasTrafficQuotaForBytes } from '../services/effective-quota'
 import {
   batchMove,
   batchTrash,
@@ -194,7 +195,14 @@ const app = new Hono<Env>()
     const storage = (await getStorage(db, matter.storageId)) as unknown as S3Storage
     if (!storage) return c.json({ error: 'Storage not found' }, 404)
 
+    if (!(await hasTrafficQuotaForBytes(db, orgId, matter.size ?? 0))) {
+      return c.json({ error: 'Traffic quota exceeded' }, 422)
+    }
+
     const downloadUrl = await s3.presignDownload(storage, matter.object, matter.name)
+    const trafficAllowed = await consumeTrafficIfQuotaAllows(db, orgId, matter.size ?? 0)
+    if (!trafficAllowed) return c.json({ error: 'Traffic quota exceeded' }, 422)
+
     return c.json({ ...matter, downloadUrl })
   })
   .patch('/:id', requireTeamRole('editor'), zValidator('json', patchMatterSchema), async (c) => {

--- a/server/routes/quotas-listing.integration.test.ts
+++ b/server/routes/quotas-listing.integration.test.ts
@@ -1,0 +1,51 @@
+import { sql } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+import { authedHeaders, createTestApp } from '../test/setup.js'
+
+async function adminHeaders(app: ReturnType<typeof import('../app')['createApp']>) {
+  await authedHeaders(app, 'admin@example.com', 'password123456')
+  const signInRes = await app.request('/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: 'admin@example.com', password: 'password123456' }),
+  })
+  return { Cookie: signInRes.headers.getSetCookie().join('; ') }
+}
+
+describe('Admin quota listing', () => {
+  it('normalizes stale traffic periods and aggregates active grants', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+    const now = Date.now()
+    const adminOrg = await db.all<{ id: string }>(sql`SELECT id FROM organization LIMIT 1`)
+
+    await db.run(sql`
+      INSERT INTO organization (id, name, slug, metadata, created_at, updated_at)
+      VALUES ('team-quota-listing', 'Team Quota Listing', 'team-quota-listing', '{"type":"team"}', ${now}, ${now})
+    `)
+    await db.run(sql`
+      INSERT INTO org_quotas (id, org_id, quota, used, traffic_quota, traffic_used, traffic_period)
+      VALUES ('team-quota-listing-row', 'team-quota-listing', 2000, 100, 3000, 2500, '1970-01')
+    `)
+    await db.run(sql`UPDATE org_quotas SET traffic_quota = 1000, traffic_used = 900, traffic_period = '1970-01'`)
+    await db.run(sql`
+      INSERT INTO quota_grants (id, org_id, source, external_event_id, bytes, active, created_at)
+      VALUES
+        ('grant-active-a', ${adminOrg[0].id}, 'stripe', 'evt-active-a', 500, 1, ${now}),
+        ('grant-active-b', ${adminOrg[0].id}, 'stripe', 'evt-active-b', 700, 1, ${now}),
+        ('grant-inactive', ${adminOrg[0].id}, 'stripe', 'evt-inactive', 900, 0, ${now})
+    `)
+
+    const res = await app.request('/api/admin/quotas', { headers })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { items: Array<Record<string, unknown>>; total: number }
+
+    expect(body.total).toBe(2)
+    expect(body.items).toHaveLength(2)
+    expect(body.items.every((item) => item.trafficUsed === 0)).toBe(true)
+    expect(body.items.every((item) => /^\d{4}-\d{2}$/.test(String(item.trafficPeriod)))).toBe(true)
+
+    const adminItem = body.items.find((item) => item.orgId === adminOrg[0].id)
+    expect(adminItem).toMatchObject({ baseQuota: 10485760, grantedQuota: 1200, quota: 10486960 })
+  })
+})

--- a/server/routes/quotas.integration.test.ts
+++ b/server/routes/quotas.integration.test.ts
@@ -44,6 +44,27 @@ describe('Admin Quotas API', () => {
     expect(body.items).toHaveLength(1)
     expect(body.total).toBe(1)
     expect(body.items[0].quota).toBe(10485760)
+    expect(body.items[0].trafficQuota).toBe(0)
+    expect(body.items[0].trafficUsed).toBe(0)
+    expect(body.items[0].trafficPeriod).toMatch(/^\d{4}-\d{2}$/)
+  })
+
+  it('GET /api/admin/quotas normalizes stale monthly traffic period', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+    await db.run(sql`UPDATE org_quotas SET traffic_quota = 1000, traffic_used = 900, traffic_period = '1970-01'`)
+
+    const res = await app.request('/api/admin/quotas', { headers })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { items: Array<Record<string, unknown>>; total: number }
+    expect(body.items[0].trafficUsed).toBe(0)
+    expect(body.items[0].trafficPeriod).toMatch(/^\d{4}-\d{2}$/)
+
+    const rows = await db.all<{ trafficUsed: number; trafficPeriod: string }>(
+      sql`SELECT traffic_used AS trafficUsed, traffic_period AS trafficPeriod FROM org_quotas LIMIT 1`,
+    )
+    expect(rows[0].trafficUsed).toBe(0)
+    expect(rows[0].trafficPeriod).toBe(body.items[0].trafficPeriod)
   })
 
   it('PUT /api/admin/quotas/:orgId creates quota for org', async () => {
@@ -59,16 +80,43 @@ describe('Admin Quotas API', () => {
     const res = await app.request(`/api/admin/quotas/${orgId}`, {
       method: 'PUT',
       headers: { ...headers, 'Content-Type': 'application/json' },
-      body: JSON.stringify({ quota: 1073741824 }), // 1GB
+      body: JSON.stringify({ quota: 1073741824, trafficQuota: 2147483648 }),
     })
     expect(res.status).toBe(200)
     const body = (await res.json()) as Record<string, unknown>
     expect(body.orgId).toBe(orgId)
     expect(body.quota).toBe(1073741824)
+    expect(body.trafficQuota).toBe(2147483648)
 
     // Verify in DB
-    const quotas = await db.all<{ quota: number }>(sql`SELECT quota FROM org_quotas WHERE org_id = ${orgId}`)
+    const quotas = await db.all<{ quota: number; trafficQuota: number }>(
+      sql`SELECT quota, traffic_quota AS trafficQuota FROM org_quotas WHERE org_id = ${orgId}`,
+    )
     expect(quotas[0].quota).toBe(1073741824)
+    expect(quotas[0].trafficQuota).toBe(2147483648)
+  })
+
+  it('PUT /api/admin/quotas/:orgId creates missing quota with default monthly traffic quota', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+
+    const orgs = await db.all<{ id: string }>(
+      sql`SELECT o.id FROM organization o WHERE o.metadata LIKE '%"type":"personal"%' LIMIT 1`,
+    )
+    const orgId = orgs[0].id
+    await db.run(sql`DELETE FROM org_quotas WHERE org_id = ${orgId}`)
+
+    const res = await app.request(`/api/admin/quotas/${orgId}`, {
+      method: 'PUT',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ quota: 2048 }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.quota).toBe(2048)
+    expect(body.trafficQuota).toBe(0)
+    expect(body.trafficUsed).toBe(0)
+    expect(body.trafficPeriod).toMatch(/^\d{4}-\d{2}$/)
   })
 
   it('PUT /api/admin/quotas/:orgId updates existing quota', async () => {
@@ -96,6 +144,9 @@ describe('Admin Quotas API', () => {
     expect(res.status).toBe(200)
     const body = (await res.json()) as Record<string, unknown>
     expect(body.quota).toBe(2000)
+    expect(body.trafficQuota).toBe(0)
+    expect(body.trafficUsed).toBe(0)
+    expect(body.trafficPeriod).toMatch(/^\d{4}-\d{2}$/)
   })
 
   it('PUT /api/admin/quotas/:orgId rejects negative quota', async () => {
@@ -127,6 +178,17 @@ describe('Admin Quotas API', () => {
       method: 'PUT',
       headers: { ...headers, 'Content-Type': 'application/json' },
       body: JSON.stringify({ quota: 1.5 }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('PUT /api/admin/quotas/:orgId rejects negative traffic quota', async () => {
+    const { app } = await createTestApp()
+    const headers = await adminHeaders(app)
+    const res = await app.request('/api/admin/quotas/some-org', {
+      method: 'PUT',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ quota: 1000, trafficQuota: -1 }),
     })
     expect(res.status).toBe(400)
   })
@@ -173,6 +235,9 @@ describe('Admin Quotas API', () => {
     expect(body.items).toHaveLength(1)
     expect(body.items[0].orgId).toBe(orgId)
     expect(body.items[0].quota).toBe(5000)
+    expect(body.items[0].trafficQuota).toBe(0)
+    expect(body.items[0].trafficUsed).toBe(0)
+    expect(body.items[0].trafficPeriod).toMatch(/^\d{4}-\d{2}$/)
     expect(body.items[0].orgName).toBeTruthy()
     expect(body.items[0].orgType).toBe('personal')
   })
@@ -193,6 +258,9 @@ describe('User Quotas API — /api/quotas', () => {
     const body = (await res.json()) as Record<string, unknown>
     expect(body.quota).toBe(10485760)
     expect(body.used).toBe(0)
+    expect(body.trafficQuota).toBe(0)
+    expect(body.trafficUsed).toBe(0)
+    expect(body.trafficPeriod).toMatch(/^\d{4}-\d{2}$/)
     expect(body.orgId).toBeTruthy()
   })
 
@@ -236,6 +304,8 @@ describe('User Quotas API — /api/quotas', () => {
     const body = (await res.json()) as Record<string, unknown>
     expect(body.quota).toBe(10000)
     expect(body.used).toBe(0)
+    expect(body.trafficQuota).toBe(0)
+    expect(body.trafficUsed).toBe(0)
   })
 
   it('admin quota updates base quota while paid grants remain effective', async () => {
@@ -252,11 +322,16 @@ describe('User Quotas API — /api/quotas', () => {
       VALUES ('grant-1', ${orgId}, 'stripe', 'evt-quota', 'order-quota', 500, 1, ${Date.now()})
     `)
 
-    await app.request(`/api/admin/quotas/${orgId}`, {
+    const putRes = await app.request(`/api/admin/quotas/${orgId}`, {
       method: 'PUT',
       headers: { ...adminH, 'Content-Type': 'application/json' },
       body: JSON.stringify({ quota: 1000 }),
     })
+    expect(putRes.status).toBe(200)
+    const updated = (await putRes.json()) as Record<string, unknown>
+    expect(updated.baseQuota).toBe(1000)
+    expect(updated.grantedQuota).toBe(500)
+    expect(updated.quota).toBe(1500)
 
     const res = await app.request('/api/quotas/me', { headers: adminH })
     const body = (await res.json()) as Record<string, unknown>

--- a/server/routes/quotas.ts
+++ b/server/routes/quotas.ts
@@ -1,45 +1,67 @@
 import { zValidator } from '@hono/zod-validator'
-import { eq } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { nanoid } from 'nanoid'
 import { z } from 'zod'
 import { organization } from '../db/auth-schema'
-import { orgQuotas } from '../db/schema'
+import { orgQuotas, quotaGrants } from '../db/schema'
 import { requireAdmin, requireAuth } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
 import { recordActivity } from '../services/activity'
-import { getEffectiveQuota } from '../services/effective-quota'
+import { currentTrafficPeriod, getEffectiveQuota } from '../services/effective-quota'
 import { findPersonalOrg } from '../services/org'
 
 const updateQuotaSchema = z.object({
   quota: z.number().int().positive(),
+  trafficQuota: z.number().int().nonnegative().optional(),
 })
 
 const adminQuotas = new Hono<Env>()
   .use(requireAdmin)
   .get('/', async (c) => {
     const db = c.get('platform').db
+    const period = currentTrafficPeriod()
+
+    await db
+      .update(orgQuotas)
+      .set({ trafficUsed: 0, trafficPeriod: period })
+      .where(sql`${orgQuotas.trafficPeriod} != ${period}`)
+
     const rows = await db
       .select({
         id: orgQuotas.id,
         orgId: orgQuotas.orgId,
-        quota: orgQuotas.quota,
+        baseQuota: orgQuotas.quota,
         used: orgQuotas.used,
+        trafficQuota: orgQuotas.trafficQuota,
+        trafficUsed: orgQuotas.trafficUsed,
+        trafficPeriod: orgQuotas.trafficPeriod,
+        grantedQuota: sql<number>`COALESCE(SUM(CASE WHEN ${quotaGrants.active} = 1 THEN ${quotaGrants.bytes} ELSE 0 END), 0)`,
         orgName: organization.name,
         orgMetadata: organization.metadata,
       })
       .from(orgQuotas)
       .innerJoin(organization, eq(organization.id, orgQuotas.orgId))
+      .leftJoin(quotaGrants, eq(quotaGrants.orgId, orgQuotas.orgId))
+      .groupBy(orgQuotas.id, organization.name, organization.metadata)
       .orderBy(organization.name)
 
-    const items = rows.map((r) => ({
-      id: r.id,
-      orgId: r.orgId,
-      quota: r.quota,
-      used: r.used,
-      orgName: r.orgName,
-      orgType: parseOrgType(r.orgMetadata),
-    }))
+    const items = rows.map((r) => {
+      const grantedQuota = Number(r.grantedQuota)
+      return {
+        id: r.id,
+        orgId: r.orgId,
+        baseQuota: r.baseQuota,
+        grantedQuota,
+        quota: r.baseQuota === 0 ? 0 : r.baseQuota + grantedQuota,
+        used: r.used,
+        trafficQuota: r.trafficQuota,
+        trafficUsed: r.trafficUsed,
+        trafficPeriod: r.trafficPeriod,
+        orgName: r.orgName,
+        orgType: parseOrgType(r.orgMetadata),
+      }
+    })
 
     return c.json({ items, total: items.length })
   })
@@ -48,14 +70,25 @@ const adminQuotas = new Hono<Env>()
     const userId = c.get('userId')!
     const adminOrgId = c.get('orgId')!
     const targetOrgId = c.req.param('orgId')
-    const { quota } = c.req.valid('json')
+    const { quota, trafficQuota } = c.req.valid('json')
 
     const existing = await db.select({ id: orgQuotas.id }).from(orgQuotas).where(eq(orgQuotas.orgId, targetOrgId))
 
     if (existing.length > 0) {
-      await db.update(orgQuotas).set({ quota }).where(eq(orgQuotas.orgId, targetOrgId))
+      await db
+        .update(orgQuotas)
+        .set(trafficQuota == null ? { quota } : { quota, trafficQuota })
+        .where(eq(orgQuotas.orgId, targetOrgId))
     } else {
-      await db.insert(orgQuotas).values({ id: nanoid(), orgId: targetOrgId, quota, used: 0 })
+      await db.insert(orgQuotas).values({
+        id: nanoid(),
+        orgId: targetOrgId,
+        quota,
+        used: 0,
+        trafficQuota: trafficQuota ?? 0,
+        trafficUsed: 0,
+        trafficPeriod: currentTrafficPeriod(),
+      })
     }
 
     await recordActivity(db, {
@@ -65,10 +98,10 @@ const adminQuotas = new Hono<Env>()
       targetType: 'quota',
       targetId: targetOrgId,
       targetName: targetOrgId,
-      metadata: { quota, targetOrgId },
+      metadata: { quota, trafficQuota, targetOrgId },
     })
 
-    return c.json({ orgId: targetOrgId, quota })
+    return c.json(await getEffectiveQuota(db, targetOrgId))
   })
 
 const userQuotas = new Hono<Env>().use(requireAuth).get('/me', async (c) => {

--- a/server/routes/redirect.cf-test.ts
+++ b/server/routes/redirect.cf-test.ts
@@ -62,7 +62,7 @@ async function insertImageHosting(
   const now = Date.now()
   await db.run(sql`
     INSERT INTO image_hostings (id, org_id, token, path, storage_id, storage_key, size, mime, status, access_count, created_at)
-    VALUES (${opts.id}, ${orgId}, ${opts.token}, ${'blog/' + opts.id + '.png'}, ${STORAGE_ID}, ${'ih/' + orgId + '/' + opts.id + '.png'}, 512, 'image/png', 'active', 0, ${now})
+    VALUES (${opts.id}, ${orgId}, ${opts.token}, ${`blog/${opts.id}.png`}, ${STORAGE_ID}, ${`ih/${orgId}/${opts.id}.png`}, 512, 'image/png', 'active', 0, ${now})
   `)
 }
 
@@ -120,7 +120,7 @@ describe('[CF] /r/:token ih_ image hosting', () => {
     const res = await app.request(`/r/${token}`, { redirect: 'manual' })
     expect(res.status).toBe(302)
     const cc = res.headers.get('cache-control') ?? ''
-    expect(cc).toContain('public')
+    expect(cc).toContain('no-store')
     vi.restoreAllMocks()
   })
 

--- a/server/routes/redirect.integration.test.ts
+++ b/server/routes/redirect.integration.test.ts
@@ -1,5 +1,6 @@
 import { sql } from 'drizzle-orm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { currentTrafficPeriod } from '../services/effective-quota.js'
 import { S3Service } from '../services/s3.js'
 import { createShare } from '../services/share.js'
 import { authedHeaders, createTestApp } from '../test/setup.js'
@@ -56,7 +57,7 @@ async function insertImageHosting(
   const now = Date.now()
   await db.run(sql`
     INSERT INTO image_hostings (id, org_id, token, path, storage_id, storage_key, size, mime, status, access_count, created_at)
-    VALUES (${opts.id}, ${orgId}, ${opts.token}, ${'blog/' + opts.id + '.png'}, ${opts.storageId ?? STORAGE_ID}, ${'ih/' + orgId + '/' + opts.id + '.png'}, 1024, 'image/png', ${opts.status ?? 'active'}, 0, ${now})
+    VALUES (${opts.id}, ${orgId}, ${opts.token}, ${`blog/${opts.id}.png`}, ${opts.storageId ?? STORAGE_ID}, ${`ih/${orgId}/${opts.id}.png`}, 1024, 'image/png', ${opts.status ?? 'active'}, 0, ${now})
   `)
 }
 
@@ -115,12 +116,87 @@ describe('GET /r/:token (ds_ direct shares)', () => {
     const res = await app.request(`/r/${share.token}`, { redirect: 'manual' })
     expect(res.status).toBe(404)
   })
+
+  it('returns 422 when direct share traffic quota is exhausted', async () => {
+    const { app, db } = await createTestApp()
+    await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    const creatorId = await getUserId(db)
+    await insertFile(db, orgId, { id: 'ds-quota', name: 'quota.bin' })
+    const trafficPeriod = currentTrafficPeriod()
+    await db.run(sql`
+      UPDATE org_quotas
+      SET traffic_quota = 512, traffic_used = 0, traffic_period = ${trafficPeriod}
+      WHERE org_id = ${orgId}
+    `)
+    const share = await createShare(db, { matterId: 'ds-quota', orgId, creatorId, kind: 'direct', downloadLimit: 1 })
+
+    const res = await app.request(`/r/${share.token}`, { redirect: 'manual' })
+    expect(res.status).toBe(422)
+    await expect(res.json()).resolves.toEqual({ error: 'Traffic quota exceeded' })
+    expect(S3Service.prototype.presignDownload).not.toHaveBeenCalled()
+
+    const shares = await db.all<{ downloads: number }>(sql`SELECT downloads FROM shares WHERE id = ${share.id}`)
+    expect(shares[0].downloads).toBe(0)
+  })
+
+  it('consumes traffic quota on successful direct share redirect', async () => {
+    const { app, db } = await createTestApp()
+    await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    const creatorId = await getUserId(db)
+    await insertFile(db, orgId, { id: 'ds-quota-ok', name: 'quota.bin' })
+    const trafficPeriod = currentTrafficPeriod()
+    await db.run(sql`
+      UPDATE org_quotas
+      SET traffic_quota = 2048, traffic_used = 256, traffic_period = ${trafficPeriod}
+      WHERE org_id = ${orgId}
+    `)
+    const share = await createShare(db, { matterId: 'ds-quota-ok', orgId, creatorId, kind: 'direct' })
+
+    const res = await app.request(`/r/${share.token}`, { redirect: 'manual' })
+    expect(res.status).toBe(302)
+
+    const rows = await db.all<{ trafficUsed: number }>(
+      sql`SELECT traffic_used AS trafficUsed FROM org_quotas WHERE org_id = ${orgId}`,
+    )
+    expect(rows[0].trafficUsed).toBe(1280)
+  })
+
+  it('compensates direct share download count when traffic is exhausted after presign', async () => {
+    const { app, db } = await createTestApp()
+    await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    const creatorId = await getUserId(db)
+    await insertFile(db, orgId, { id: 'ds-quota-race', name: 'quota.bin' })
+    const trafficPeriod = currentTrafficPeriod()
+    await db.run(sql`
+      UPDATE org_quotas
+      SET traffic_quota = 1024, traffic_used = 0, traffic_period = ${trafficPeriod}
+      WHERE org_id = ${orgId}
+    `)
+    vi.mocked(S3Service.prototype.presignDownload).mockImplementationOnce(async () => {
+      await db.run(sql`UPDATE org_quotas SET traffic_used = 1024 WHERE org_id = ${orgId}`)
+      return MOCK_PRESIGN_URL
+    })
+    const share = await createShare(db, { matterId: 'ds-quota-race', orgId, creatorId, kind: 'direct' })
+
+    const res = await app.request(`/r/${share.token}`, { redirect: 'manual' })
+    expect(res.status).toBe(422)
+    await expect(res.json()).resolves.toEqual({ error: 'Traffic quota exceeded' })
+
+    const shares = await db.all<{ downloads: number }>(sql`SELECT downloads FROM shares WHERE id = ${share.id}`)
+    expect(shares[0].downloads).toBe(0)
+  })
 })
 
 // ─── ih_ image hosting tests ──────────────────────────────────────────────────
 
 describe('GET /r/:token (ih_ image hosting)', () => {
-  it('returns 302 with inline disposition and max-age for active image', async () => {
+  it('returns 302 with inline disposition and no-store cache for active image', async () => {
     const { app, db } = await createTestApp()
     await authedHeaders(app)
     await insertStorage(db)
@@ -131,8 +207,7 @@ describe('GET /r/:token (ih_ image hosting)', () => {
     expect(res.status).toBe(302)
     expect(res.headers.get('location')).toBe(MOCK_INLINE_URL)
     const cc = res.headers.get('cache-control') ?? ''
-    expect(cc).toContain('public')
-    expect(cc).toContain('max-age=')
+    expect(cc).toContain('no-store')
   })
 
   it('strips .png extension and resolves same image', async () => {
@@ -186,6 +261,52 @@ describe('GET /r/:token (ih_ image hosting)', () => {
     expect(await getAccessCount(db, 'ih-cnt1')).toBe(0)
     await app.request('/r/ih_counttest1', { redirect: 'manual' })
     expect(await getAccessCount(db, 'ih-cnt1')).toBe(1)
+  })
+
+  it('consumes traffic quota on successful image hosting redirect', async () => {
+    const { app, db } = await createTestApp()
+    await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    await insertImageHosting(db, orgId, { id: 'ih-quota-ok', token: 'ih_quotaok' })
+    const trafficPeriod = currentTrafficPeriod()
+    await db.run(sql`
+      UPDATE org_quotas
+      SET traffic_quota = 2048, traffic_used = 256, traffic_period = ${trafficPeriod}
+      WHERE org_id = ${orgId}
+    `)
+
+    const res = await app.request('/r/ih_quotaok', { redirect: 'manual' })
+    expect(res.status).toBe(302)
+
+    const rows = await db.all<{ trafficUsed: number }>(
+      sql`SELECT traffic_used AS trafficUsed FROM org_quotas WHERE org_id = ${orgId}`,
+    )
+    expect(rows[0].trafficUsed).toBe(1280)
+  })
+
+  it('rejects the next image redirect after the first one consumes the remaining monthly traffic quota', async () => {
+    const { app, db } = await createTestApp()
+    await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    await insertImageHosting(db, orgId, { id: 'ih-quota-repeat', token: 'ih_quotarepeat' })
+    const trafficPeriod = currentTrafficPeriod()
+    await db.run(sql`
+      UPDATE org_quotas
+      SET traffic_quota = 1024, traffic_used = 0, traffic_period = ${trafficPeriod}
+      WHERE org_id = ${orgId}
+    `)
+
+    const first = await app.request('/r/ih_quotarepeat', { redirect: 'manual' })
+    expect(first.status).toBe(302)
+    expect(first.headers.get('cache-control')).toBe('no-store')
+
+    const second = await app.request('/r/ih_quotarepeat', { redirect: 'manual' })
+    expect(second.status).toBe(422)
+    await expect(second.json()).resolves.toEqual({ error: 'Traffic quota exceeded' })
+    expect(S3Service.prototype.presignInline).toHaveBeenCalledTimes(1)
+    expect(await getAccessCount(db, 'ih-quota-repeat')).toBe(1)
   })
 
   it('does NOT increment accessCount on 404', async () => {
@@ -338,5 +459,24 @@ describe('GET /r/:token — two-org isolation', () => {
     const res = await app.request('/r/ih_isolationtest', { redirect: 'manual' })
     expect(res.status).toBe(302)
     expect(res.headers.get('location')).toBe(MOCK_INLINE_URL)
+  })
+
+  it('returns 422 when image hosting traffic quota is exhausted', async () => {
+    const { app, db } = await createTestApp()
+    await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    await insertImageHosting(db, orgId, { id: 'ih-quota', token: 'ih_quotatest' })
+    const trafficPeriod = currentTrafficPeriod()
+    await db.run(sql`
+      UPDATE org_quotas
+      SET traffic_quota = 512, traffic_used = 0, traffic_period = ${trafficPeriod}
+      WHERE org_id = ${orgId}
+    `)
+
+    const res = await app.request('/r/ih_quotatest', { redirect: 'manual' })
+    expect(res.status).toBe(422)
+    await expect(res.json()).resolves.toEqual({ error: 'Traffic quota exceeded' })
+    expect(S3Service.prototype.presignInline).not.toHaveBeenCalled()
   })
 })

--- a/server/routes/redirect.ts
+++ b/server/routes/redirect.ts
@@ -3,8 +3,14 @@ import { Hono } from 'hono'
 import type { Storage as S3Storage } from '../../shared/types'
 import type { Env } from '../middleware/platform'
 import type { Database } from '../platform/interface'
+import { consumeTrafficIfQuotaAllows, hasTrafficQuotaForBytes } from '../services/effective-quota'
 import { incrementAccessCount, resolveActiveImageByToken } from '../services/image-hosting'
-import { incrementDownloadsAtomic, resolveShareByToken } from '../services/share'
+import {
+  decrementDownloads,
+  hasDownloadsAvailable,
+  incrementDownloadsAtomic,
+  resolveShareByToken,
+} from '../services/share'
 import { getStorage } from '../services/storage'
 import { PRESIGN_TTL_SECS, s3 } from './share-utils'
 
@@ -28,9 +34,6 @@ function checkReferer(refererAllowlist: string[], refererHeader: string | null):
   }
 }
 
-// max-age is min(PRESIGN_TTL_SECS - 30, 300) to avoid caching beyond presign validity
-const IMAGE_MAX_AGE = Math.min(PRESIGN_TTL_SECS - 30, 300)
-
 async function handleDirectShare(c: Context<Env>, db: Database, token: string): Promise<Response> {
   const resolved = await resolveShareByToken(db, token)
   if (resolved.status !== 'ok') {
@@ -43,13 +46,26 @@ async function handleDirectShare(c: Context<Env>, db: Database, token: string): 
 
   if (share.expiresAt && share.expiresAt < new Date()) return c.json({ error: 'Share has expired' }, 410)
 
-  const { ok } = await incrementDownloadsAtomic(db, share.id)
-  if (!ok) return c.json({ error: 'Download limit exceeded' }, 410)
+  if (!(await hasDownloadsAvailable(db, share.id))) return c.json({ error: 'Download limit exceeded' }, 410)
 
   const storage = (await getStorage(db, matter.storageId)) as unknown as S3Storage
   if (!storage) return c.json({ error: 'Storage not found' }, 404)
 
+  if (!(await hasTrafficQuotaForBytes(db, share.orgId, matter.size ?? 0))) {
+    return c.json({ error: 'Traffic quota exceeded' }, 422)
+  }
+
   const url = await s3.presignDownload(storage, matter.object, matter.name, PRESIGN_TTL_SECS)
+
+  const { ok } = await incrementDownloadsAtomic(db, share.id)
+  if (!ok) return c.json({ error: 'Download limit exceeded' }, 410)
+
+  const trafficAllowed = await consumeTrafficIfQuotaAllows(db, share.orgId, matter.size ?? 0)
+  if (!trafficAllowed) {
+    await decrementDownloads(db, share.id)
+    return c.json({ error: 'Traffic quota exceeded' }, 422)
+  }
+
   const res = c.redirect(url, 302)
   res.headers.set('Cache-Control', 'no-store')
   return res
@@ -73,11 +89,18 @@ async function handleImageHosting(c: Context<Env>, db: Database, token: string):
   const storage = (await getStorage(db, image.storageId)) as unknown as S3Storage
   if (!storage) return c.json({ error: 'Storage not found' }, 404)
 
-  await incrementAccessCount(db, image.id)
+  if (!(await hasTrafficQuotaForBytes(db, image.orgId, image.size))) {
+    return c.json({ error: 'Traffic quota exceeded' }, 422)
+  }
 
   const url = await s3.presignInline(storage, image.storageKey, image.mime, PRESIGN_TTL_SECS)
+
+  const trafficAllowed = await consumeTrafficIfQuotaAllows(db, image.orgId, image.size)
+  if (!trafficAllowed) return c.json({ error: 'Traffic quota exceeded' }, 422)
+  await incrementAccessCount(db, image.id)
+
   const res = c.redirect(url, 302)
-  res.headers.set('Cache-Control', `public, max-age=${IMAGE_MAX_AGE}`)
+  res.headers.set('Cache-Control', 'no-store')
   return res
 }
 

--- a/server/routes/share-public.integration.test.ts
+++ b/server/routes/share-public.integration.test.ts
@@ -1,5 +1,6 @@
 import { sql } from 'drizzle-orm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { currentTrafficPeriod } from '../services/effective-quota.js'
 import { S3Service } from '../services/s3.js'
 import { createShare } from '../services/share.js'
 import { authedHeaders, createTestApp } from '../test/setup.js'
@@ -319,6 +320,85 @@ describe('GET /api/shares/:token/objects/:ref — root file', () => {
     expect(res.status).toBe(200)
     expect(res.headers.get('cache-control')).toBe('no-store')
     await expect(res.json()).resolves.toEqual({ downloadUrl: MOCK_PRESIGN_URL })
+  })
+
+  it('consumes traffic quota when public share download URL is issued', async () => {
+    const { app, db } = await createTestApp()
+    await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    const creatorId = await getUserId(db)
+    await insertFile(db, orgId, { id: 'dl-traffic-ok', name: 'traffic.txt' })
+    const trafficPeriod = currentTrafficPeriod()
+    await db.run(sql`
+      UPDATE org_quotas
+      SET traffic_quota = 2048, traffic_used = 256, traffic_period = ${trafficPeriod}
+      WHERE org_id = ${orgId}
+    `)
+    const share = await createShare(db, { matterId: 'dl-traffic-ok', orgId, creatorId, kind: 'landing' })
+
+    const rootRef = await fetchRootRef(app, share.token)
+    const res = await app.request(`/api/shares/${share.token}/objects/${rootRef}?downloadUrl=1`, { redirect: 'manual' })
+    expect(res.status).toBe(200)
+
+    const rows = await db.all<{ trafficUsed: number }>(
+      sql`SELECT traffic_used AS trafficUsed FROM org_quotas WHERE org_id = ${orgId}`,
+    )
+    expect(rows[0].trafficUsed).toBe(1280)
+  })
+
+  it('compensates public share download count when traffic is exhausted after presign', async () => {
+    const { app, db } = await createTestApp()
+    await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    const creatorId = await getUserId(db)
+    await insertFile(db, orgId, { id: 'dl-traffic-race', name: 'traffic.txt' })
+    const trafficPeriod = currentTrafficPeriod()
+    await db.run(sql`
+      UPDATE org_quotas
+      SET traffic_quota = 1024, traffic_used = 0, traffic_period = ${trafficPeriod}
+      WHERE org_id = ${orgId}
+    `)
+    vi.mocked(S3Service.prototype.presignDownload).mockImplementationOnce(async () => {
+      await db.run(sql`UPDATE org_quotas SET traffic_used = 1024 WHERE org_id = ${orgId}`)
+      return MOCK_PRESIGN_URL
+    })
+    const share = await createShare(db, { matterId: 'dl-traffic-race', orgId, creatorId, kind: 'landing' })
+
+    const rootRef = await fetchRootRef(app, share.token)
+    const res = await app.request(`/api/shares/${share.token}/objects/${rootRef}?downloadUrl=1`, { redirect: 'manual' })
+    expect(res.status).toBe(422)
+    await expect(res.json()).resolves.toEqual({ error: 'Traffic quota exceeded' })
+
+    const shares = await db.all<{ downloads: number }>(sql`SELECT downloads FROM shares WHERE id = ${share.id}`)
+    expect(shares[0].downloads).toBe(0)
+  })
+
+  it('returns 422 when public share traffic quota is exhausted', async () => {
+    const { app, db } = await createTestApp()
+    await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    const creatorId = await getUserId(db)
+    await insertFile(db, orgId, { id: 'dl-traffic', name: 'traffic.txt' })
+    const trafficPeriod = currentTrafficPeriod()
+    await db.run(sql`
+      UPDATE org_quotas
+      SET traffic_quota = 512, traffic_used = 0, traffic_period = ${trafficPeriod}
+      WHERE org_id = ${orgId}
+    `)
+    const share = await createShare(db, { matterId: 'dl-traffic', orgId, creatorId, kind: 'landing', downloadLimit: 1 })
+
+    const rootRef = await fetchRootRef(app, share.token)
+    const res = await app.request(`/api/shares/${share.token}/objects/${rootRef}?downloadUrl=1`, { redirect: 'manual' })
+
+    expect(res.status).toBe(422)
+    await expect(res.json()).resolves.toEqual({ error: 'Traffic quota exceeded' })
+    expect(S3Service.prototype.presignDownload).not.toHaveBeenCalled()
+
+    const shares = await db.all<{ downloads: number }>(sql`SELECT downloads FROM shares WHERE id = ${share.id}`)
+    expect(shares[0].downloads).toBe(0)
   })
 
   it('returns 401 when password required and no cookie', async () => {

--- a/server/routes/shares.ts
+++ b/server/routes/shares.ts
@@ -11,6 +11,7 @@ import { matters } from '../db/schema'
 import { requireAuth, requireTeamRole } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
 import { recordActivity } from '../services/activity'
+import { consumeTrafficIfQuotaAllows, hasTrafficQuotaForBytes } from '../services/effective-quota'
 import { listMatters } from '../services/matter'
 import { getMemberRole, isPersonalOrg } from '../services/org'
 import {
@@ -20,7 +21,9 @@ import {
 } from '../services/save-to-drive'
 import {
   createShare,
+  decrementDownloads,
   getShareCreatorByToken,
+  hasDownloadsAvailable,
   incrementDownloadsAtomic,
   incrementViews,
   isAccessibleByUser,
@@ -265,13 +268,24 @@ export const publicShares = new Hono<Env>()
       return c.json({ error: 'Cannot download a folder directly' }, 400)
     }
 
-    const { ok } = await incrementDownloadsAtomic(db, share.id)
-    if (!ok) return c.json({ error: 'Download limit exceeded' }, 410)
+    if (!(await hasDownloadsAvailable(db, share.id))) return c.json({ error: 'Download limit exceeded' }, 410)
 
     const storage = (await getStorage(db, targetMatter.storageId)) as unknown as S3Storage
     if (!storage) return c.json({ error: 'Storage not found' }, 404)
 
+    if (!(await hasTrafficQuotaForBytes(db, share.orgId, targetMatter.size ?? 0))) {
+      return c.json({ error: 'Traffic quota exceeded' }, 422)
+    }
+
     const url = await s3.presignDownload(storage, targetMatter.object, targetMatter.name, PRESIGN_TTL_SECS)
+    const { ok } = await incrementDownloadsAtomic(db, share.id)
+    if (!ok) return c.json({ error: 'Download limit exceeded' }, 410)
+
+    const trafficAllowed = await consumeTrafficIfQuotaAllows(db, share.orgId, targetMatter.size ?? 0)
+    if (!trafficAllowed) {
+      await decrementDownloads(db, share.id)
+      return c.json({ error: 'Traffic quota exceeded' }, 422)
+    }
 
     // Record download audit event. Use the authenticated viewer if available;
     // fall back to the share creator as the org-attributed actor for anonymous

--- a/server/routes/system.integration.test.ts
+++ b/server/routes/system.integration.test.ts
@@ -93,4 +93,22 @@ describe('System API — options CRUD', () => {
       expect(res.status).toBe(400)
     }
   })
+
+  it('validates default monthly traffic quota values', async () => {
+    const { app } = await createTestApp()
+    const admin = await adminHeaders(app)
+
+    for (const value of ['', '   ', '-1', '1.5', 'abc']) {
+      const res = await putOption(app, admin, 'default_org_monthly_traffic_quota', { value })
+      expect(res.status).toBe(400)
+    }
+
+    const created = await putOption(app, admin, 'default_org_monthly_traffic_quota', { value: ' 1024 ' })
+    expect(created.status).toBe(201)
+    await expect(created.json()).resolves.toMatchObject({ value: '1024' })
+
+    const updated = await putOption(app, admin, 'default_org_monthly_traffic_quota', { value: '0' })
+    expect(updated.status).toBe(200)
+    await expect(updated.json()).resolves.toMatchObject({ value: '0' })
+  })
 })

--- a/server/routes/system.ts
+++ b/server/routes/system.ts
@@ -41,6 +41,7 @@ const app = new Hono<Env>()
     const orgId = c.get('orgId')!
     const key = c.req.param('key')
     const body = c.req.valid('json')
+    let value = body.value
 
     if (key === 'auth_signup_mode' && body.value === SignupMode.OPEN) {
       const state = await loadBindingState(db)
@@ -59,13 +60,21 @@ const app = new Hono<Env>()
       }
     }
 
+    if (key === 'default_org_monthly_traffic_quota') {
+      value = body.value.trim()
+      const quota = Number(value)
+      if (value === '' || !Number.isInteger(quota) || quota < 0) {
+        return c.json({ error: 'Default organization monthly traffic quota must be a non-negative number' }, 400)
+      }
+    }
+
     const existing = await db
       .select({ key: systemOptions.key, public: systemOptions.public })
       .from(systemOptions)
       .where(eq(systemOptions.key, key))
     if (existing.length > 0) {
       const nextPublic = body.public ?? existing[0].public
-      await db.update(systemOptions).set({ value: body.value, public: nextPublic }).where(eq(systemOptions.key, key))
+      await db.update(systemOptions).set({ value, public: nextPublic }).where(eq(systemOptions.key, key))
       await recordActivity(db, {
         orgId,
         userId,
@@ -74,10 +83,10 @@ const app = new Hono<Env>()
         targetName: key,
         metadata: { key, public: !!nextPublic },
       })
-      return c.json({ key, value: body.value, public: !!nextPublic })
+      return c.json({ key, value, public: !!nextPublic })
     }
     const nextPublic = body.public ?? false
-    await db.insert(systemOptions).values({ key, value: body.value, public: nextPublic })
+    await db.insert(systemOptions).values({ key, value, public: nextPublic })
     await recordActivity(db, {
       orgId,
       userId,
@@ -86,7 +95,7 @@ const app = new Hono<Env>()
       targetName: key,
       metadata: { key, public: nextPublic },
     })
-    return c.json({ key, value: body.value, public: !!nextPublic }, 201)
+    return c.json({ key, value, public: !!nextPublic }, 201)
   })
   .delete('/options/:key', requireAdmin, async (c) => {
     const db = c.get('platform').db

--- a/server/services/effective-quota.test.ts
+++ b/server/services/effective-quota.test.ts
@@ -1,0 +1,138 @@
+import { eq, sql } from 'drizzle-orm'
+import { nanoid } from 'nanoid'
+import { describe, expect, it } from 'vitest'
+import { orgQuotas } from '../db/schema.js'
+import { createTestApp } from '../test/setup.js'
+import { consumeTrafficIfQuotaAllows, getEffectiveQuota, hasTrafficQuotaForBytes } from './effective-quota.js'
+
+describe('effective quota', () => {
+  it('returns storage and traffic quota state', async () => {
+    const { db } = await createTestApp()
+    const orgId = nanoid()
+    await db.insert(orgQuotas).values({
+      id: nanoid(),
+      orgId,
+      quota: 1000,
+      used: 250,
+      trafficQuota: 2000,
+      trafficUsed: 500,
+      trafficPeriod: '2026-05',
+    })
+
+    await expect(getEffectiveQuota(db, orgId, new Date('2026-05-06T00:00:00Z'))).resolves.toMatchObject({
+      orgId,
+      baseQuota: 1000,
+      grantedQuota: 0,
+      quota: 1000,
+      used: 250,
+      trafficQuota: 2000,
+      trafficUsed: 500,
+      trafficPeriod: '2026-05',
+    })
+  })
+
+  it('resets monthly traffic usage when the period changes', async () => {
+    const { db } = await createTestApp()
+    const orgId = nanoid()
+    await db.insert(orgQuotas).values({
+      id: nanoid(),
+      orgId,
+      quota: 1000,
+      used: 0,
+      trafficQuota: 2000,
+      trafficUsed: 1500,
+      trafficPeriod: '2026-04',
+    })
+
+    const quota = await getEffectiveQuota(db, orgId, new Date('2026-05-01T00:00:00Z'))
+    expect(quota.trafficUsed).toBe(0)
+    expect(quota.trafficPeriod).toBe('2026-05')
+
+    const rows = await db.select().from(orgQuotas).where(eq(orgQuotas.orgId, orgId))
+    expect(rows[0].trafficUsed).toBe(0)
+    expect(rows[0].trafficPeriod).toBe('2026-05')
+  })
+
+  it('consumes traffic within the monthly quota and rejects overage', async () => {
+    const { db } = await createTestApp()
+    const orgId = nanoid()
+    const now = new Date('2026-05-06T00:00:00Z')
+    await db.insert(orgQuotas).values({
+      id: nanoid(),
+      orgId,
+      quota: 1000,
+      used: 0,
+      trafficQuota: 1000,
+      trafficUsed: 400,
+      trafficPeriod: '2026-05',
+    })
+
+    await expect(hasTrafficQuotaForBytes(db, orgId, 600, now)).resolves.toBe(true)
+    await expect(consumeTrafficIfQuotaAllows(db, orgId, 600, now)).resolves.toBe(true)
+    await expect(consumeTrafficIfQuotaAllows(db, orgId, 1, now)).resolves.toBe(false)
+
+    const rows = await db.select().from(orgQuotas).where(eq(orgQuotas.orgId, orgId))
+    expect(rows[0].trafficUsed).toBe(1000)
+  })
+
+  it('consumes traffic from zero when the period changes', async () => {
+    const { db } = await createTestApp()
+    const orgId = nanoid()
+    const now = new Date('2026-05-06T00:00:00Z')
+    await db.insert(orgQuotas).values({
+      id: nanoid(),
+      orgId,
+      quota: 1000,
+      used: 0,
+      trafficQuota: 1000,
+      trafficUsed: 900,
+      trafficPeriod: '2026-04',
+    })
+
+    await expect(consumeTrafficIfQuotaAllows(db, orgId, 600, now)).resolves.toBe(true)
+    await expect(consumeTrafficIfQuotaAllows(db, orgId, 401, now)).resolves.toBe(false)
+
+    const rows = await db.select().from(orgQuotas).where(eq(orgQuotas.orgId, orgId))
+    expect(rows[0].trafficUsed).toBe(600)
+    expect(rows[0].trafficPeriod).toBe('2026-05')
+  })
+
+  it('retries current-period traffic consumption when another request advances the period first', async () => {
+    const { db } = await createTestApp()
+    const orgId = 'org-rollover-race'
+    const now = new Date('2026-05-06T00:00:00Z')
+    await db.insert(orgQuotas).values({
+      id: nanoid(),
+      orgId,
+      quota: 1000,
+      used: 0,
+      trafficQuota: 1000,
+      trafficUsed: 900,
+      trafficPeriod: '2026-04',
+    })
+    await db.run(sql`
+      CREATE TRIGGER org_quotas_rollover_race
+      BEFORE UPDATE ON org_quotas
+      WHEN OLD.org_id = 'org-rollover-race' AND OLD.traffic_period != '2026-05'
+      BEGIN
+        UPDATE org_quotas SET traffic_used = 300, traffic_period = '2026-05' WHERE org_id = OLD.org_id;
+        SELECT RAISE(IGNORE);
+      END
+    `)
+
+    await expect(consumeTrafficIfQuotaAllows(db, orgId, 400, now)).resolves.toBe(true)
+
+    const rows = await db.select().from(orgQuotas).where(eq(orgQuotas.orgId, orgId))
+    expect(rows[0].trafficUsed).toBe(700)
+    expect(rows[0].trafficPeriod).toBe('2026-05')
+  })
+
+  it('allows traffic when no quota row exists', async () => {
+    const { db } = await createTestApp()
+    const orgId = nanoid()
+    const now = new Date('2026-05-06T00:00:00Z')
+
+    await expect(hasTrafficQuotaForBytes(db, orgId, 1024, now)).resolves.toBe(true)
+    await expect(consumeTrafficIfQuotaAllows(db, orgId, 1024, now)).resolves.toBe(true)
+  })
+})

--- a/server/services/effective-quota.ts
+++ b/server/services/effective-quota.ts
@@ -8,28 +8,55 @@ export interface EffectiveQuota {
   grantedQuota: number
   quota: number
   used: number
+  trafficQuota: number
+  trafficUsed: number
+  trafficPeriod: string
 }
 
-export async function getEffectiveQuota(db: Database, orgId: string): Promise<EffectiveQuota> {
+export function currentTrafficPeriod(now = new Date()): string {
+  const month = String(now.getUTCMonth() + 1).padStart(2, '0')
+  return `${now.getUTCFullYear()}-${month}`
+}
+
+export async function getEffectiveQuota(db: Database, orgId: string, now = new Date()): Promise<EffectiveQuota> {
+  const period = currentTrafficPeriod(now)
+  await db
+    .update(orgQuotas)
+    .set({ trafficUsed: 0, trafficPeriod: period })
+    .where(sql`${orgQuotas.orgId} = ${orgId} AND ${orgQuotas.trafficPeriod} != ${period}`)
+
   const quotaRows = await db
-    .select({ baseQuota: orgQuotas.quota, used: orgQuotas.used })
+    .select({
+      id: orgQuotas.id,
+      baseQuota: orgQuotas.quota,
+      used: orgQuotas.used,
+      trafficQuota: orgQuotas.trafficQuota,
+      trafficUsed: orgQuotas.trafficUsed,
+      trafficPeriod: orgQuotas.trafficPeriod,
+    })
     .from(orgQuotas)
     .where(eq(orgQuotas.orgId, orgId))
     .limit(1)
+  const quotaRow = quotaRows[0]
 
   const grantRows = await db
     .select({ total: sql<number>`COALESCE(SUM(${quotaGrants.bytes}), 0)` })
     .from(quotaGrants)
     .where(sql`${quotaGrants.orgId} = ${orgId} AND ${quotaGrants.active} = 1`)
 
-  const baseQuota = quotaRows[0]?.baseQuota ?? 0
+  const baseQuota = quotaRow?.baseQuota ?? 0
   const grantedQuota = Number(grantRows[0]?.total ?? 0)
+  const trafficUsed = quotaRow && quotaRow.trafficPeriod === period ? quotaRow.trafficUsed : 0
+  const trafficPeriod = quotaRow?.trafficPeriod === period ? quotaRow.trafficPeriod : period
   return {
     orgId,
     baseQuota,
     grantedQuota,
     quota: baseQuota === 0 ? 0 : baseQuota + grantedQuota,
-    used: quotaRows[0]?.used ?? 0,
+    used: quotaRow?.used ?? 0,
+    trafficQuota: quotaRow?.trafficQuota ?? 0,
+    trafficUsed,
+    trafficPeriod,
   }
 }
 
@@ -38,6 +65,59 @@ export async function hasQuotaForBytes(db: Database, orgId: string, bytes: numbe
   const quota = await getEffectiveQuota(db, orgId)
   if (quota.baseQuota === 0) return true
   return quota.used + bytes <= quota.quota
+}
+
+export async function hasTrafficQuotaForBytes(
+  db: Database,
+  orgId: string,
+  bytes: number,
+  now = new Date(),
+): Promise<boolean> {
+  if (bytes <= 0) return true
+  const quota = await getEffectiveQuota(db, orgId, now)
+  if (quota.trafficQuota === 0) return true
+  return quota.trafficUsed + bytes <= quota.trafficQuota
+}
+
+export async function consumeTrafficIfQuotaAllows(
+  db: Database,
+  orgId: string,
+  bytes: number,
+  now = new Date(),
+): Promise<boolean> {
+  if (bytes <= 0) return true
+  const period = currentTrafficPeriod(now)
+  const quotaRows = await db
+    .select({ id: orgQuotas.id, trafficPeriod: orgQuotas.trafficPeriod, trafficQuota: orgQuotas.trafficQuota })
+    .from(orgQuotas)
+    .where(eq(orgQuotas.orgId, orgId))
+    .limit(1)
+  if (quotaRows.length === 0) return true
+
+  if (quotaRows[0].trafficPeriod !== period) {
+    const updated = await db
+      .update(orgQuotas)
+      .set({ trafficUsed: bytes, trafficPeriod: period })
+      .where(
+        sql`${orgQuotas.orgId} = ${orgId}
+          AND ${orgQuotas.trafficPeriod} != ${period}
+          AND (${orgQuotas.trafficQuota} = 0 OR ${bytes} <= ${orgQuotas.trafficQuota})`,
+      )
+      .returning({ id: orgQuotas.id })
+    if (updated.length > 0) return true
+  }
+
+  const updated = await db
+    .update(orgQuotas)
+    .set({ trafficUsed: sql`${orgQuotas.trafficUsed} + ${bytes}` })
+    .where(
+      sql`${orgQuotas.orgId} = ${orgId}
+        AND ${orgQuotas.trafficPeriod} = ${period}
+        AND (${orgQuotas.trafficQuota} = 0 OR ${orgQuotas.trafficUsed} + ${bytes} <= ${orgQuotas.trafficQuota})`,
+    )
+    .returning({ id: orgQuotas.id })
+
+  return updated.length > 0
 }
 
 export async function incrementUsageIfEffectiveQuotaAllows(

--- a/server/services/matter-conflict.integration.test.ts
+++ b/server/services/matter-conflict.integration.test.ts
@@ -474,8 +474,8 @@ describe('confirmUpload — quota-then-replace atomicity', () => {
     // Insert a tight quota that allows zero growth
     const quotaId = nanoid()
     await db.run(sql`
-      INSERT INTO org_quotas (id, org_id, quota, used)
-      VALUES (${quotaId}, ${orgId}, 100, 100)
+      INSERT INTO org_quotas (id, org_id, quota, used, traffic_quota, traffic_used, traffic_period)
+      VALUES (${quotaId}, ${orgId}, 100, 100, 0, 0, '2026-05')
     `)
 
     // Incumbent active file that 'replace' would trash

--- a/server/services/matter.integration.test.ts
+++ b/server/services/matter.integration.test.ts
@@ -20,7 +20,15 @@ async function insertStorage(db: TestDb, opts: { id?: string; used?: number } = 
 }
 
 async function insertOrgQuota(db: TestDb, orgId: string, quota: number, used = 0) {
-  await db.insert(orgQuotas).values({ id: nanoid(), orgId, quota, used })
+  await db.insert(orgQuotas).values({
+    id: nanoid(),
+    orgId,
+    quota,
+    used,
+    trafficQuota: 0,
+    trafficUsed: 0,
+    trafficPeriod: '2026-05',
+  })
 }
 
 async function insertDraftFile(

--- a/server/services/save-to-drive.integration.test.ts
+++ b/server/services/save-to-drive.integration.test.ts
@@ -58,7 +58,15 @@ async function seedMatter(
 }
 
 async function seedOrgQuota(db: TestDb, orgId: string, quota: number, used = 0) {
-  await db.insert(orgQuotas).values({ id: nanoid(), orgId, quota, used })
+  await db.insert(orgQuotas).values({
+    id: nanoid(),
+    orgId,
+    quota,
+    used,
+    trafficQuota: 0,
+    trafficUsed: 0,
+    trafficPeriod: '2026-05',
+  })
 }
 
 async function getShare(db: TestDb, shareId: string) {
@@ -622,7 +630,15 @@ describe('POST /api/shares/:token/objects', () => {
       VALUES (${nanoid()}, ${quotaOrgId}, ${userId}, 'editor', ${Date.now()})
     `)
     // Insert a tight quota row for this org (only 100 bytes allowed)
-    await db.insert(orgQuotas).values({ id: nanoid(), orgId: quotaOrgId, quota: 100, used: 0 })
+    await db.insert(orgQuotas).values({
+      id: nanoid(),
+      orgId: quotaOrgId,
+      quota: 100,
+      used: 0,
+      trafficQuota: 0,
+      trafficUsed: 0,
+      trafficPeriod: '2026-05',
+    })
 
     // The share from setup() has a matter with size 512 — well above the 100-byte quota
     const res = await app.request(`/api/shares/${share.token}/objects`, {

--- a/server/services/share.ts
+++ b/server/services/share.ts
@@ -103,6 +103,23 @@ export async function incrementViews(db: Database, shareId: string): Promise<voi
     .where(eq(shares.id, shareId))
 }
 
+export async function hasDownloadsAvailable(db: Database, shareId: string): Promise<boolean> {
+  const nowSecs = Math.floor(Date.now() / 1000)
+  const rows = await db
+    .select({ id: shares.id })
+    .from(shares)
+    .where(
+      and(
+        eq(shares.id, shareId),
+        eq(shares.status, 'active'),
+        or(isNull(shares.downloadLimit), sql`${shares.downloads} < ${shares.downloadLimit}`),
+        or(isNull(shares.expiresAt), sql`${shares.expiresAt} > ${nowSecs}`),
+      ),
+    )
+    .limit(1)
+  return rows.length === 1
+}
+
 export async function incrementDownloadsAtomic(
   db: Database,
   shareId: string,
@@ -128,6 +145,13 @@ export async function incrementDownloadsAtomic(
   const current = await db.select({ downloads: shares.downloads }).from(shares).where(eq(shares.id, shareId))
   if (!current[0]) throw new Error('SHARE_NOT_FOUND')
   return { ok: false, downloads: current[0].downloads }
+}
+
+export async function decrementDownloads(db: Database, shareId: string): Promise<void> {
+  await db
+    .update(shares)
+    .set({ downloads: sql`CASE WHEN ${shares.downloads} > 0 THEN ${shares.downloads} - 1 ELSE 0 END` })
+    .where(eq(shares.id, shareId))
 }
 
 export async function listShareRecipientUserIds(db: Database, shareId: string): Promise<string[]> {

--- a/server/services/user.ts
+++ b/server/services/user.ts
@@ -3,6 +3,7 @@ import { nanoid } from 'nanoid'
 import { member, organization, user } from '../db/auth-schema'
 import { orgQuotas } from '../db/schema'
 import type { Database } from '../platform/interface'
+import { currentTrafficPeriod } from './effective-quota'
 
 export interface UserWithOrg {
   id: string
@@ -161,7 +162,15 @@ export async function setUsersPersonalQuota(
   }
 
   for (const orgId of nowMissing) {
-    await db.insert(orgQuotas).values({ id: nanoid(), orgId, quota, used: 0 })
+    await db.insert(orgQuotas).values({
+      id: nanoid(),
+      orgId,
+      quota,
+      used: 0,
+      trafficQuota: 0,
+      trafficUsed: 0,
+      trafficPeriod: currentTrafficPeriod(),
+    })
   }
 
   return { updated: rows.length, userIds: existingIds, orgIds, quota }

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -132,7 +132,10 @@ const APP_SCHEMA_SQL = `
     id TEXT PRIMARY KEY,
     org_id TEXT NOT NULL,
     quota INTEGER NOT NULL DEFAULT 0,
-    used INTEGER NOT NULL DEFAULT 0
+    used INTEGER NOT NULL DEFAULT 0,
+    traffic_quota INTEGER NOT NULL DEFAULT 0,
+    traffic_used INTEGER NOT NULL DEFAULT 0,
+    traffic_period TEXT NOT NULL DEFAULT '1970-01'
   );
   CREATE TABLE IF NOT EXISTS quota_store_settings (
     id TEXT PRIMARY KEY,

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -47,6 +47,7 @@ export const ZPAN_CLOUD_URL_DEFAULT = 'https://cloud.zpan.space'
 export const DEFAULT_SITE_NAME = 'ZPan'
 export const DEFAULT_SITE_DESCRIPTION = ''
 export const DEFAULT_ORG_QUOTA = 10 * 1024 * 1024
+export const DEFAULT_ORG_TRAFFIC_QUOTA = 0
 
 // Free plan allows up to this many organizations per user (including personal workspace).
 // The 3rd organization requires the teams_unlimited feature.

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -39,6 +39,9 @@ export interface OrgQuota {
   orgId: string
   quota: number
   used: number
+  trafficQuota: number
+  trafficUsed: number
+  trafficPeriod: string
 }
 
 export type QuotaGrantSource = 'stripe' | 'redeem_code' | 'admin_adjustment'

--- a/src/components/layout/quota-panel.test.tsx
+++ b/src/components/layout/quota-panel.test.tsx
@@ -90,7 +90,16 @@ afterEach(() => {
 
 describe('QuotaPanel', () => {
   it('keeps the storage area clickable when the store is unavailable', async () => {
-    vi.mocked(getUserQuota).mockResolvedValue({ orgId: 'org-1', baseQuota: 100, grantedQuota: 0, quota: 100, used: 25 })
+    vi.mocked(getUserQuota).mockResolvedValue({
+      orgId: 'org-1',
+      baseQuota: 100,
+      grantedQuota: 0,
+      quota: 100,
+      used: 25,
+      trafficQuota: 0,
+      trafficUsed: 0,
+      trafficPeriod: '2026-05',
+    })
     vi.mocked(listPurchasableQuotaPackages).mockRejectedValue(new Error('quota_store_disabled'))
     vi.mocked(listQuotaGrants).mockResolvedValue({ items: [], total: 0 })
 
@@ -102,7 +111,16 @@ describe('QuotaPanel', () => {
   })
 
   it('loads grants when redemption is available without packages', async () => {
-    vi.mocked(getUserQuota).mockResolvedValue({ orgId: 'org-1', baseQuota: 100, grantedQuota: 0, quota: 100, used: 25 })
+    vi.mocked(getUserQuota).mockResolvedValue({
+      orgId: 'org-1',
+      baseQuota: 100,
+      grantedQuota: 0,
+      quota: 100,
+      used: 25,
+      trafficQuota: 0,
+      trafficUsed: 0,
+      trafficPeriod: '2026-05',
+    })
     vi.mocked(listPurchasableQuotaPackages).mockResolvedValue({ items: [], total: 0 })
     vi.mocked(listQuotaGrants).mockResolvedValue({ items: [], total: 0 })
 
@@ -119,6 +137,9 @@ describe('QuotaPanel', () => {
       grantedQuota: 100,
       quota: 200,
       used: 25,
+      trafficQuota: 0,
+      trafficUsed: 0,
+      trafficPeriod: '2026-05',
     })
     vi.mocked(listPurchasableQuotaPackages).mockResolvedValue({ items: [quotaPackage()], total: 1 })
     vi.mocked(listQuotaGrants).mockResolvedValue({

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -996,7 +996,12 @@ describe('api', () => {
 
   describe('listQuotas', () => {
     it('fetches quotas list', async () => {
-      const payload = { items: [{ orgId: 'org1', quota: 1024, used: 512 }], total: 1 }
+      const payload = {
+        items: [
+          { orgId: 'org1', quota: 1024, used: 512, trafficQuota: 2048, trafficUsed: 256, trafficPeriod: '2026-05' },
+        ],
+        total: 1,
+      }
       vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
 
       const result = await listQuotas()
@@ -1015,17 +1020,24 @@ describe('api', () => {
 
   describe('updateQuota', () => {
     it('puts quota for an org and returns updated quota', async () => {
-      const updated = { orgId: 'org1', quota: 2048 }
+      const updated = {
+        orgId: 'org1',
+        quota: 2048,
+        used: 512,
+        trafficQuota: 4096,
+        trafficUsed: 256,
+        trafficPeriod: '2026-05',
+      }
       vi.mocked(fetch).mockResolvedValueOnce(makeResponse(updated))
 
-      const result = await updateQuota('org1', 2048)
+      const result = await updateQuota('org1', 2048, 4096)
 
       expect(result).toEqual(updated)
       const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
       expect(url).toContain('/api/admin/quotas/org1')
       expect(init.method).toBe('PUT')
       const body = typeof init.body === 'string' ? JSON.parse(init.body) : null
-      expect(body).toMatchObject({ quota: 2048 })
+      expect(body).toMatchObject({ quota: 2048, trafficQuota: 4096 })
     })
 
     it('throws on error response', async () => {
@@ -1037,7 +1049,16 @@ describe('api', () => {
 
   describe('getUserQuota', () => {
     it('fetches the current user quota', async () => {
-      const payload = { orgId: 'org1', quota: 1024, used: 256 }
+      const payload = {
+        orgId: 'org1',
+        baseQuota: 1024,
+        grantedQuota: 0,
+        quota: 1024,
+        used: 256,
+        trafficQuota: 2048,
+        trafficUsed: 512,
+        trafficPeriod: '2026-05',
+      }
       vi.mocked(fetch).mockResolvedValueOnce(makeResponse(payload))
 
       const result = await getUserQuota()

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -23,6 +23,7 @@ import type {
   IhostConfigResponse,
   ImageHosting,
   Notification,
+  OrgQuota,
   PaginatedResponse,
   QuotaGrant,
   QuotaStorePackage,
@@ -267,26 +268,39 @@ export function batchUpdateUserQuota(ids: string[], quota: number) {
 
 // Admin Quotas API
 
-export interface QuotaItem {
-  orgId: string
-  quota: number
-  used: number
+export type QuotaItem = Pick<
+  OrgQuota,
+  'orgId' | 'quota' | 'used' | 'trafficQuota' | 'trafficUsed' | 'trafficPeriod'
+> & {
+  orgName?: string
+  orgType?: string
 }
 
 export function listQuotas() {
   return unwrap<{ items: QuotaItem[]; total: number }>(adminQuotas.index.$get())
 }
 
-export function updateQuota(orgId: string, quota: number) {
-  return unwrap<{ orgId: string; quota: number }>(adminQuotas[':orgId'].$put({ param: { orgId }, json: { quota } }))
+export function updateQuota(orgId: string, quota: number, trafficQuota?: number) {
+  return unwrap<QuotaItem>(
+    adminQuotas[':orgId'].$put({
+      param: { orgId },
+      json: trafficQuota == null ? { quota } : { quota, trafficQuota },
+    }),
+  )
 }
 
 // User Quotas API
 
 export function getUserQuota() {
-  return unwrap<{ orgId: string; baseQuota: number; grantedQuota: number; quota: number; used: number }>(
-    userQuotas.me.$get(),
-  )
+  return unwrap<
+    {
+      orgId: string
+      baseQuota: number
+      grantedQuota: number
+      quota: number
+      used: number
+    } & Pick<OrgQuota, 'trafficQuota' | 'trafficUsed' | 'trafficPeriod'>
+  >(userQuotas.me.$get())
 }
 
 // Quota Store API

--- a/src/routes/_authenticated/storage.test.tsx
+++ b/src/routes/_authenticated/storage.test.tsx
@@ -119,6 +119,9 @@ describe('StoragePage', () => {
       grantedQuota: 512,
       quota: 1536,
       used: 0,
+      trafficQuota: 0,
+      trafficUsed: 0,
+      trafficPeriod: '2026-05',
     })
   })
 


### PR DESCRIPTION
## Summary
- add monthly traffic quota fields to org_quotas with generated migration defaults
- initialize default monthly traffic quota for new personal org quota rows and validate the system option boundary
- expose effective storage and traffic quota state in admin/user quota responses
- enforce monthly traffic consumption across authenticated object downloads, public/direct shares, and image redirects
- normalize monthly periods lazily and keep admin quota listing aggregated without per-org effective quota calls

## Tests
- npm run typecheck
- npm run lint (passes with existing warnings)
- npm test -- server/services/effective-quota.test.ts server/routes/quotas.integration.test.ts server/routes/quotas-listing.integration.test.ts server/routes/auth.integration.test.ts server/auth.integration.test.ts server/routes/objects-quota.integration.test.ts server/routes/redirect.integration.test.ts server/routes/share-public.integration.test.ts server/routes/system.integration.test.ts server/services/matter.integration.test.ts server/services/matter-conflict.integration.test.ts server/services/save-to-drive.integration.test.ts src/lib/api.test.ts src/routes/_authenticated/storage.test.tsx src/components/layout/quota-panel.test.tsx
- npm run test:cf -- server/routes/redirect.cf-test.ts server/routes/share-public.cf-test.ts