### PR TITLE
fix: enforce monthly traffic on download URL issuance

### DIFF
--- a/server/middleware/image-hosting-domain.cf-test.ts
+++ b/server/middleware/image-hosting-domain.cf-test.ts
@@ -75,8 +75,7 @@ describe('[CF] imageHostingDomain — custom Host serves image redirect', () => 
     })
     expect(res.status).toBe(302)
     expect(res.headers.get('location')).toBe(MOCK_INLINE_URL)
-    const cc = res.headers.get('cache-control') ?? ''
-    expect(cc).toContain('public')
+    expect(res.headers.get('cache-control')).toBe('no-store')
     vi.restoreAllMocks()
   })
 })

--- a/server/middleware/image-hosting-domain.integration.test.ts
+++ b/server/middleware/image-hosting-domain.integration.test.ts
@@ -1,5 +1,6 @@
 import { sql } from 'drizzle-orm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { currentTrafficPeriod } from '../services/effective-quota'
 import { S3Service } from '../services/s3'
 import { authedHeaders, createTestApp } from '../test/setup'
 
@@ -149,6 +150,84 @@ describe('imageHostingDomain middleware — custom domain redirect', () => {
     const cc = res.headers.get('cache-control') ?? ''
     expect(cc).toContain('public')
     expect(cc).toMatch(/max-age=\d+/)
+  })
+
+  it('verified custom domain consumes traffic quota when inline URL is issued', async () => {
+    const { app, db } = await createTestApp()
+    await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    await insertImageHosting(db, orgId, { id: 'dm-quota-ok', path: 'quota/image.png' })
+    await insertImageHostingConfig(db, orgId, { customDomain: 'img.quota.com' })
+    const trafficPeriod = currentTrafficPeriod()
+    await db.run(sql`
+      UPDATE org_quotas
+      SET traffic_quota = 2048, traffic_used = 256, traffic_period = ${trafficPeriod}
+      WHERE org_id = ${orgId}
+    `)
+
+    const res = await app.request('/quota/image.png', {
+      headers: { host: 'img.quota.com' },
+      redirect: 'manual',
+    })
+    expect(res.status).toBe(302)
+
+    const rows = await db.all<{ trafficUsed: number }>(
+      sql`SELECT traffic_used AS trafficUsed FROM org_quotas WHERE org_id = ${orgId}`,
+    )
+    expect(rows[0].trafficUsed).toBe(1280)
+  })
+
+  it('verified custom domain returns 422 when traffic quota is exhausted', async () => {
+    const { app, db } = await createTestApp()
+    await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    await insertImageHosting(db, orgId, { id: 'dm-quota-over', path: 'quota/over.png' })
+    await insertImageHostingConfig(db, orgId, { customDomain: 'img.quota-over.com' })
+    const trafficPeriod = currentTrafficPeriod()
+    await db.run(sql`
+      UPDATE org_quotas
+      SET traffic_quota = 512, traffic_used = 0, traffic_period = ${trafficPeriod}
+      WHERE org_id = ${orgId}
+    `)
+
+    const res = await app.request('/quota/over.png', {
+      headers: { host: 'img.quota-over.com' },
+      redirect: 'manual',
+    })
+    expect(res.status).toBe(422)
+    await expect(res.json()).resolves.toEqual({ error: 'Traffic quota exceeded' })
+    expect(S3Service.prototype.presignInline).not.toHaveBeenCalled()
+    expect(await getAccessCount(db, 'dm-quota-over')).toBe(0)
+  })
+
+  it('verified custom domain refunds traffic when inline URL signing fails', async () => {
+    const { app, db } = await createTestApp()
+    await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    await insertImageHosting(db, orgId, { id: 'dm-sign-fail', path: 'quota/sign-fail.png' })
+    await insertImageHostingConfig(db, orgId, { customDomain: 'img.sign-fail.com' })
+    const trafficPeriod = currentTrafficPeriod()
+    await db.run(sql`
+      UPDATE org_quotas
+      SET traffic_quota = 2048, traffic_used = 256, traffic_period = ${trafficPeriod}
+      WHERE org_id = ${orgId}
+    `)
+    vi.mocked(S3Service.prototype.presignInline).mockRejectedValueOnce(new Error('sign failed'))
+
+    const res = await app.request('/quota/sign-fail.png', {
+      headers: { host: 'img.sign-fail.com' },
+      redirect: 'manual',
+    })
+    expect(res.status).toBe(500)
+
+    const rows = await db.all<{ trafficUsed: number }>(
+      sql`SELECT traffic_used AS trafficUsed FROM org_quotas WHERE org_id = ${orgId}`,
+    )
+    expect(rows[0].trafficUsed).toBe(256)
+    expect(await getAccessCount(db, 'dm-sign-fail')).toBe(0)
   })
 
   it('verified custom domain, path not found → 404', async () => {

--- a/server/middleware/image-hosting-domain.integration.test.ts
+++ b/server/middleware/image-hosting-domain.integration.test.ts
@@ -133,7 +133,7 @@ describe('imageHostingDomain middleware — unverified domain', () => {
 // ─── Custom domain redirect ───────────────────────────────────────────────────
 
 describe('imageHostingDomain middleware — custom domain redirect', () => {
-  it('verified custom domain with valid path → 302 with Cache-Control: public, max-age=300', async () => {
+  it('verified custom domain with valid path returns non-cacheable metered redirect', async () => {
     const { app, db } = await createTestApp()
     await authedHeaders(app)
     await insertStorage(db)
@@ -147,9 +147,7 @@ describe('imageHostingDomain middleware — custom domain redirect', () => {
     })
     expect(res.status).toBe(302)
     expect(res.headers.get('location')).toBe(MOCK_INLINE_URL)
-    const cc = res.headers.get('cache-control') ?? ''
-    expect(cc).toContain('public')
-    expect(cc).toMatch(/max-age=\d+/)
+    expect(res.headers.get('cache-control')).toBe('no-store')
   })
 
   it('verified custom domain consumes traffic quota when inline URL is issued', async () => {

--- a/server/middleware/image-hosting-domain.ts
+++ b/server/middleware/image-hosting-domain.ts
@@ -4,6 +4,7 @@ import type { Storage as S3Storage } from '../../shared/types'
 import { imageHostingConfigs } from '../db/schema'
 import type { Env } from '../middleware/platform'
 import { PRESIGN_TTL_SECS, s3 } from '../routes/share-utils'
+import { consumeTrafficIfQuotaAllows, refundTraffic } from '../services/effective-quota'
 import { getImageByOrgPath, incrementAccessCount, resolveCustomDomain } from '../services/image-hosting'
 import { getStorage } from '../services/storage'
 
@@ -65,9 +66,17 @@ async function handleImageByPath(c: Context<Env>, orgId: string, virtualPath: st
   const storage = (await getStorage(db, image.storageId)) as unknown as S3Storage
   if (!storage) return c.json({ error: 'Storage not found' }, 404)
 
-  await incrementAccessCount(db, image.id)
+  const trafficAllowed = await consumeTrafficIfQuotaAllows(db, image.orgId, image.size)
+  if (!trafficAllowed) return c.json({ error: 'Traffic quota exceeded' }, 422)
 
-  const url = await s3.presignInline(storage, image.storageKey, image.mime, PRESIGN_TTL_SECS)
+  let url: string
+  try {
+    url = await s3.presignInline(storage, image.storageKey, image.mime, PRESIGN_TTL_SECS)
+    await incrementAccessCount(db, image.id)
+  } catch (e) {
+    await refundTraffic(db, image.orgId, image.size)
+    throw e
+  }
   const res = c.redirect(url, 302)
   res.headers.set('Cache-Control', `public, max-age=${IMAGE_MAX_AGE}`)
   return res

--- a/server/middleware/image-hosting-domain.ts
+++ b/server/middleware/image-hosting-domain.ts
@@ -8,8 +8,6 @@ import { consumeTrafficIfQuotaAllows, refundTraffic } from '../services/effectiv
 import { getImageByOrgPath, incrementAccessCount, resolveCustomDomain } from '../services/image-hosting'
 import { getStorage } from '../services/storage'
 
-const IMAGE_MAX_AGE = Math.min(PRESIGN_TTL_SECS - 30, 300)
-
 function stripPort(host: string): string {
   const lastColon = host.lastIndexOf(':')
   if (lastColon < 0) return host
@@ -78,7 +76,7 @@ async function handleImageByPath(c: Context<Env>, orgId: string, virtualPath: st
     throw e
   }
   const res = c.redirect(url, 302)
-  res.headers.set('Cache-Control', `public, max-age=${IMAGE_MAX_AGE}`)
+  res.headers.set('Cache-Control', 'no-store')
   return res
 }
 

--- a/server/routes/objects-quota.integration.test.ts
+++ b/server/routes/objects-quota.integration.test.ts
@@ -235,6 +235,53 @@ describe('GET /api/objects/:id — traffic quota enforcement', () => {
     expect(rows[0].trafficUsed).toBe(125)
   })
 
+  it('resets stale monthly traffic period before consuming traffic', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    await insertFile(db, orgId, { id: 'm-download-reset', name: 'download.txt', size: 100 })
+    const trafficPeriod = currentTrafficPeriod()
+    await db.run(sql`
+      UPDATE org_quotas
+      SET traffic_quota = 500, traffic_used = 500, traffic_period = '1970-01'
+      WHERE org_id = ${orgId}
+    `)
+
+    const res = await app.request('/api/objects/m-download-reset', { headers })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.downloadUrl).toBe('https://presigned-download.example.com')
+
+    const rows = await db.all<{ trafficUsed: number; trafficPeriod: string }>(
+      sql`SELECT traffic_used AS trafficUsed, traffic_period AS trafficPeriod FROM org_quotas WHERE org_id = ${orgId}`,
+    )
+    expect(rows[0]).toEqual({ trafficUsed: 100, trafficPeriod })
+  })
+
+  it('refunds traffic when download URL signing fails', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    await insertFile(db, orgId, { id: 'm-download-sign-fail', name: 'download.txt', size: 100 })
+    const trafficPeriod = currentTrafficPeriod()
+    await db.run(sql`
+      UPDATE org_quotas
+      SET traffic_quota = 500, traffic_used = 25, traffic_period = ${trafficPeriod}
+      WHERE org_id = ${orgId}
+    `)
+    vi.mocked(S3Service.prototype.presignDownload).mockRejectedValueOnce(new Error('sign failed'))
+
+    const res = await app.request('/api/objects/m-download-sign-fail', { headers })
+    expect(res.status).toBe(500)
+
+    const rows = await db.all<{ trafficUsed: number }>(
+      sql`SELECT traffic_used AS trafficUsed FROM org_quotas WHERE org_id = ${orgId}`,
+    )
+    expect(rows[0].trafficUsed).toBe(25)
+  })
+
   it('returns 422 when download traffic quota is exhausted', async () => {
     const { app, db } = await createTestApp()
     const headers = await authedHeaders(app)

--- a/server/routes/objects.ts
+++ b/server/routes/objects.ts
@@ -12,7 +12,7 @@ import type { Storage as S3Storage } from '../../shared/types'
 import { requireAuth, requireTeamRole } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
 import { recordActivity } from '../services/activity'
-import { consumeTrafficIfQuotaAllows, hasTrafficQuotaForBytes } from '../services/effective-quota'
+import { consumeTrafficIfQuotaAllows, refundTraffic } from '../services/effective-quota'
 import {
   batchMove,
   batchTrash,
@@ -195,13 +195,16 @@ const app = new Hono<Env>()
     const storage = (await getStorage(db, matter.storageId)) as unknown as S3Storage
     if (!storage) return c.json({ error: 'Storage not found' }, 404)
 
-    if (!(await hasTrafficQuotaForBytes(db, orgId, matter.size ?? 0))) {
-      return c.json({ error: 'Traffic quota exceeded' }, 422)
-    }
-
-    const downloadUrl = await s3.presignDownload(storage, matter.object, matter.name)
     const trafficAllowed = await consumeTrafficIfQuotaAllows(db, orgId, matter.size ?? 0)
     if (!trafficAllowed) return c.json({ error: 'Traffic quota exceeded' }, 422)
+
+    let downloadUrl: string
+    try {
+      downloadUrl = await s3.presignDownload(storage, matter.object, matter.name)
+    } catch (e) {
+      await refundTraffic(db, orgId, matter.size ?? 0)
+      throw e
+    }
 
     return c.json({ ...matter, downloadUrl })
   })

--- a/server/routes/redirect.integration.test.ts
+++ b/server/routes/redirect.integration.test.ts
@@ -165,31 +165,32 @@ describe('GET /r/:token (ds_ direct shares)', () => {
     expect(rows[0].trafficUsed).toBe(1280)
   })
 
-  it('compensates direct share download count when traffic is exhausted after presign', async () => {
+  it('refunds traffic and download count when direct share signing fails', async () => {
     const { app, db } = await createTestApp()
     await authedHeaders(app)
     await insertStorage(db)
     const orgId = await getOrgId(db)
     const creatorId = await getUserId(db)
-    await insertFile(db, orgId, { id: 'ds-quota-race', name: 'quota.bin' })
+    await insertFile(db, orgId, { id: 'ds-sign-fail', name: 'quota.bin' })
     const trafficPeriod = currentTrafficPeriod()
     await db.run(sql`
       UPDATE org_quotas
-      SET traffic_quota = 1024, traffic_used = 0, traffic_period = ${trafficPeriod}
+      SET traffic_quota = 2048, traffic_used = 256, traffic_period = ${trafficPeriod}
       WHERE org_id = ${orgId}
     `)
-    vi.mocked(S3Service.prototype.presignDownload).mockImplementationOnce(async () => {
-      await db.run(sql`UPDATE org_quotas SET traffic_used = 1024 WHERE org_id = ${orgId}`)
-      return MOCK_PRESIGN_URL
-    })
-    const share = await createShare(db, { matterId: 'ds-quota-race', orgId, creatorId, kind: 'direct' })
+    vi.mocked(S3Service.prototype.presignDownload).mockRejectedValueOnce(new Error('sign failed'))
+    const share = await createShare(db, { matterId: 'ds-sign-fail', orgId, creatorId, kind: 'direct' })
 
     const res = await app.request(`/r/${share.token}`, { redirect: 'manual' })
-    expect(res.status).toBe(422)
-    await expect(res.json()).resolves.toEqual({ error: 'Traffic quota exceeded' })
+    expect(res.status).toBe(500)
 
-    const shares = await db.all<{ downloads: number }>(sql`SELECT downloads FROM shares WHERE id = ${share.id}`)
-    expect(shares[0].downloads).toBe(0)
+    const trafficRows = await db.all<{ trafficUsed: number }>(
+      sql`SELECT traffic_used AS trafficUsed FROM org_quotas WHERE org_id = ${orgId}`,
+    )
+    expect(trafficRows[0].trafficUsed).toBe(256)
+
+    const shareRows = await db.all<{ downloads: number }>(sql`SELECT downloads FROM shares WHERE id = ${share.id}`)
+    expect(shareRows[0].downloads).toBe(0)
   })
 })
 
@@ -283,6 +284,30 @@ describe('GET /r/:token (ih_ image hosting)', () => {
       sql`SELECT traffic_used AS trafficUsed FROM org_quotas WHERE org_id = ${orgId}`,
     )
     expect(rows[0].trafficUsed).toBe(1280)
+  })
+
+  it('refunds traffic when image hosting signing fails', async () => {
+    const { app, db } = await createTestApp()
+    await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    await insertImageHosting(db, orgId, { id: 'ih-sign-fail', token: 'ih_signfail' })
+    const trafficPeriod = currentTrafficPeriod()
+    await db.run(sql`
+      UPDATE org_quotas
+      SET traffic_quota = 2048, traffic_used = 256, traffic_period = ${trafficPeriod}
+      WHERE org_id = ${orgId}
+    `)
+    vi.mocked(S3Service.prototype.presignInline).mockRejectedValueOnce(new Error('sign failed'))
+
+    const res = await app.request('/r/ih_signfail', { redirect: 'manual' })
+    expect(res.status).toBe(500)
+
+    const rows = await db.all<{ trafficUsed: number }>(
+      sql`SELECT traffic_used AS trafficUsed FROM org_quotas WHERE org_id = ${orgId}`,
+    )
+    expect(rows[0].trafficUsed).toBe(256)
+    expect(await getAccessCount(db, 'ih-sign-fail')).toBe(0)
   })
 
   it('rejects the next image redirect after the first one consumes the remaining monthly traffic quota', async () => {

--- a/server/routes/redirect.ts
+++ b/server/routes/redirect.ts
@@ -3,7 +3,7 @@ import { Hono } from 'hono'
 import type { Storage as S3Storage } from '../../shared/types'
 import type { Env } from '../middleware/platform'
 import type { Database } from '../platform/interface'
-import { consumeTrafficIfQuotaAllows, hasTrafficQuotaForBytes } from '../services/effective-quota'
+import { consumeTrafficIfQuotaAllows, refundTraffic } from '../services/effective-quota'
 import { incrementAccessCount, resolveActiveImageByToken } from '../services/image-hosting'
 import {
   decrementDownloads,
@@ -51,12 +51,6 @@ async function handleDirectShare(c: Context<Env>, db: Database, token: string): 
   const storage = (await getStorage(db, matter.storageId)) as unknown as S3Storage
   if (!storage) return c.json({ error: 'Storage not found' }, 404)
 
-  if (!(await hasTrafficQuotaForBytes(db, share.orgId, matter.size ?? 0))) {
-    return c.json({ error: 'Traffic quota exceeded' }, 422)
-  }
-
-  const url = await s3.presignDownload(storage, matter.object, matter.name, PRESIGN_TTL_SECS)
-
   const { ok } = await incrementDownloadsAtomic(db, share.id)
   if (!ok) return c.json({ error: 'Download limit exceeded' }, 410)
 
@@ -64,6 +58,15 @@ async function handleDirectShare(c: Context<Env>, db: Database, token: string): 
   if (!trafficAllowed) {
     await decrementDownloads(db, share.id)
     return c.json({ error: 'Traffic quota exceeded' }, 422)
+  }
+
+  let url: string
+  try {
+    url = await s3.presignDownload(storage, matter.object, matter.name, PRESIGN_TTL_SECS)
+  } catch (e) {
+    await refundTraffic(db, share.orgId, matter.size ?? 0)
+    await decrementDownloads(db, share.id)
+    throw e
   }
 
   const res = c.redirect(url, 302)
@@ -89,15 +92,17 @@ async function handleImageHosting(c: Context<Env>, db: Database, token: string):
   const storage = (await getStorage(db, image.storageId)) as unknown as S3Storage
   if (!storage) return c.json({ error: 'Storage not found' }, 404)
 
-  if (!(await hasTrafficQuotaForBytes(db, image.orgId, image.size))) {
-    return c.json({ error: 'Traffic quota exceeded' }, 422)
-  }
-
-  const url = await s3.presignInline(storage, image.storageKey, image.mime, PRESIGN_TTL_SECS)
-
   const trafficAllowed = await consumeTrafficIfQuotaAllows(db, image.orgId, image.size)
   if (!trafficAllowed) return c.json({ error: 'Traffic quota exceeded' }, 422)
-  await incrementAccessCount(db, image.id)
+
+  let url: string
+  try {
+    url = await s3.presignInline(storage, image.storageKey, image.mime, PRESIGN_TTL_SECS)
+    await incrementAccessCount(db, image.id)
+  } catch (e) {
+    await refundTraffic(db, image.orgId, image.size)
+    throw e
+  }
 
   const res = c.redirect(url, 302)
   res.headers.set('Cache-Control', 'no-store')

--- a/server/routes/share-public.integration.test.ts
+++ b/server/routes/share-public.integration.test.ts
@@ -296,6 +296,12 @@ describe('GET /api/shares/:token/objects/:ref — root file', () => {
     const orgId = await getOrgId(db)
     const creatorId = await getUserId(db)
     await insertFile(db, orgId, { id: 'dl1', name: 'file.txt' })
+    const trafficPeriod = currentTrafficPeriod()
+    await db.run(sql`
+      UPDATE org_quotas
+      SET traffic_quota = 2048, traffic_used = 256, traffic_period = ${trafficPeriod}
+      WHERE org_id = ${orgId}
+    `)
     const share = await createShare(db, { matterId: 'dl1', orgId, creatorId, kind: 'landing' })
 
     const rootRef = await fetchRootRef(app, share.token)
@@ -303,6 +309,11 @@ describe('GET /api/shares/:token/objects/:ref — root file', () => {
     expect(res.status).toBe(302)
     expect(res.headers.get('location')).toBe(MOCK_PRESIGN_URL)
     expect(res.headers.get('cache-control')).toBe('no-store')
+
+    const rows = await db.all<{ trafficUsed: number }>(
+      sql`SELECT traffic_used AS trafficUsed FROM org_quotas WHERE org_id = ${orgId}`,
+    )
+    expect(rows[0].trafficUsed).toBe(1280)
   })
 
   it('returns JSON downloadUrl for public share when requested by preview', async () => {
@@ -347,32 +358,33 @@ describe('GET /api/shares/:token/objects/:ref — root file', () => {
     expect(rows[0].trafficUsed).toBe(1280)
   })
 
-  it('compensates public share download count when traffic is exhausted after presign', async () => {
+  it('refunds traffic and download count when public share signing fails', async () => {
     const { app, db } = await createTestApp()
     await authedHeaders(app)
     await insertStorage(db)
     const orgId = await getOrgId(db)
     const creatorId = await getUserId(db)
-    await insertFile(db, orgId, { id: 'dl-traffic-race', name: 'traffic.txt' })
+    await insertFile(db, orgId, { id: 'dl-sign-fail', name: 'traffic.txt' })
     const trafficPeriod = currentTrafficPeriod()
     await db.run(sql`
       UPDATE org_quotas
-      SET traffic_quota = 1024, traffic_used = 0, traffic_period = ${trafficPeriod}
+      SET traffic_quota = 2048, traffic_used = 256, traffic_period = ${trafficPeriod}
       WHERE org_id = ${orgId}
     `)
-    vi.mocked(S3Service.prototype.presignDownload).mockImplementationOnce(async () => {
-      await db.run(sql`UPDATE org_quotas SET traffic_used = 1024 WHERE org_id = ${orgId}`)
-      return MOCK_PRESIGN_URL
-    })
-    const share = await createShare(db, { matterId: 'dl-traffic-race', orgId, creatorId, kind: 'landing' })
+    vi.mocked(S3Service.prototype.presignDownload).mockRejectedValueOnce(new Error('sign failed'))
+    const share = await createShare(db, { matterId: 'dl-sign-fail', orgId, creatorId, kind: 'landing' })
 
     const rootRef = await fetchRootRef(app, share.token)
     const res = await app.request(`/api/shares/${share.token}/objects/${rootRef}?downloadUrl=1`, { redirect: 'manual' })
-    expect(res.status).toBe(422)
-    await expect(res.json()).resolves.toEqual({ error: 'Traffic quota exceeded' })
+    expect(res.status).toBe(500)
 
-    const shares = await db.all<{ downloads: number }>(sql`SELECT downloads FROM shares WHERE id = ${share.id}`)
-    expect(shares[0].downloads).toBe(0)
+    const trafficRows = await db.all<{ trafficUsed: number }>(
+      sql`SELECT traffic_used AS trafficUsed FROM org_quotas WHERE org_id = ${orgId}`,
+    )
+    expect(trafficRows[0].trafficUsed).toBe(256)
+
+    const shareRows = await db.all<{ downloads: number }>(sql`SELECT downloads FROM shares WHERE id = ${share.id}`)
+    expect(shareRows[0].downloads).toBe(0)
   })
 
   it('returns 422 when public share traffic quota is exhausted', async () => {

--- a/server/routes/shares.ts
+++ b/server/routes/shares.ts
@@ -11,7 +11,7 @@ import { matters } from '../db/schema'
 import { requireAuth, requireTeamRole } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
 import { recordActivity } from '../services/activity'
-import { consumeTrafficIfQuotaAllows, hasTrafficQuotaForBytes } from '../services/effective-quota'
+import { consumeTrafficIfQuotaAllows, refundTraffic } from '../services/effective-quota'
 import { listMatters } from '../services/matter'
 import { getMemberRole, isPersonalOrg } from '../services/org'
 import {
@@ -273,11 +273,6 @@ export const publicShares = new Hono<Env>()
     const storage = (await getStorage(db, targetMatter.storageId)) as unknown as S3Storage
     if (!storage) return c.json({ error: 'Storage not found' }, 404)
 
-    if (!(await hasTrafficQuotaForBytes(db, share.orgId, targetMatter.size ?? 0))) {
-      return c.json({ error: 'Traffic quota exceeded' }, 422)
-    }
-
-    const url = await s3.presignDownload(storage, targetMatter.object, targetMatter.name, PRESIGN_TTL_SECS)
     const { ok } = await incrementDownloadsAtomic(db, share.id)
     if (!ok) return c.json({ error: 'Download limit exceeded' }, 410)
 
@@ -291,15 +286,23 @@ export const publicShares = new Hono<Env>()
     // fall back to the share creator as the org-attributed actor for anonymous
     // downloads. The presigned URL is never stored in metadata.
     const actorId = viewerId ?? share.creatorId
-    await recordActivity(db, {
-      orgId: share.orgId,
-      userId: actorId,
-      action: 'share_download',
-      targetType: 'share',
-      targetId: share.id,
-      targetName: targetMatter.name,
-      metadata: { anonymous: !viewerId },
-    })
+    let url: string
+    try {
+      url = await s3.presignDownload(storage, targetMatter.object, targetMatter.name, PRESIGN_TTL_SECS)
+      await recordActivity(db, {
+        orgId: share.orgId,
+        userId: actorId,
+        action: 'share_download',
+        targetType: 'share',
+        targetId: share.id,
+        targetName: targetMatter.name,
+        metadata: { anonymous: !viewerId },
+      })
+    } catch (e) {
+      await refundTraffic(db, share.orgId, targetMatter.size ?? 0)
+      await decrementDownloads(db, share.id)
+      throw e
+    }
 
     if (returnUrl) {
       const res = c.json({ downloadUrl: url })

--- a/server/services/effective-quota.test.ts
+++ b/server/services/effective-quota.test.ts
@@ -3,7 +3,12 @@ import { nanoid } from 'nanoid'
 import { describe, expect, it } from 'vitest'
 import { orgQuotas } from '../db/schema.js'
 import { createTestApp } from '../test/setup.js'
-import { consumeTrafficIfQuotaAllows, getEffectiveQuota, hasTrafficQuotaForBytes } from './effective-quota.js'
+import {
+  consumeTrafficIfQuotaAllows,
+  getEffectiveQuota,
+  hasTrafficQuotaForBytes,
+  refundTraffic,
+} from './effective-quota.js'
 
 describe('effective quota', () => {
   it('returns storage and traffic quota state', async () => {
@@ -73,6 +78,26 @@ describe('effective quota', () => {
 
     const rows = await db.select().from(orgQuotas).where(eq(orgQuotas.orgId, orgId))
     expect(rows[0].trafficUsed).toBe(1000)
+  })
+
+  it('refunds current monthly traffic usage', async () => {
+    const { db } = await createTestApp()
+    const orgId = nanoid()
+    const now = new Date('2026-05-06T00:00:00Z')
+    await db.insert(orgQuotas).values({
+      id: nanoid(),
+      orgId,
+      quota: 1000,
+      used: 0,
+      trafficQuota: 1000,
+      trafficUsed: 700,
+      trafficPeriod: '2026-05',
+    })
+
+    await refundTraffic(db, orgId, 300, now)
+
+    const rows = await db.select().from(orgQuotas).where(eq(orgQuotas.orgId, orgId))
+    expect(rows[0].trafficUsed).toBe(400)
   })
 
   it('consumes traffic from zero when the period changes', async () => {

--- a/server/services/effective-quota.test.ts
+++ b/server/services/effective-quota.test.ts
@@ -100,6 +100,26 @@ describe('effective quota', () => {
     expect(rows[0].trafficUsed).toBe(400)
   })
 
+  it('clamps refunded monthly traffic usage at zero', async () => {
+    const { db } = await createTestApp()
+    const orgId = nanoid()
+    const now = new Date('2026-05-06T00:00:00Z')
+    await db.insert(orgQuotas).values({
+      id: nanoid(),
+      orgId,
+      quota: 1000,
+      used: 0,
+      trafficQuota: 1000,
+      trafficUsed: 100,
+      trafficPeriod: '2026-05',
+    })
+
+    await refundTraffic(db, orgId, 300, now)
+
+    const rows = await db.select().from(orgQuotas).where(eq(orgQuotas.orgId, orgId))
+    expect(rows[0].trafficUsed).toBe(0)
+  })
+
   it('consumes traffic from zero when the period changes', async () => {
     const { db } = await createTestApp()
     const orgId = nanoid()

--- a/server/services/effective-quota.ts
+++ b/server/services/effective-quota.ts
@@ -125,7 +125,9 @@ export async function refundTraffic(db: Database, orgId: string, bytes: number, 
   const period = currentTrafficPeriod(now)
   await db
     .update(orgQuotas)
-    .set({ trafficUsed: sql`${orgQuotas.trafficUsed} - ${bytes}` })
+    .set({
+      trafficUsed: sql`CASE WHEN ${orgQuotas.trafficUsed} > ${bytes} THEN ${orgQuotas.trafficUsed} - ${bytes} ELSE 0 END`,
+    })
     .where(sql`${orgQuotas.orgId} = ${orgId} AND ${orgQuotas.trafficPeriod} = ${period}`)
 }
 

--- a/server/services/effective-quota.ts
+++ b/server/services/effective-quota.ts
@@ -120,6 +120,15 @@ export async function consumeTrafficIfQuotaAllows(
   return updated.length > 0
 }
 
+export async function refundTraffic(db: Database, orgId: string, bytes: number, now = new Date()): Promise<void> {
+  if (bytes <= 0) return
+  const period = currentTrafficPeriod(now)
+  await db
+    .update(orgQuotas)
+    .set({ trafficUsed: sql`${orgQuotas.trafficUsed} - ${bytes}` })
+    .where(sql`${orgQuotas.orgId} = ${orgId} AND ${orgQuotas.trafficPeriod} = ${period}`)
+}
+
 export async function incrementUsageIfEffectiveQuotaAllows(
   db: Database,
   orgId: string,


### PR DESCRIPTION
## Summary
- consume monthly traffic quota before issuing authenticated object download URLs
- consume and compensate share download counters before public/direct share URL issuance
- enforce traffic quota for image hosting inline redirects, including custom domains
- refund traffic when presign/audit/access-count work fails before a URL is returned

## Verification
- npm test -- server/services/effective-quota.test.ts server/routes/objects-quota.integration.test.ts server/routes/share-public.integration.test.ts server/routes/redirect.integration.test.ts server/middleware/image-hosting-domain.integration.test.ts
- npm run typecheck
- npx biome check server/services/effective-quota.ts server/services/effective-quota.test.ts server/routes/objects.ts server/routes/shares.ts server/routes/redirect.ts server/middleware/image-hosting-domain.ts server/routes/objects-quota.integration.test.ts server/routes/share-public.integration.test.ts server/routes/redirect.integration.test.ts server/middleware/image-hosting-domain.integration.test.ts

Note: full npm run lint currently reports unrelated pre-existing diagnostics outside this task.