### PR TITLE
feat: add quota entitlement model

### DIFF
--- a/migrations/0029_past_stepford_cuckoos.sql
+++ b/migrations/0029_past_stepford_cuckoos.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `org_quota_entitlements` (
+	`id` text PRIMARY KEY NOT NULL,
+	`org_id` text NOT NULL,
+	`resource_type` text NOT NULL,
+	`source` text NOT NULL,
+	`source_id` text NOT NULL,
+	`bytes` integer NOT NULL,
+	`starts_at` integer NOT NULL,
+	`expires_at` integer,
+	`status` text NOT NULL,
+	`metadata` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `org_quota_entitlements_source_uniq` ON `org_quota_entitlements` (`org_id`,`resource_type`,`source`,`source_id`);--> statement-breakpoint
+CREATE INDEX `org_quota_entitlements_effective_idx` ON `org_quota_entitlements` (`org_id`,`resource_type`,`status`,`starts_at`,`expires_at`);

--- a/migrations/meta/0029_snapshot.json
+++ b/migrations/meta/0029_snapshot.json
@@ -1,0 +1,2549 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1a85106a-c620-43df-b1d7-bad2e46f94a4",
+  "prevId": "892fb4f3-8acb-424f-934e-3be566c66324",
+  "tables": {
+    "activity_events": {
+      "name": "activity_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "announcements": {
+      "name": "announcements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "announcements_status_priority_idx": {
+          "name": "announcements_status_priority_idx",
+          "columns": [
+            "status",
+            "priority"
+          ],
+          "isUnique": false
+        },
+        "announcements_published_idx": {
+          "name": "announcements_published_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "image_hosting_configs": {
+      "name": "image_hosting_configs",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_domain": {
+          "name": "custom_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cf_hostname_id": {
+          "name": "cf_hostname_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "domain_verified_at": {
+          "name": "domain_verified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referer_allowlist": {
+          "name": "referer_allowlist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "image_hosting_configs_custom_domain_unique": {
+          "name": "image_hosting_configs_custom_domain_unique",
+          "columns": [
+            "custom_domain"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "image_hosting_configs_org_id_organization_id_fk": {
+          "name": "image_hosting_configs_org_id_organization_id_fk",
+          "tableFrom": "image_hosting_configs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "image_hostings": {
+      "name": "image_hostings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "image_hostings_token_unique": {
+          "name": "image_hostings_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "image_hostings_org_path_uniq": {
+          "name": "image_hostings_org_path_uniq",
+          "columns": [
+            "org_id",
+            "path"
+          ],
+          "isUnique": true
+        },
+        "image_hostings_org_created_idx": {
+          "name": "image_hostings_org_created_idx",
+          "columns": [
+            "org_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "image_hostings_token_idx": {
+          "name": "image_hostings_token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "image_hostings_org_id_organization_id_fk": {
+          "name": "image_hostings_org_id_organization_id_fk",
+          "tableFrom": "image_hostings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "image_hostings_storage_id_storages_id_fk": {
+          "name": "image_hostings_storage_id_storages_id_fk",
+          "tableFrom": "image_hostings",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invite_codes": {
+      "name": "invite_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invite_codes_code_unique": {
+          "name": "invite_codes_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "license_bindings": {
+      "name": "license_bindings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_binding_id": {
+          "name": "cloud_binding_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_store_id": {
+          "name": "cloud_store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_account_id": {
+          "name": "cloud_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_account_email": {
+          "name": "cloud_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cached_certificate": {
+          "name": "cached_certificate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cached_certificate_expires_at": {
+          "name": "cached_certificate_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bound_at": {
+          "name": "bound_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disconnected_at": {
+          "name": "disconnected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refresh_at": {
+          "name": "last_refresh_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refresh_error": {
+          "name": "last_refresh_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "license_bindings_active_uniq": {
+          "name": "license_bindings_active_uniq",
+          "columns": [
+            "status"
+          ],
+          "isUnique": true,
+          "where": "status = 'active'"
+        },
+        "license_bindings_cloud_binding_idx": {
+          "name": "license_bindings_cloud_binding_idx",
+          "columns": [
+            "cloud_binding_id"
+          ],
+          "isUnique": false
+        },
+        "license_bindings_instance_idx": {
+          "name": "license_bindings_instance_idx",
+          "columns": [
+            "instance_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "matters": {
+      "name": "matters",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dirtype": {
+          "name": "dirtype",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "parent": {
+          "name": "parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "trashed_at": {
+          "name": "trashed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "matters_alias_unique": {
+          "name": "matters_alias_unique",
+          "columns": [
+            "alias"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "notifications_user_read_idx": {
+          "name": "notifications_user_read_idx",
+          "columns": [
+            "user_id",
+            "read_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "org_quota_entitlements": {
+      "name": "org_quota_entitlements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "org_quota_entitlements_source_uniq": {
+          "name": "org_quota_entitlements_source_uniq",
+          "columns": [
+            "org_id",
+            "resource_type",
+            "source",
+            "source_id"
+          ],
+          "isUnique": true
+        },
+        "org_quota_entitlements_effective_idx": {
+          "name": "org_quota_entitlements_effective_idx",
+          "columns": [
+            "org_id",
+            "resource_type",
+            "status",
+            "starts_at",
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "org_quotas": {
+      "name": "org_quotas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quota": {
+          "name": "quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "traffic_quota": {
+          "name": "traffic_quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "traffic_used": {
+          "name": "traffic_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "traffic_period": {
+          "name": "traffic_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1970-01'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_recipients": {
+      "name": "share_recipients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "share_id": {
+          "name": "share_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "share_recipients_share_id_idx": {
+          "name": "share_recipients_share_id_idx",
+          "columns": [
+            "share_id"
+          ],
+          "isUnique": false
+        },
+        "share_recipients_user_id_idx": {
+          "name": "share_recipients_user_id_idx",
+          "columns": [
+            "recipient_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shares": {
+      "name": "shares",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matter_id": {
+          "name": "matter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_limit": {
+          "name": "download_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "downloads": {
+          "name": "downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "shares_token_unique": {
+          "name": "shares_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "shares_creator_status_created_idx": {
+          "name": "shares_creator_status_created_idx",
+          "columns": [
+            "creator_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_invitations": {
+      "name": "site_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "site_invitations_token_unique": {
+          "name": "site_invitations_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "site_invitations_email_idx": {
+          "name": "site_invitations_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "site_invitations_created_idx": {
+          "name": "site_invitations_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "site_invitations_expires_idx": {
+          "name": "site_invitations_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "storages": {
+      "name": "storages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'auto'"
+        },
+        "access_key": {
+          "name": "access_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_key": {
+          "name": "secret_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "custom_host": {
+          "name": "custom_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_options": {
+      "name": "system_options",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "public": {
+          "name": "public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_invite_links": {
+      "name": "team_invite_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_invite_links_token_unique": {
+          "name": "team_invite_links_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_events": {
+      "name": "webhook_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cloud'"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'order.quota_changed'"
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhook_events_source_event_uniq": {
+          "name": "webhook_events_source_event_uniq",
+          "columns": [
+            "source",
+            "event_id"
+          ],
+          "isUnique": true
+        },
+        "webhook_events_source_created_idx": {
+          "name": "webhook_events_source_created_idx",
+          "columns": [
+            "source",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "webhook_events_status_idx": {
+          "name": "webhook_events_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_config_id_idx": {
+          "name": "apikey_config_id_idx",
+          "columns": [
+            "config_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_reference_id_idx": {
+          "name": "apikey_reference_id_idx",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1778246297143,
       "tag": "0028_move-cloud-store-settings-to-system-options",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "6",
+      "when": 1778270757288,
+      "tag": "0029_past_stepford_cuckoos",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -47,6 +47,28 @@ export const orgQuotas = sqliteTable('org_quotas', {
   trafficPeriod: text('traffic_period').notNull().default('1970-01'),
 })
 
+export const orgQuotaEntitlements = sqliteTable(
+  'org_quota_entitlements',
+  {
+    id: text('id').primaryKey(),
+    orgId: text('org_id').notNull(),
+    resourceType: text('resource_type').notNull(),
+    source: text('source').notNull(),
+    sourceId: text('source_id').notNull(),
+    bytes: integer('bytes').notNull(),
+    startsAt: integer('starts_at', { mode: 'timestamp_ms' }).notNull(),
+    expiresAt: integer('expires_at', { mode: 'timestamp_ms' }),
+    status: text('status').notNull(),
+    metadata: text('metadata'),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+    updatedAt: integer('updated_at', { mode: 'timestamp_ms' }).notNull(),
+  },
+  (t) => [
+    uniqueIndex('org_quota_entitlements_source_uniq').on(t.orgId, t.resourceType, t.source, t.sourceId),
+    index('org_quota_entitlements_effective_idx').on(t.orgId, t.resourceType, t.status, t.startsAt, t.expiresAt),
+  ],
+)
+
 export const webhookEvents = sqliteTable(
   'webhook_events',
   {

--- a/server/routes/objects-copy-cleanup.integration.test.ts
+++ b/server/routes/objects-copy-cleanup.integration.test.ts
@@ -1,0 +1,165 @@
+import { eq, sql } from 'drizzle-orm'
+import { nanoid } from 'nanoid'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { orgQuotas } from '../db/schema.js'
+import { currentTrafficPeriod } from '../services/effective-quota.js'
+import { S3Service } from '../services/s3.js'
+import { authedHeaders, createTestApp } from '../test/setup.js'
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  vi.spyOn(S3Service.prototype, 'deleteObject').mockResolvedValue(undefined)
+  vi.spyOn(S3Service.prototype, 'deleteObjects').mockResolvedValue(undefined)
+  vi.spyOn(S3Service.prototype, 'copyObject').mockResolvedValue(undefined)
+})
+
+const validStorage = {
+  id: 'st-copy-cleanup',
+  title: 'Copy Cleanup S3',
+  mode: 'private',
+  bucket: 'test-bucket',
+  endpoint: 'https://s3.amazonaws.com',
+  region: 'us-east-1',
+  accessKey: 'AKIAIOSFODNN7EXAMPLE',
+  secretKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+}
+
+async function insertStorage(db: Awaited<ReturnType<typeof createTestApp>>['db'], used = 0) {
+  const now = Date.now()
+  await db.run(sql`
+    INSERT INTO storages (id, title, mode, bucket, endpoint, region, access_key, secret_key, file_path, custom_host, capacity, used, status, created_at, updated_at)
+    VALUES (${validStorage.id}, ${validStorage.title}, ${validStorage.mode}, ${validStorage.bucket},
+            ${validStorage.endpoint}, ${validStorage.region}, ${validStorage.accessKey},
+            ${validStorage.secretKey}, '', '', 0, ${used}, 'active', ${now}, ${now})
+  `)
+}
+
+async function insertFile(
+  db: Awaited<ReturnType<typeof createTestApp>>['db'],
+  orgId: string,
+  id: string,
+  name: string,
+) {
+  const now = Date.now()
+  await db.run(sql`
+    INSERT INTO matters (id, org_id, alias, name, type, size, dirtype, parent, object, storage_id, status, created_at, updated_at)
+    VALUES (${id}, ${orgId}, ${`${id}-alias`}, ${name}, 'text/plain', 100, 0, '',
+            'some/key.txt', ${validStorage.id}, 'active', ${now}, ${now})
+  `)
+}
+
+async function getOrgId(db: Awaited<ReturnType<typeof createTestApp>>['db']): Promise<string> {
+  const rows = await db.all<{ id: string }>(sql`
+    SELECT id FROM organization WHERE metadata LIKE '%"type":"personal"%' LIMIT 1
+  `)
+  return rows[0].id
+}
+
+async function setOrgQuota(
+  db: Awaited<ReturnType<typeof createTestApp>>['db'],
+  orgId: string,
+  quota: number,
+  used = 0,
+) {
+  const existing = await db.select().from(orgQuotas).where(eq(orgQuotas.orgId, orgId))
+  if (existing.length > 0) {
+    await db.update(orgQuotas).set({ quota, used }).where(eq(orgQuotas.orgId, orgId))
+  } else {
+    await db.insert(orgQuotas).values({
+      id: nanoid(),
+      orgId,
+      quota,
+      used,
+      trafficQuota: 0,
+      trafficUsed: 0,
+      trafficPeriod: currentTrafficPeriod(),
+    })
+  }
+}
+
+describe('POST /api/objects/copy — cleanup after quota reservation', () => {
+  it('rolls back reserved usage when S3 copy fails', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await authedHeaders(app)
+    await insertStorage(db, 50)
+    const orgId = await getOrgId(db)
+    await setOrgQuota(db, orgId, 1000, 100)
+    await insertFile(db, orgId, 'm-copy-s3-fail', 's3-fail.txt')
+    vi.spyOn(S3Service.prototype, 'copyObject').mockRejectedValueOnce(new Error('copy_failed'))
+
+    const res = await app.request('/api/objects/copy', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ copyFrom: 'm-copy-s3-fail', parent: '' }),
+    })
+    expect(res.status).toBe(500)
+
+    const quotaRows = await db.all<{ used: number }>(sql`SELECT used FROM org_quotas WHERE org_id = ${orgId}`)
+    const storageRows = await db.all<{ used: number }>(sql`SELECT used FROM storages WHERE id = ${validStorage.id}`)
+    expect(quotaRows[0].used).toBe(100)
+    expect(storageRows[0].used).toBe(50)
+    expect(S3Service.prototype.deleteObject).not.toHaveBeenCalled()
+  })
+
+  it('rolls back reserved usage and deletes the copied object when copy hits a name conflict', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await authedHeaders(app)
+    await insertStorage(db, 50)
+    const orgId = await getOrgId(db)
+    await setOrgQuota(db, orgId, 1000, 100)
+    await insertFile(db, orgId, 'm-copy-conflict-source', 'conflict.txt')
+    await insertFile(db, orgId, 'm-copy-conflict-target', 'conflict.txt')
+
+    const res = await app.request('/api/objects/copy', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ copyFrom: 'm-copy-conflict-source', parent: '', onConflict: 'fail' }),
+    })
+    expect(res.status).toBe(409)
+
+    const quotaRows = await db.all<{ used: number }>(sql`SELECT used FROM org_quotas WHERE org_id = ${orgId}`)
+    const storageRows = await db.all<{ used: number }>(sql`SELECT used FROM storages WHERE id = ${validStorage.id}`)
+    expect(quotaRows[0].used).toBe(100)
+    expect(storageRows[0].used).toBe(50)
+    expect(S3Service.prototype.deleteObject).toHaveBeenCalledWith(
+      expect.objectContaining({ id: validStorage.id }),
+      vi.mocked(S3Service.prototype.copyObject).mock.calls[0][3],
+    )
+    expect(vi.mocked(S3Service.prototype.deleteObject).mock.calls[0][1]).not.toBe('some/key.txt')
+  })
+
+  it('keeps reserved usage and copied object when failure happens after matter insert', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await authedHeaders(app)
+    await insertStorage(db, 50)
+    const orgId = await getOrgId(db)
+    await setOrgQuota(db, orgId, 1000, 100)
+    await insertFile(db, orgId, 'm-copy-activity-fail', 'activity-fail.txt')
+    await db.run(sql`
+      CREATE TRIGGER fail_object_copy_activity
+      BEFORE INSERT ON activity_events
+      WHEN NEW.action = 'object_copy'
+      BEGIN
+        SELECT RAISE(ABORT, 'activity_insert_failed');
+      END
+    `)
+
+    const res = await app.request('/api/objects/copy', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ copyFrom: 'm-copy-activity-fail', parent: '' }),
+    })
+    expect(res.status).toBe(500)
+
+    const copiedObject = vi.mocked(S3Service.prototype.copyObject).mock.calls[0][3]
+    const quotaRows = await db.all<{ used: number }>(sql`SELECT used FROM org_quotas WHERE org_id = ${orgId}`)
+    const storageRows = await db.all<{ used: number }>(sql`SELECT used FROM storages WHERE id = ${validStorage.id}`)
+    const matterRows = await db.all<{ status: string }>(sql`
+      SELECT status FROM matters WHERE org_id = ${orgId} AND object = ${copiedObject}
+    `)
+    expect(quotaRows[0].used).toBe(200)
+    expect(storageRows[0].used).toBe(150)
+    expect(matterRows).toEqual([{ status: 'active' }])
+    expect(S3Service.prototype.deleteObject).not.toHaveBeenCalled()
+  })
+})

--- a/server/routes/objects-quota.integration.test.ts
+++ b/server/routes/objects-quota.integration.test.ts
@@ -1,7 +1,7 @@
 import { eq, sql } from 'drizzle-orm'
 import { nanoid } from 'nanoid'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { orgQuotas } from '../db/schema.js'
+import { orgQuotaEntitlements, orgQuotas } from '../db/schema.js'
 import { currentTrafficPeriod } from '../services/effective-quota.js'
 import { S3Service } from '../services/s3.js'
 import { authedHeaders, createTestApp, seedProLicense } from '../test/setup.js'
@@ -100,6 +100,38 @@ describe('POST /api/objects/copy — quota enforcement', () => {
     expect(res.status).toBe(422)
     const body = (await res.json()) as Record<string, unknown>
     expect(body.error).toBe('Quota exceeded')
+  })
+
+  it('uses active storage entitlements when copying a file', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    await setOrgQuota(db, orgId, 100, 90)
+    await db.insert(orgQuotaEntitlements).values({
+      id: nanoid(),
+      orgId,
+      resourceType: 'storage',
+      source: 'cloud_order',
+      sourceId: 'order-copy',
+      bytes: 50,
+      startsAt: new Date(),
+      expiresAt: null,
+      status: 'active',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    await insertFile(db, orgId, { id: 'm-copy-entitlement', name: 'entitled-copy.txt', size: 50 })
+
+    const res = await app.request('/api/objects/copy', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ copyFrom: 'm-copy-entitlement', parent: '' }),
+    })
+    expect(res.status).toBe(201)
+
+    const quotaRows = await db.all<{ used: number }>(sql`SELECT used FROM org_quotas WHERE org_id = ${orgId}`)
+    expect(quotaRows[0].used).toBe(140)
   })
 
   it('returns 201 and increments orgQuotas.used when copy succeeds within quota', async () => {
@@ -368,6 +400,39 @@ describe('PATCH /api/objects/:id (action: confirm) — quota enforcement via con
     expect(res.status).toBe(422)
     const body = (await res.json()) as Record<string, unknown>
     expect(body.error).toBe('Quota exceeded')
+  })
+
+  it('uses active storage entitlements when confirming upload quota', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    await setOrgQuota(db, orgId, 100, 90)
+    await db.insert(orgQuotaEntitlements).values({
+      id: nanoid(),
+      orgId,
+      resourceType: 'storage',
+      source: 'cloud_order',
+      sourceId: 'order-confirm',
+      bytes: 50,
+      startsAt: new Date(),
+      expiresAt: null,
+      status: 'active',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    await insertFile(db, orgId, { id: 'm-done-entitlement', name: 'entitled.txt', size: 50, status: 'draft' })
+
+    const res = await app.request('/api/objects/m-done-entitlement', {
+      method: 'PATCH',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'confirm' }),
+    })
+    expect(res.status).toBe(200)
+
+    const quotaRows = await db.all<{ used: number }>(sql`SELECT used FROM org_quotas WHERE org_id = ${orgId}`)
+    expect(quotaRows[0].used).toBe(140)
   })
 
   it('does not change usage when a file with size 0 is confirmed', async () => {

--- a/server/routes/objects.ts
+++ b/server/routes/objects.ts
@@ -1,4 +1,5 @@
 import { zValidator } from '@hono/zod-validator'
+import { and, eq } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { DirType } from '../../shared/constants'
 import {
@@ -9,6 +10,7 @@ import {
   patchMatterSchema,
 } from '../../shared/schemas'
 import type { Storage as S3Storage } from '../../shared/types'
+import { matters } from '../db/schema'
 import { requireAuth, requireTeamRole } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
 import { recordActivity } from '../services/activity'
@@ -21,6 +23,7 @@ import {
   confirmUpload,
   copyMatter,
   createMatter,
+  decrementUsage,
   getMatter,
   getMatters,
   incrementUsageIfAllowed,
@@ -306,30 +309,53 @@ const app = new Hono<Env>()
     if (!source) return c.json({ error: 'Not found' }, 404)
 
     const sourceSize = source.size ?? 0
+    const reservedStorageBytes = sourceSize > 0 ? new Map([[source.storageId, sourceSize]]) : new Map<string, number>()
     if (sourceSize > 0) {
       const allowed = await incrementUsageIfAllowed(db, orgId, source.storageId, sourceSize)
       if (!allowed) return c.json({ error: 'Quota exceeded' }, 422)
     }
 
+    let copiedStorage: S3Storage | null = null
+    let copiedObject = false
     let newObject = ''
-    if (source.object) {
-      const storage = (await getStorage(db, source.storageId)) as unknown as S3Storage
-      if (!storage) return c.json({ error: 'Storage not found' }, 404)
-      newObject = buildObjectKey({
-        uid: userId,
-        orgId,
-        rawExt: fileExt(source.name),
-      })
-      await s3.copyObject(storage, source.object, storage, newObject)
-    }
-
     try {
+      if (source.object) {
+        const storage = (await getStorage(db, source.storageId)) as unknown as S3Storage
+        if (!storage) {
+          await decrementUsage(db, orgId, reservedStorageBytes, sourceSize)
+          return c.json({ error: 'Storage not found' }, 404)
+        }
+        copiedStorage = storage
+        newObject = buildObjectKey({
+          uid: userId,
+          orgId,
+          rawExt: fileExt(source.name),
+        })
+        await s3.copyObject(storage, source.object, storage, newObject)
+        copiedObject = true
+      }
       const copy = await copyMatter(db, source, parent, newObject, { onConflict, userId })
       return c.json(copy, 201)
     } catch (e) {
+      if (copiedObject && newObject && (await copiedMatterExists(db, orgId, newObject))) throw e
+      await decrementUsage(db, orgId, reservedStorageBytes, sourceSize)
+      if (copiedObject && copiedStorage && newObject) await s3.deleteObject(copiedStorage, newObject)
       if (e instanceof NameConflictError) return c.json(conflictBody(e), 409)
       throw e
     }
   })
 
 export default app
+
+async function copiedMatterExists(
+  db: Env['Variables']['platform']['db'],
+  orgId: string,
+  object: string,
+): Promise<boolean> {
+  const rows = await db
+    .select({ id: matters.id })
+    .from(matters)
+    .where(and(eq(matters.orgId, orgId), eq(matters.object, object)))
+    .limit(1)
+  return rows.length > 0
+}

--- a/server/routes/quotas-listing.integration.test.ts
+++ b/server/routes/quotas-listing.integration.test.ts
@@ -27,6 +27,13 @@ describe('Admin quota listing', () => {
       INSERT INTO org_quotas (id, org_id, quota, used, traffic_quota, traffic_used, traffic_period)
       VALUES ('team-quota-listing-row', 'team-quota-listing', 2000, 100, 3000, 2500, '1970-01')
     `)
+    await db.run(sql`
+      INSERT INTO org_quota_entitlements
+        (id, org_id, resource_type, source, source_id, bytes, starts_at, expires_at, status, metadata, created_at, updated_at)
+      VALUES
+        ('team-quota-listing-storage-entitlement', 'team-quota-listing', 'storage', 'cloud_order', 'order-listing-storage', 500, ${now}, NULL, 'active', NULL, ${now}, ${now}),
+        ('team-quota-listing-traffic-entitlement', 'team-quota-listing', 'traffic', 'cloud_order', 'order-listing-traffic', 700, ${now}, NULL, 'active', NULL, ${now}, ${now})
+    `)
     await db.run(sql`UPDATE org_quotas SET traffic_quota = 1000, traffic_used = 900, traffic_period = '1970-01'`)
     const res = await app.request('/api/admin/quotas', { headers })
     expect(res.status).toBe(200)
@@ -39,5 +46,7 @@ describe('Admin quota listing', () => {
 
     const adminItem = body.items.find((item) => item.orgId === adminOrg[0].id)
     expect(adminItem).toMatchObject({ baseQuota: 10485760, quota: 10485760 })
+    const teamItem = body.items.find((item) => item.orgId === 'team-quota-listing')
+    expect(teamItem).toMatchObject({ baseQuota: 2000, quota: 2500, trafficQuota: 1700 })
   })
 })

--- a/server/routes/quotas.ts
+++ b/server/routes/quotas.ts
@@ -8,7 +8,7 @@ import { orgQuotas } from '../db/schema'
 import { requireAdmin, requireAuth } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
 import { recordActivity } from '../services/activity'
-import { currentTrafficPeriod, getEffectiveQuota } from '../services/effective-quota'
+import { currentTrafficPeriod, getActiveQuotaEntitlementBytes, getEffectiveQuota } from '../services/effective-quota'
 import { findPersonalOrg } from '../services/org'
 
 const updateQuotaSchema = z.object({
@@ -43,18 +43,7 @@ const adminQuotas = new Hono<Env>()
       .innerJoin(organization, eq(organization.id, orgQuotas.orgId))
       .orderBy(organization.name)
 
-    const items = rows.map((r) => ({
-      id: r.id,
-      orgId: r.orgId,
-      baseQuota: r.baseQuota,
-      quota: r.baseQuota,
-      used: r.used,
-      trafficQuota: r.trafficQuota,
-      trafficUsed: r.trafficUsed,
-      trafficPeriod: r.trafficPeriod,
-      orgName: r.orgName,
-      orgType: parseOrgType(r.orgMetadata),
-    }))
+    const items = await Promise.all(rows.map((row) => adminQuotaItem(db, row)))
 
     return c.json({ items, total: items.length })
   })
@@ -111,6 +100,36 @@ const userQuotas = new Hono<Env>().use(requireAuth).get('/me', async (c) => {
 })
 
 export { adminQuotas, userQuotas }
+
+async function adminQuotaItem(
+  db: Env['Variables']['platform']['db'],
+  row: {
+    id: string
+    orgId: string
+    baseQuota: number
+    used: number
+    trafficQuota: number
+    trafficUsed: number
+    trafficPeriod: string
+    orgName: string
+    orgMetadata: string | null
+  },
+) {
+  const storageEntitlements = await getActiveQuotaEntitlementBytes(db, row.orgId, 'storage')
+  const trafficEntitlements = await getActiveQuotaEntitlementBytes(db, row.orgId, 'traffic')
+  return {
+    id: row.id,
+    orgId: row.orgId,
+    baseQuota: row.baseQuota,
+    quota: row.baseQuota === 0 ? 0 : row.baseQuota + storageEntitlements,
+    used: row.used,
+    trafficQuota: row.trafficQuota === 0 ? 0 : row.trafficQuota + trafficEntitlements,
+    trafficUsed: row.trafficUsed,
+    trafficPeriod: row.trafficPeriod,
+    orgName: row.orgName,
+    orgType: parseOrgType(row.orgMetadata),
+  }
+}
 
 function parseOrgType(metadata: string | null): string {
   if (!metadata) return 'unknown'

--- a/server/services/cloud-store-entitlements.test.ts
+++ b/server/services/cloud-store-entitlements.test.ts
@@ -1,0 +1,461 @@
+import { sql } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+import { orgQuotaEntitlements, orgQuotas } from '../db/schema'
+import { createTestApp } from '../test/setup'
+import { processCloudOrderQuotaChange } from './cloud-store'
+
+describe('processCloudOrderQuotaChange entitlements', () => {
+  it('creates storage entitlements without mutating base storage quota and treats duplicate webhooks as idempotent', async () => {
+    const { db } = await createTestApp()
+    await db.insert(orgQuotas).values({
+      id: 'quota-webhook-idempotent',
+      orgId: 'org-webhook-idempotent',
+      quota: 1000,
+      used: 0,
+      trafficQuota: 2000,
+      trafficUsed: 0,
+      trafficPeriod: '2026-05',
+    })
+    const event = {
+      eventId: 'evt-webhook-idempotent',
+      eventType: 'order.quota_changed' as const,
+      cloudOrderId: 'order-webhook-idempotent',
+      targetOrgId: 'org-webhook-idempotent',
+      direction: 'increase' as const,
+      storageBytes: 4096,
+      trafficBytes: 0,
+      occurredAt: '2026-05-06T00:00:00Z',
+    }
+
+    await expect(
+      processCloudOrderQuotaChange(db, event, JSON.stringify(event), 'hash-webhook-idempotent'),
+    ).resolves.toEqual({
+      duplicate: false,
+      eventId: event.eventId,
+    })
+    await expect(
+      processCloudOrderQuotaChange(db, event, JSON.stringify(event), 'hash-webhook-idempotent'),
+    ).resolves.toEqual({
+      duplicate: true,
+      eventId: event.eventId,
+    })
+
+    const quotaRows = await db.all<{ quota: number; trafficQuota: number }>(sql`
+      SELECT quota, traffic_quota AS trafficQuota FROM org_quotas WHERE org_id = ${event.targetOrgId}
+    `)
+    expect(quotaRows[0]).toEqual({ quota: 1000, trafficQuota: 2000 })
+
+    const entitlementRows = await db.all<{ resourceType: string; bytes: number; status: string }>(sql`
+      SELECT resource_type AS resourceType, bytes, status
+      FROM org_quota_entitlements
+      WHERE org_id = ${event.targetOrgId}
+      ORDER BY resource_type
+    `)
+    expect(entitlementRows).toEqual([{ resourceType: 'storage', bytes: 4096, status: 'active' }])
+  })
+
+  it('applies traffic quota changes to local traffic quota', async () => {
+    const { db } = await createTestApp()
+    await db.insert(orgQuotas).values({
+      id: 'quota-webhook-traffic',
+      orgId: 'org-webhook-traffic',
+      quota: 1000,
+      used: 0,
+      trafficQuota: 2000,
+      trafficUsed: 0,
+      trafficPeriod: '2026-05',
+    })
+    const increase = {
+      eventId: 'evt-webhook-traffic-increase',
+      eventType: 'order.quota_changed' as const,
+      cloudOrderId: 'order-webhook-traffic',
+      targetOrgId: 'org-webhook-traffic',
+      direction: 'increase' as const,
+      storageBytes: 0,
+      trafficBytes: 8192,
+      occurredAt: '2026-05-06T00:00:00Z',
+    }
+    const decrease = {
+      ...increase,
+      eventId: 'evt-webhook-traffic-decrease',
+      direction: 'decrease' as const,
+      trafficBytes: 1024,
+    }
+
+    await processCloudOrderQuotaChange(db, increase, JSON.stringify(increase), 'hash-webhook-traffic-increase')
+    await processCloudOrderQuotaChange(db, decrease, JSON.stringify(decrease), 'hash-webhook-traffic-decrease')
+
+    const quotaRows = await db.all<{ quota: number; trafficQuota: number }>(sql`
+      SELECT quota, traffic_quota AS trafficQuota FROM org_quotas WHERE org_id = ${increase.targetOrgId}
+    `)
+    expect(quotaRows[0]).toEqual({ quota: 1000, trafficQuota: 9168 })
+
+    const entitlementRows = await db.all<{ resourceType: string }>(sql`
+      SELECT resource_type AS resourceType
+      FROM org_quota_entitlements
+      WHERE org_id = ${increase.targetOrgId}
+    `)
+    expect(entitlementRows).toEqual([])
+  })
+
+  it('accumulates repeated storage increases for the same cloud order', async () => {
+    const { db } = await createTestApp()
+    await db.insert(orgQuotas).values({
+      id: 'quota-webhook-repeat-increase',
+      orgId: 'org-webhook-repeat-increase',
+      quota: 1000,
+      used: 0,
+      trafficQuota: 2000,
+      trafficUsed: 0,
+      trafficPeriod: '2026-05',
+    })
+    const firstIncrease = {
+      eventId: 'evt-webhook-repeat-increase-a',
+      eventType: 'order.quota_changed' as const,
+      cloudOrderId: 'order-webhook-repeat-increase',
+      targetOrgId: 'org-webhook-repeat-increase',
+      direction: 'increase' as const,
+      storageBytes: 4096,
+      trafficBytes: 0,
+      occurredAt: '2026-05-06T00:00:00Z',
+    }
+    const secondIncrease = {
+      ...firstIncrease,
+      eventId: 'evt-webhook-repeat-increase-b',
+      storageBytes: 1024,
+    }
+
+    await processCloudOrderQuotaChange(
+      db,
+      firstIncrease,
+      JSON.stringify(firstIncrease),
+      'hash-webhook-repeat-increase-a',
+    )
+    await processCloudOrderQuotaChange(
+      db,
+      secondIncrease,
+      JSON.stringify(secondIncrease),
+      'hash-webhook-repeat-increase-b',
+    )
+
+    const entitlementRows = await db.all<{ bytes: number; status: string }>(sql`
+      SELECT bytes, status
+      FROM org_quota_entitlements
+      WHERE org_id = ${firstIncrease.targetOrgId} AND source_id = ${firstIncrease.cloudOrderId}
+    `)
+    expect(entitlementRows).toEqual([{ bytes: 5120, status: 'active' }])
+  })
+
+  it('revokes matching cloud order entitlements on reversal', async () => {
+    const { db } = await createTestApp()
+    await db.insert(orgQuotas).values({
+      id: 'quota-webhook-reversal',
+      orgId: 'org-webhook-reversal',
+      quota: 1000,
+      used: 0,
+      trafficQuota: 2000,
+      trafficUsed: 0,
+      trafficPeriod: '2026-05',
+    })
+    const increase = {
+      eventId: 'evt-webhook-increase',
+      eventType: 'order.quota_changed' as const,
+      cloudOrderId: 'order-webhook-reversal',
+      targetOrgId: 'org-webhook-reversal',
+      direction: 'increase' as const,
+      storageBytes: 4096,
+      trafficBytes: 0,
+      occurredAt: '2026-05-06T00:00:00Z',
+    }
+    const decrease = {
+      ...increase,
+      eventId: 'evt-webhook-decrease',
+      direction: 'decrease' as const,
+    }
+
+    await processCloudOrderQuotaChange(db, increase, JSON.stringify(increase), 'hash-webhook-increase')
+    await processCloudOrderQuotaChange(db, decrease, JSON.stringify(decrease), 'hash-webhook-decrease')
+
+    const entitlementRows = await db.all<{ status: string; expiresAt: number | null }>(sql`
+      SELECT status, expires_at AS expiresAt
+      FROM org_quota_entitlements
+      WHERE org_id = ${increase.targetOrgId} AND source_id = ${increase.cloudOrderId}
+    `)
+    expect(entitlementRows).toHaveLength(1)
+    expect(entitlementRows[0].status).toBe('revoked')
+    expect(entitlementRows[0].expiresAt).not.toBeNull()
+  })
+
+  it('does not apply a repeated reversal after the matching entitlement is revoked', async () => {
+    const { db } = await createTestApp()
+    await db.insert(orgQuotas).values({
+      id: 'quota-webhook-repeat-reversal',
+      orgId: 'org-webhook-repeat-reversal',
+      quota: 10000,
+      used: 0,
+      trafficQuota: 2000,
+      trafficUsed: 0,
+      trafficPeriod: '2026-05',
+    })
+    const increase = {
+      eventId: 'evt-webhook-repeat-increase',
+      eventType: 'order.quota_changed' as const,
+      cloudOrderId: 'order-webhook-repeat-reversal',
+      targetOrgId: 'org-webhook-repeat-reversal',
+      direction: 'increase' as const,
+      storageBytes: 4096,
+      trafficBytes: 0,
+      occurredAt: '2026-05-06T00:00:00Z',
+    }
+    const decrease = {
+      ...increase,
+      eventId: 'evt-webhook-repeat-decrease',
+      direction: 'decrease' as const,
+    }
+    const repeatedDecrease = {
+      ...decrease,
+      eventId: 'evt-webhook-repeat-decrease-again',
+    }
+
+    await processCloudOrderQuotaChange(db, increase, JSON.stringify(increase), 'hash-webhook-repeat-increase')
+    await processCloudOrderQuotaChange(db, decrease, JSON.stringify(decrease), 'hash-webhook-repeat-decrease')
+    await processCloudOrderQuotaChange(
+      db,
+      repeatedDecrease,
+      JSON.stringify(repeatedDecrease),
+      'hash-webhook-repeat-decrease-again',
+    )
+
+    const quotaRows = await db.all<{ quota: number }>(sql`
+      SELECT quota FROM org_quotas WHERE org_id = ${increase.targetOrgId}
+    `)
+    expect(quotaRows[0].quota).toBe(10000)
+
+    const entitlementRows = await db.all<{ status: string }>(sql`
+      SELECT status FROM org_quota_entitlements WHERE org_id = ${increase.targetOrgId}
+    `)
+    expect(entitlementRows).toEqual([{ status: 'revoked' }])
+  })
+
+  it('partially reduces matching cloud order entitlements on reversal', async () => {
+    const { db } = await createTestApp()
+    await db.insert(orgQuotas).values({
+      id: 'quota-webhook-partial-reversal',
+      orgId: 'org-webhook-partial-reversal',
+      quota: 1000,
+      used: 0,
+      trafficQuota: 2000,
+      trafficUsed: 0,
+      trafficPeriod: '2026-05',
+    })
+    const increase = {
+      eventId: 'evt-webhook-partial-increase',
+      eventType: 'order.quota_changed' as const,
+      cloudOrderId: 'order-webhook-partial-reversal',
+      targetOrgId: 'org-webhook-partial-reversal',
+      direction: 'increase' as const,
+      storageBytes: 4096,
+      trafficBytes: 0,
+      occurredAt: '2026-05-06T00:00:00Z',
+    }
+    const decrease = {
+      ...increase,
+      eventId: 'evt-webhook-partial-decrease',
+      direction: 'decrease' as const,
+      storageBytes: 1024,
+    }
+
+    await processCloudOrderQuotaChange(db, increase, JSON.stringify(increase), 'hash-webhook-partial-increase')
+    await processCloudOrderQuotaChange(db, decrease, JSON.stringify(decrease), 'hash-webhook-partial-decrease')
+
+    const entitlementRows = await db.all<{ bytes: number; status: string }>(sql`
+      SELECT bytes, status
+      FROM org_quota_entitlements
+      WHERE org_id = ${increase.targetOrgId} AND source_id = ${increase.cloudOrderId}
+    `)
+    expect(entitlementRows).toEqual([{ bytes: 3072, status: 'active' }])
+  })
+
+  it('falls back to legacy base quota for oversized matching reversals', async () => {
+    const { db } = await createTestApp()
+    await db.insert(orgQuotas).values({
+      id: 'quota-webhook-oversized-reversal',
+      orgId: 'org-webhook-oversized-reversal',
+      quota: 10000,
+      used: 0,
+      trafficQuota: 2000,
+      trafficUsed: 0,
+      trafficPeriod: '2026-05',
+    })
+    const increase = {
+      eventId: 'evt-webhook-oversized-increase',
+      eventType: 'order.quota_changed' as const,
+      cloudOrderId: 'order-webhook-oversized-reversal',
+      targetOrgId: 'org-webhook-oversized-reversal',
+      direction: 'increase' as const,
+      storageBytes: 4096,
+      trafficBytes: 0,
+      occurredAt: '2026-05-06T00:00:00Z',
+    }
+    const decrease = {
+      ...increase,
+      eventId: 'evt-webhook-oversized-decrease',
+      direction: 'decrease' as const,
+      storageBytes: 5000,
+    }
+
+    await processCloudOrderQuotaChange(db, increase, JSON.stringify(increase), 'hash-webhook-oversized-increase')
+    await processCloudOrderQuotaChange(db, decrease, JSON.stringify(decrease), 'hash-webhook-oversized-decrease')
+
+    const quotaRows = await db.all<{ quota: number }>(sql`
+      SELECT quota FROM org_quotas WHERE org_id = ${increase.targetOrgId}
+    `)
+    expect(quotaRows[0].quota).toBe(9096)
+
+    const entitlementRows = await db.all<{ status: string }>(sql`
+      SELECT status FROM org_quota_entitlements WHERE org_id = ${increase.targetOrgId}
+    `)
+    expect(entitlementRows).toEqual([{ status: 'revoked' }])
+  })
+
+  it('reduces active entitlements before falling back to legacy base quota on unmatched decreases', async () => {
+    const { db } = await createTestApp()
+    const now = new Date('2026-05-06T00:00:00Z')
+    await db.insert(orgQuotas).values({
+      id: 'quota-webhook-unmatched-decrease',
+      orgId: 'org-webhook-unmatched-decrease',
+      quota: 10000,
+      used: 0,
+      trafficQuota: 20000,
+      trafficUsed: 0,
+      trafficPeriod: '2026-05',
+    })
+    await db.insert(orgQuotaEntitlements).values([
+      {
+        id: 'entitlement-unmatched-storage-a',
+        orgId: 'org-webhook-unmatched-decrease',
+        resourceType: 'storage',
+        source: 'cloud_order',
+        sourceId: 'order-existing-storage-a',
+        bytes: 1000,
+        startsAt: now,
+        expiresAt: null,
+        status: 'active',
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: 'entitlement-unmatched-storage-b',
+        orgId: 'org-webhook-unmatched-decrease',
+        resourceType: 'storage',
+        source: 'cloud_order',
+        sourceId: 'order-existing-storage-b',
+        bytes: 2000,
+        startsAt: now,
+        expiresAt: null,
+        status: 'active',
+        createdAt: now,
+        updatedAt: now,
+      },
+    ])
+    const decrease = {
+      eventId: 'evt-webhook-unmatched-decrease',
+      eventType: 'order.quota_changed' as const,
+      cloudOrderId: 'order-without-active-entitlement',
+      targetOrgId: 'org-webhook-unmatched-decrease',
+      direction: 'decrease' as const,
+      storageBytes: 3500,
+      trafficBytes: 1000,
+      occurredAt: '2026-05-07T00:00:00Z',
+    }
+
+    await processCloudOrderQuotaChange(db, decrease, JSON.stringify(decrease), 'hash-webhook-unmatched-decrease')
+
+    const quotaRows = await db.all<{ quota: number; trafficQuota: number }>(sql`
+      SELECT quota, traffic_quota AS trafficQuota
+      FROM org_quotas
+      WHERE org_id = ${decrease.targetOrgId}
+    `)
+    expect(quotaRows[0]).toEqual({ quota: 9500, trafficQuota: 19000 })
+
+    const entitlementRows = await db.all<{ id: string; bytes: number; status: string }>(sql`
+      SELECT id, bytes, status
+      FROM org_quota_entitlements
+      WHERE org_id = ${decrease.targetOrgId}
+      ORDER BY id
+    `)
+    expect(entitlementRows).toEqual([
+      { id: 'entitlement-unmatched-storage-a', bytes: 1000, status: 'revoked' },
+      { id: 'entitlement-unmatched-storage-b', bytes: 2000, status: 'revoked' },
+    ])
+  })
+
+  it('ignores inactive entitlement windows on unmatched decreases', async () => {
+    const { db } = await createTestApp()
+    await db.insert(orgQuotas).values({
+      id: 'quota-webhook-windowed-decrease',
+      orgId: 'org-webhook-windowed-decrease',
+      quota: 10000,
+      used: 0,
+      trafficQuota: 20000,
+      trafficUsed: 0,
+      trafficPeriod: '2026-05',
+    })
+    await db.insert(orgQuotaEntitlements).values([
+      {
+        id: 'entitlement-windowed-future',
+        orgId: 'org-webhook-windowed-decrease',
+        resourceType: 'storage',
+        source: 'cloud_order',
+        sourceId: 'order-windowed-future',
+        bytes: 1000,
+        startsAt: new Date('2026-06-01T00:00:00Z'),
+        expiresAt: null,
+        status: 'active',
+        createdAt: new Date('2026-05-01T00:00:00Z'),
+        updatedAt: new Date('2026-05-01T00:00:00Z'),
+      },
+      {
+        id: 'entitlement-windowed-expired',
+        orgId: 'org-webhook-windowed-decrease',
+        resourceType: 'storage',
+        source: 'cloud_order',
+        sourceId: 'order-windowed-expired',
+        bytes: 1000,
+        startsAt: new Date('2026-04-01T00:00:00Z'),
+        expiresAt: new Date('2026-05-01T00:00:00Z'),
+        status: 'active',
+        createdAt: new Date('2026-04-01T00:00:00Z'),
+        updatedAt: new Date('2026-04-01T00:00:00Z'),
+      },
+    ])
+    const decrease = {
+      eventId: 'evt-webhook-windowed-decrease',
+      eventType: 'order.quota_changed' as const,
+      cloudOrderId: 'order-windowed-missing',
+      targetOrgId: 'org-webhook-windowed-decrease',
+      direction: 'decrease' as const,
+      storageBytes: 500,
+      trafficBytes: 0,
+      occurredAt: '2026-05-07T00:00:00Z',
+    }
+
+    await processCloudOrderQuotaChange(db, decrease, JSON.stringify(decrease), 'hash-webhook-windowed-decrease')
+
+    const quotaRows = await db.all<{ quota: number }>(sql`
+      SELECT quota FROM org_quotas WHERE org_id = ${decrease.targetOrgId}
+    `)
+    expect(quotaRows[0].quota).toBe(9500)
+
+    const entitlementRows = await db.all<{ id: string; status: string }>(sql`
+      SELECT id, status
+      FROM org_quota_entitlements
+      WHERE org_id = ${decrease.targetOrgId}
+      ORDER BY id
+    `)
+    expect(entitlementRows).toEqual([
+      { id: 'entitlement-windowed-expired', status: 'active' },
+      { id: 'entitlement-windowed-future', status: 'active' },
+    ])
+  })
+})

--- a/server/services/cloud-store.test.ts
+++ b/server/services/cloud-store.test.ts
@@ -1,33 +1,133 @@
 import { describe, expect, it } from 'vitest'
-import { activityEvents, orgQuotas, webhookEvents } from '../db/schema'
+import { activityEvents, orgQuotaEntitlements, orgQuotas, webhookEvents } from '../db/schema'
 import type { Database } from '../platform/interface'
 import { processCloudOrderQuotaChange } from './cloud-store'
+
+function queryRows<T>(rows: T[]) {
+  return {
+    all: () => rows,
+    limit: async () => rows,
+    orderBy: async () => rows,
+    // biome-ignore lint/suspicious/noThenProperty: Drizzle async queries are thenable; these fakes mimic that API.
+    then: (resolve: (value: T[]) => unknown, reject?: (reason: unknown) => unknown) =>
+      Promise.resolve(rows).then(resolve, reject),
+  }
+}
 
 function createAsyncDb(quotaRows: Array<{ id: string }> = [{ id: 'quota-1' }]) {
   const state = {
     audits: 0,
+    entitlementRevokes: 0,
+    entitlementUpserts: 0,
+    legacyQuotaReversals: 0,
     webhookStatus: '',
-    quotaUpdates: 0,
   }
   const db = {
     constructor: { name: 'AsyncTestDatabase' },
     transaction: async (fn: (tx: unknown) => Promise<void>) => fn(db),
     insert: (table: unknown) => ({
-      values: async (values: Record<string, unknown>) => {
-        if (table === webhookEvents) state.webhookStatus = String(values.status)
-        if (table === activityEvents) state.audits += 1
+      values: (values: Record<string, unknown>) => {
+        if (table === webhookEvents) {
+          state.webhookStatus = String(values.status)
+          return Promise.resolve()
+        }
+        if (table === activityEvents) {
+          state.audits += 1
+          return Promise.resolve()
+        }
+        return {
+          onConflictDoUpdate: async () => {
+            state.entitlementUpserts += 1
+          },
+        }
       },
+    }),
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => {
+          if (table === orgQuotas) return queryRows(quotaRows)
+          if (table === orgQuotaEntitlements) return queryRows([{ id: 'entitlement-1', bytes: 4096, status: 'active' }])
+          return queryRows([])
+        },
+      }),
     }),
     update: (table: unknown) => ({
       set: (values: Record<string, unknown>) => ({
         where: () => {
-          if (table === orgQuotas) {
+          if (table === orgQuotaEntitlements) {
+            state.entitlementRevokes += 1
             return {
               returning: async () => {
-                state.quotaUpdates += 1
-                return quotaRows
+                return [{ id: 'entitlement-1' }]
               },
+              run: () => undefined,
             }
+          }
+          if (table === orgQuotas) {
+            state.legacyQuotaReversals += 1
+            return Promise.resolve()
+          }
+          if (table === webhookEvents) state.webhookStatus = String(values.status)
+          return Promise.resolve()
+        },
+      }),
+    }),
+  }
+
+  return { db: db as unknown as Database, state }
+}
+
+function createLegacyReversalDb() {
+  const state = {
+    audits: 0,
+    entitlementRevokes: 0,
+    entitlementUpserts: 0,
+    legacyQuotaReversals: 0,
+    webhookStatus: '',
+  }
+  const db = {
+    constructor: { name: 'AsyncTestDatabase' },
+    transaction: async (fn: (tx: unknown) => Promise<void>) => fn(db),
+    insert: (table: unknown) => ({
+      values: (values: Record<string, unknown>) => {
+        if (table === webhookEvents) {
+          state.webhookStatus = String(values.status)
+          return Promise.resolve()
+        }
+        if (table === activityEvents) {
+          state.audits += 1
+          return Promise.resolve()
+        }
+        return {
+          onConflictDoUpdate: async () => {
+            state.entitlementUpserts += 1
+          },
+        }
+      },
+    }),
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => {
+          const rows = table === orgQuotas ? [{ id: 'quota-legacy' }] : []
+          return queryRows(rows)
+        },
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: (values: Record<string, unknown>) => ({
+        where: () => {
+          if (table === orgQuotaEntitlements) {
+            state.entitlementRevokes += 1
+            return {
+              returning: async () => {
+                return []
+              },
+              run: () => undefined,
+            }
+          }
+          if (table === orgQuotas) {
+            state.legacyQuotaReversals += 1
+            return Promise.resolve()
           }
           if (table === webhookEvents) state.webhookStatus = String(values.status)
           return Promise.resolve()
@@ -49,41 +149,63 @@ function createFailingBeginDb() {
   } as unknown as Database
 }
 
-function createUniqueConflictDb(existing: { id: string; payloadHash: string; status: string } | null) {
+function createUniqueConflictDb(
+  existing: { id: string; payloadHash: string; status: string; createdAt?: Date } | null,
+  claimRows: Array<{ id: string }> = existing ? [{ id: existing.id }] : [],
+) {
   const state = {
     audits: 0,
+    entitlementRevokes: 0,
+    entitlementUpserts: 0,
+    legacyQuotaReversals: 0,
     webhookStatus: existing?.status ?? '',
-    quotaUpdates: 0,
   }
   const db = {
     constructor: { name: 'AsyncTestDatabase' },
     transaction: async (fn: (tx: unknown) => Promise<void>) => fn(db),
     insert: (table: unknown) => ({
-      values: async (values: Record<string, unknown>) => {
+      values: (_values: Record<string, unknown>) => {
         if (table === webhookEvents) throw new Error('UNIQUE constraint failed: webhook_events.source, event_id')
-        if (table === activityEvents) state.audits += 1
-        return values
+        if (table === activityEvents) {
+          state.audits += 1
+          return Promise.resolve()
+        }
+        return {
+          onConflictDoUpdate: async () => {
+            state.entitlementUpserts += 1
+          },
+        }
       },
     }),
     select: () => ({
-      from: () => ({
-        where: () => ({
-          limit: async () => (existing ? [existing] : []),
-        }),
+      from: (table: unknown) => ({
+        where: () => {
+          if (table === webhookEvents) return queryRows(existing ? [existing] : [])
+          if (table === orgQuotas) return queryRows([{ id: 'quota-retry' }])
+          if (table === orgQuotaEntitlements) {
+            return queryRows([{ id: 'entitlement-retry', bytes: 999999, status: 'active' }])
+          }
+          return queryRows([])
+        },
       }),
     }),
     update: (table: unknown) => ({
       set: (values: Record<string, unknown>) => ({
         where: () => {
-          if (table === orgQuotas) {
+          if (table === orgQuotaEntitlements) {
+            state.entitlementRevokes += 1
             return {
               returning: async () => {
-                state.quotaUpdates += 1
-                return [{ id: 'quota-retry' }]
+                return [{ id: 'entitlement-retry' }]
               },
+              run: () => undefined,
             }
           }
-          if (table === webhookEvents) state.webhookStatus = String(values.status)
+          if (table === orgQuotas) state.legacyQuotaReversals += 1
+          if (table === webhookEvents) {
+            state.webhookStatus = String(values.status)
+            return { returning: async () => claimRows }
+          }
           return Promise.resolve()
         },
       }),
@@ -96,8 +218,10 @@ function createUniqueConflictDb(existing: { id: string; payloadHash: string; sta
 function createSyncDb() {
   const state = {
     audits: 0,
+    entitlementRevokes: 0,
+    entitlementUpserts: 0,
+    legacyQuotaReversals: 0,
     webhookStatus: '',
-    quotaUpdates: 0,
   }
 
   class BetterSQLite3Database {
@@ -108,6 +232,15 @@ function createSyncDb() {
     insert(table: unknown) {
       return {
         values: (values: Record<string, unknown>) => {
+          if (table === orgQuotaEntitlements) {
+            return {
+              onConflictDoUpdate: () => ({
+                run: () => {
+                  state.entitlementUpserts += 1
+                },
+              }),
+            }
+          }
           return {
             run: () => {
               if (table === webhookEvents) state.webhookStatus = String(values.status)
@@ -118,19 +251,43 @@ function createSyncDb() {
       }
     }
 
+    select() {
+      return {
+        from: (table: unknown) => ({
+          where: () => {
+            const rows =
+              table === orgQuotas
+                ? [{ id: 'quota-sync' }]
+                : table === orgQuotaEntitlements
+                  ? [{ id: 'entitlement-sync', bytes: 999999, status: 'active' }]
+                  : []
+            return {
+              all: () => rows,
+              limit: () => ({ all: () => rows }),
+            }
+          },
+        }),
+      }
+    }
+
     update(table: unknown) {
       return {
         set: (values: Record<string, unknown>) => ({
           where: () => {
-            if (table === orgQuotas) {
+            if (table === orgQuotaEntitlements) {
+              state.entitlementRevokes += 1
               return {
                 returning: () => ({
                   all: () => {
-                    state.quotaUpdates += 1
-                    return [{ id: 'quota-sync' }]
+                    return [{ id: 'entitlement-sync' }]
                   },
                 }),
+                run: () => undefined,
               }
+            }
+            if (table === orgQuotas) {
+              state.legacyQuotaReversals += 1
+              return { run: () => undefined }
             }
             state.webhookStatus = String(values.status)
             return { run: () => undefined }
@@ -160,7 +317,7 @@ describe('processCloudOrderQuotaChange', () => {
       duplicate: false,
       eventId: 'evt-async',
     })
-    expect(state).toMatchObject({ audits: 1, webhookStatus: 'processed', quotaUpdates: 1 })
+    expect(state).toMatchObject({ audits: 1, entitlementUpserts: 1, webhookStatus: 'processed' })
   })
 
   it('processes quota change with a sync transaction database', async () => {
@@ -179,7 +336,26 @@ describe('processCloudOrderQuotaChange', () => {
       duplicate: false,
       eventId: 'evt-sync',
     })
-    expect(state).toMatchObject({ audits: 1, webhookStatus: 'processed', quotaUpdates: 1 })
+    expect(state).toMatchObject({ audits: 1, legacyQuotaReversals: 1, webhookStatus: 'processed' })
+  })
+
+  it('reverses legacy base quota when a decrease has no matching entitlement', async () => {
+    const { db, state } = createLegacyReversalDb()
+    const event = {
+      eventId: 'evt-legacy-reversal',
+      eventType: 'order.quota_changed' as const,
+      cloudOrderId: 'order-legacy',
+      targetOrgId: 'org-legacy',
+      direction: 'decrease' as const,
+      storageBytes: 4096,
+      trafficBytes: 0,
+    }
+
+    await expect(processCloudOrderQuotaChange(db, event, JSON.stringify(event), 'hash-legacy')).resolves.toEqual({
+      duplicate: false,
+      eventId: 'evt-legacy-reversal',
+    })
+    expect(state).toMatchObject({ audits: 1, entitlementRevokes: 0, legacyQuotaReversals: 1 })
   })
 
   it('marks async quota change failed when the target quota is missing', async () => {
@@ -197,7 +373,7 @@ describe('processCloudOrderQuotaChange', () => {
     await expect(processCloudOrderQuotaChange(db, event, JSON.stringify(event), 'hash-missing')).rejects.toThrow(
       'target_quota_missing',
     )
-    expect(state).toMatchObject({ audits: 0, webhookStatus: 'failed', quotaUpdates: 1 })
+    expect(state).toMatchObject({ audits: 0, webhookStatus: 'failed', entitlementRevokes: 0 })
   })
 
   it('surfaces quota change webhook insert failures', async () => {
@@ -236,7 +412,7 @@ describe('processCloudOrderQuotaChange', () => {
       duplicate: true,
       eventId: 'evt-duplicate',
     })
-    expect(state).toMatchObject({ audits: 0, webhookStatus: 'processed', quotaUpdates: 0 })
+    expect(state).toMatchObject({ audits: 0, webhookStatus: 'processed', entitlementUpserts: 0 })
   })
 
   it('rejects duplicate webhook events when the payload hash changes', async () => {
@@ -260,6 +436,35 @@ describe('processCloudOrderQuotaChange', () => {
     )
   })
 
+  it('treats a stale processing webhook as duplicate when another retry claims it first', async () => {
+    const { db, state } = createUniqueConflictDb(
+      {
+        id: 'webhook-stale-processing-lost',
+        payloadHash: 'hash-stale-processing-lost',
+        status: 'processing',
+        createdAt: new Date(Date.now() - 10 * 60 * 1000),
+      },
+      [],
+    )
+    const event = {
+      eventId: 'evt-stale-processing-lost',
+      eventType: 'order.quota_changed' as const,
+      cloudOrderId: 'order-stale-processing-lost',
+      targetOrgId: 'org-stale-processing-lost',
+      direction: 'decrease' as const,
+      storageBytes: 1024,
+      trafficBytes: 0,
+    }
+
+    await expect(
+      processCloudOrderQuotaChange(db, event, JSON.stringify(event), 'hash-stale-processing-lost'),
+    ).resolves.toEqual({
+      duplicate: true,
+      eventId: 'evt-stale-processing-lost',
+    })
+    expect(state).toMatchObject({ audits: 0, entitlementRevokes: 0, legacyQuotaReversals: 0 })
+  })
+
   it('reprocesses failed webhook events when the payload is unchanged', async () => {
     const { db, state } = createUniqueConflictDb({
       id: 'webhook-failed',
@@ -280,6 +485,11 @@ describe('processCloudOrderQuotaChange', () => {
       duplicate: false,
       eventId: 'evt-retry',
     })
-    expect(state).toMatchObject({ audits: 1, webhookStatus: 'processed', quotaUpdates: 1 })
+    expect(state).toMatchObject({
+      audits: 1,
+      entitlementRevokes: 1,
+      legacyQuotaReversals: 1,
+      webhookStatus: 'processed',
+    })
   })
 })

--- a/server/services/cloud-store.ts
+++ b/server/services/cloud-store.ts
@@ -1,11 +1,13 @@
 import type { CloudOrderQuotaChange, CloudStoreSettingsInput } from '@shared/schemas'
 import type { CloudStoreSettings, CloudStoreTarget } from '@shared/types'
-import { and, eq, inArray, sql } from 'drizzle-orm'
+import { and, eq, inArray } from 'drizzle-orm'
 import { nanoid } from 'nanoid'
 import { member, organization, user } from '../db/auth-schema'
-import { activityEvents, orgQuotas, systemOptions, webhookEvents } from '../db/schema'
+import { activityEvents, systemOptions, webhookEvents } from '../db/schema'
 import { loadActiveLicenseBinding } from '../licensing/license-state'
 import type { Database } from '../platform/interface'
+import { quotaChangeMetadata } from './quota-change-event'
+import { applyQuotaChange, applyQuotaChangeSync } from './quota-entitlements'
 
 const CLOUD_STORE_ENABLED_KEY = 'cloud_store_enabled'
 const CLOUD_STORE_CREATED_AT_KEY = 'cloud_store_created_at'
@@ -15,6 +17,7 @@ const CLOUD_STORE_SETTING_KEYS = [
   CLOUD_STORE_CREATED_AT_KEY,
   CLOUD_STORE_UPDATED_AT_KEY,
 ] as const
+const WEBHOOK_PROCESSING_STALE_MS = 5 * 60 * 1000
 
 export async function getCloudStoreSettings(db: Database): Promise<CloudStoreSettings | null> {
   const settings = await getRawSettings(db)
@@ -153,54 +156,6 @@ async function processQuotaChangeTransaction(
   })
 }
 
-async function applyQuotaChange(db: Database, event: CloudOrderQuotaChange): Promise<void> {
-  const rows = await db
-    .update(orgQuotas)
-    .set(quotaUpdateValues(event))
-    .where(eq(orgQuotas.orgId, event.targetOrgId))
-    .returning({ id: orgQuotas.id })
-
-  if (rows.length === 0) throw new Error('target_quota_missing')
-}
-
-function applyQuotaChangeSync(db: Database, event: CloudOrderQuotaChange): void {
-  const rows = (
-    db
-      .update(orgQuotas)
-      .set(quotaUpdateValues(event))
-      .where(eq(orgQuotas.orgId, event.targetOrgId))
-      .returning({ id: orgQuotas.id }) as {
-      all(): Array<{ id: string }>
-    }
-  ).all()
-
-  if (rows.length === 0) throw new Error('target_quota_missing')
-}
-
-function quotaUpdateValues(event: CloudOrderQuotaChange) {
-  return {
-    quota: quotaUpdateExpression(orgQuotas.quota, event.storageBytes, event.direction),
-    trafficQuota: quotaUpdateExpression(orgQuotas.trafficQuota, event.trafficBytes, event.direction),
-  }
-}
-
-function quotaUpdateExpression(
-  column: typeof orgQuotas.quota | typeof orgQuotas.trafficQuota,
-  bytes: number,
-  direction: CloudOrderQuotaChange['direction'],
-) {
-  if (direction === 'increase') return sql`${column} + ${bytes}`
-  return sql`MAX(0, ${column} - ${bytes})`
-}
-
-async function recordQuotaChangeAudit(db: Database, event: CloudOrderQuotaChange): Promise<void> {
-  await db.insert(activityEvents).values(quotaChangeAuditValues(event))
-}
-
-function recordQuotaChangeAuditSync(db: Database, event: CloudOrderQuotaChange): void {
-  ;(db.insert(activityEvents).values(quotaChangeAuditValues(event)) as { run(): void }).run()
-}
-
 function quotaChangeAuditValues(event: CloudOrderQuotaChange): typeof activityEvents.$inferInsert {
   return {
     id: nanoid(),
@@ -210,16 +165,43 @@ function quotaChangeAuditValues(event: CloudOrderQuotaChange): typeof activityEv
     targetType: 'quota',
     targetId: event.targetOrgId,
     targetName: event.targetOrgId,
-    metadata: JSON.stringify({
-      eventId: event.eventId,
-      eventType: event.eventType,
-      direction: event.direction,
-      storageBytes: event.storageBytes,
-      trafficBytes: event.trafficBytes,
-      cloudOrderId: event.cloudOrderId ?? null,
-    }),
+    metadata: quotaChangeMetadata(event),
     createdAt: new Date(),
   }
+}
+
+function isUniqueConflict(error: unknown): boolean {
+  return error instanceof Error && error.message.toLowerCase().includes('unique')
+}
+
+function isSyncDatabase(db: Database): boolean {
+  return db.constructor.name === 'BetterSQLite3Database'
+}
+
+function settingsDto(
+  row: { id: string; enabled: boolean; createdAt: Date; updatedAt: Date },
+  cloudReady = true,
+): CloudStoreSettings {
+  return {
+    id: row.id,
+    enabled: row.enabled,
+    status: cloudReady ? 'ready' : 'cloud_unbound',
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  }
+}
+
+function parseOrgType(metadata: string | null): string {
+  if (!metadata) return 'unknown'
+  return (JSON.parse(metadata) as { type?: string }).type ?? 'unknown'
+}
+
+async function recordQuotaChangeAudit(db: Database, event: CloudOrderQuotaChange): Promise<void> {
+  await db.insert(activityEvents).values(quotaChangeAuditValues(event))
+}
+
+function recordQuotaChangeAuditSync(db: Database, event: CloudOrderQuotaChange): void {
+  ;(db.insert(activityEvents).values(quotaChangeAuditValues(event)) as { run(): void }).run()
 }
 
 async function beginWebhookEvent(
@@ -256,6 +238,7 @@ async function resumeWebhookEvent(
   const rows = await db
     .select({
       id: webhookEvents.id,
+      createdAt: webhookEvents.createdAt,
       payloadHash: webhookEvents.payloadHash,
       status: webhookEvents.status,
     })
@@ -268,8 +251,12 @@ async function resumeWebhookEvent(
   if (existing.payloadHash !== payloadHash) {
     throw new Error('webhook_payload_conflict')
   }
-  if (existing.status === 'processed' || existing.status === 'duplicate' || existing.status === 'processing') {
+  if (existing.status === 'processed' || existing.status === 'duplicate') {
     return { id: existing.id, duplicate: true }
+  }
+  if (existing.status === 'processing') {
+    if (!isStaleProcessingWebhook(existing.createdAt)) return { id: existing.id, duplicate: true }
+    return claimStaleProcessingWebhook(db, existing.id, existing.createdAt, rawPayload)
   }
 
   await db
@@ -278,6 +265,27 @@ async function resumeWebhookEvent(
     .where(eq(webhookEvents.id, existing.id))
 
   return { id: existing.id, duplicate: false }
+}
+
+async function claimStaleProcessingWebhook(
+  db: Database,
+  id: string,
+  createdAt: Date,
+  rawPayload: string,
+): Promise<{ id: string; duplicate: boolean }> {
+  const rows = await db
+    .update(webhookEvents)
+    .set({ rawPayload, status: 'processing', error: null, processedAt: null, createdAt: new Date() })
+    .where(
+      and(eq(webhookEvents.id, id), eq(webhookEvents.status, 'processing'), eq(webhookEvents.createdAt, createdAt)),
+    )
+    .returning({ id: webhookEvents.id })
+
+  return rows.length > 0 ? { id, duplicate: false } : { id, duplicate: true }
+}
+
+function isStaleProcessingWebhook(createdAt: Date): boolean {
+  return Date.now() - createdAt.getTime() > WEBHOOK_PROCESSING_STALE_MS
 }
 
 async function markWebhookEvent(db: Database, id: string, status: string, error: string | null): Promise<void> {
@@ -290,30 +298,4 @@ function markWebhookEventSync(db: Database, id: string, status: string, error: s
       run(): void
     }
   ).run()
-}
-
-function settingsDto(
-  row: { id: string; enabled: boolean; createdAt: Date; updatedAt: Date },
-  cloudReady = true,
-): CloudStoreSettings {
-  return {
-    id: row.id,
-    enabled: row.enabled,
-    status: cloudReady ? 'ready' : 'cloud_unbound',
-    createdAt: row.createdAt.toISOString(),
-    updatedAt: row.updatedAt.toISOString(),
-  }
-}
-
-function parseOrgType(metadata: string | null): string {
-  if (!metadata) return 'unknown'
-  return (JSON.parse(metadata) as { type?: string }).type ?? 'unknown'
-}
-
-function isUniqueConflict(error: unknown): boolean {
-  return error instanceof Error && error.message.toLowerCase().includes('unique')
-}
-
-function isSyncDatabase(db: Database): boolean {
-  return db.constructor.name === 'BetterSQLite3Database'
 }

--- a/server/services/effective-quota.test.ts
+++ b/server/services/effective-quota.test.ts
@@ -1,11 +1,12 @@
 import { eq, sql } from 'drizzle-orm'
 import { nanoid } from 'nanoid'
 import { describe, expect, it } from 'vitest'
-import { orgQuotas } from '../db/schema.js'
+import { orgQuotaEntitlements, orgQuotas } from '../db/schema.js'
 import { createTestApp } from '../test/setup.js'
 import {
   consumeTrafficIfQuotaAllows,
   getEffectiveQuota,
+  hasQuotaForBytes,
   hasTrafficQuotaForBytes,
   refundTraffic,
 } from './effective-quota.js'
@@ -32,6 +33,118 @@ describe('effective quota', () => {
       trafficQuota: 2000,
       trafficUsed: 500,
       trafficPeriod: '2026-05',
+    })
+  })
+
+  it('adds active entitlement bytes to finite storage and traffic quotas', async () => {
+    const { db } = await createTestApp()
+    const orgId = nanoid()
+    await db.insert(orgQuotas).values({
+      id: nanoid(),
+      orgId,
+      quota: 1000,
+      used: 250,
+      trafficQuota: 2000,
+      trafficUsed: 500,
+      trafficPeriod: '2026-05',
+    })
+    const timestamp = new Date('2026-05-01T00:00:00Z')
+    await db.insert(orgQuotaEntitlements).values([
+      {
+        id: nanoid(),
+        orgId,
+        resourceType: 'storage',
+        source: 'cloud_order',
+        sourceId: 'order-storage-a',
+        bytes: 400,
+        startsAt: timestamp,
+        expiresAt: null,
+        status: 'active',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+      {
+        id: nanoid(),
+        orgId,
+        resourceType: 'storage',
+        source: 'cloud_order',
+        sourceId: 'order-storage-b',
+        bytes: 200,
+        startsAt: timestamp,
+        expiresAt: null,
+        status: 'active',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+      {
+        id: nanoid(),
+        orgId,
+        resourceType: 'traffic',
+        source: 'cloud_order',
+        sourceId: 'order-traffic',
+        bytes: 300,
+        startsAt: timestamp,
+        expiresAt: null,
+        status: 'active',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+    ])
+
+    await expect(getEffectiveQuota(db, orgId, new Date('2026-05-06T00:00:00Z'))).resolves.toMatchObject({
+      baseQuota: 1000,
+      quota: 1600,
+      used: 250,
+      trafficQuota: 2300,
+    })
+    await expect(hasQuotaForBytes(db, orgId, 1350)).resolves.toBe(true)
+    await expect(hasQuotaForBytes(db, orgId, 1351)).resolves.toBe(false)
+  })
+
+  it('ignores inactive and expired storage entitlements', async () => {
+    const { db } = await createTestApp()
+    const orgId = nanoid()
+    await db.insert(orgQuotas).values({
+      id: nanoid(),
+      orgId,
+      quota: 1000,
+      used: 0,
+      trafficQuota: 0,
+      trafficUsed: 0,
+      trafficPeriod: '2026-05',
+    })
+    await db.insert(orgQuotaEntitlements).values([
+      {
+        id: nanoid(),
+        orgId,
+        resourceType: 'storage',
+        source: 'cloud_order',
+        sourceId: 'order-revoked',
+        bytes: 400,
+        startsAt: new Date('2026-05-01T00:00:00Z'),
+        expiresAt: null,
+        status: 'revoked',
+        createdAt: new Date('2026-05-01T00:00:00Z'),
+        updatedAt: new Date('2026-05-01T00:00:00Z'),
+      },
+      {
+        id: nanoid(),
+        orgId,
+        resourceType: 'storage',
+        source: 'cloud_order',
+        sourceId: 'order-expired',
+        bytes: 400,
+        startsAt: new Date('2026-04-01T00:00:00Z'),
+        expiresAt: new Date('2026-05-01T00:00:00Z'),
+        status: 'active',
+        createdAt: new Date('2026-04-01T00:00:00Z'),
+        updatedAt: new Date('2026-04-01T00:00:00Z'),
+      },
+    ])
+
+    await expect(getEffectiveQuota(db, orgId, new Date('2026-05-06T00:00:00Z'))).resolves.toMatchObject({
+      baseQuota: 1000,
+      quota: 1000,
     })
   })
 
@@ -73,10 +186,76 @@ describe('effective quota', () => {
 
     await expect(hasTrafficQuotaForBytes(db, orgId, 600, now)).resolves.toBe(true)
     await expect(consumeTrafficIfQuotaAllows(db, orgId, 600, now)).resolves.toBe(true)
-    await expect(consumeTrafficIfQuotaAllows(db, orgId, 1, now)).resolves.toBe(false)
+    await expect(consumeTrafficIfQuotaAllows(db, orgId, 101, now)).resolves.toBe(false)
 
     const rows = await db.select().from(orgQuotas).where(eq(orgQuotas.orgId, orgId))
     expect(rows[0].trafficUsed).toBe(1000)
+  })
+
+  it('uses active traffic entitlements when consuming monthly traffic', async () => {
+    const { db } = await createTestApp()
+    const orgId = nanoid()
+    const now = new Date('2026-05-06T00:00:00Z')
+    await db.insert(orgQuotas).values({
+      id: nanoid(),
+      orgId,
+      quota: 1000,
+      used: 0,
+      trafficQuota: 1000,
+      trafficUsed: 900,
+      trafficPeriod: '2026-05',
+    })
+    await db.insert(orgQuotaEntitlements).values({
+      id: nanoid(),
+      orgId,
+      resourceType: 'traffic',
+      source: 'cloud_order',
+      sourceId: 'order-traffic',
+      bytes: 500,
+      startsAt: new Date('2026-05-01T00:00:00Z'),
+      expiresAt: null,
+      status: 'active',
+      createdAt: new Date('2026-05-01T00:00:00Z'),
+      updatedAt: new Date('2026-05-01T00:00:00Z'),
+    })
+
+    await expect(hasTrafficQuotaForBytes(db, orgId, 500, now)).resolves.toBe(true)
+    await expect(consumeTrafficIfQuotaAllows(db, orgId, 500, now)).resolves.toBe(true)
+    await expect(consumeTrafficIfQuotaAllows(db, orgId, 101, now)).resolves.toBe(false)
+
+    const rows = await db.select().from(orgQuotas).where(eq(orgQuotas.orgId, orgId))
+    expect(rows[0].trafficUsed).toBe(1400)
+  })
+
+  it('keeps zero traffic quota unlimited when traffic entitlements exist', async () => {
+    const { db } = await createTestApp()
+    const orgId = nanoid()
+    const now = new Date('2026-05-06T00:00:00Z')
+    await db.insert(orgQuotas).values({
+      id: nanoid(),
+      orgId,
+      quota: 1000,
+      used: 0,
+      trafficQuota: 0,
+      trafficUsed: 900,
+      trafficPeriod: '2026-05',
+    })
+    await db.insert(orgQuotaEntitlements).values({
+      id: nanoid(),
+      orgId,
+      resourceType: 'traffic',
+      source: 'cloud_order',
+      sourceId: 'order-traffic-unlimited',
+      bytes: 500,
+      startsAt: new Date('2026-05-01T00:00:00Z'),
+      expiresAt: null,
+      status: 'active',
+      createdAt: new Date('2026-05-01T00:00:00Z'),
+      updatedAt: new Date('2026-05-01T00:00:00Z'),
+    })
+
+    await expect(getEffectiveQuota(db, orgId, now)).resolves.toMatchObject({ trafficQuota: 0 })
+    await expect(consumeTrafficIfQuotaAllows(db, orgId, 10_000, now)).resolves.toBe(true)
   })
 
   it('refunds current monthly traffic usage', async () => {

--- a/server/services/effective-quota.ts
+++ b/server/services/effective-quota.ts
@@ -1,5 +1,5 @@
 import { eq, sql } from 'drizzle-orm'
-import { orgQuotas, storages } from '../db/schema'
+import { orgQuotaEntitlements, orgQuotas, storages } from '../db/schema'
 import type { Database } from '../platform/interface'
 
 export interface EffectiveQuota {
@@ -39,17 +39,42 @@ export async function getEffectiveQuota(db: Database, orgId: string, now = new D
   const quotaRow = quotaRows[0]
 
   const baseQuota = quotaRow?.baseQuota ?? 0
+  const storageEntitlements = await getActiveQuotaEntitlementBytes(db, orgId, 'storage', now)
+  const trafficEntitlements = await getActiveQuotaEntitlementBytes(db, orgId, 'traffic', now)
   const trafficUsed = quotaRow && quotaRow.trafficPeriod === period ? quotaRow.trafficUsed : 0
   const trafficPeriod = quotaRow?.trafficPeriod === period ? quotaRow.trafficPeriod : period
   return {
     orgId,
     baseQuota,
-    quota: baseQuota,
+    quota: baseQuota === 0 ? 0 : baseQuota + storageEntitlements,
     used: quotaRow?.used ?? 0,
-    trafficQuota: quotaRow?.trafficQuota ?? 0,
+    trafficQuota: !quotaRow || quotaRow.trafficQuota === 0 ? 0 : quotaRow.trafficQuota + trafficEntitlements,
     trafficUsed,
     trafficPeriod,
   }
+}
+
+export async function getActiveQuotaEntitlementBytes(
+  db: Database,
+  orgId: string,
+  resourceType: 'storage' | 'traffic',
+  now = new Date(),
+): Promise<number> {
+  const nowMs = now.getTime()
+  const rows = await db
+    .select({
+      bytes: sql<number>`COALESCE(SUM(${orgQuotaEntitlements.bytes}), 0)`,
+    })
+    .from(orgQuotaEntitlements)
+    .where(
+      sql`${orgQuotaEntitlements.orgId} = ${orgId}
+        AND ${orgQuotaEntitlements.resourceType} = ${resourceType}
+        AND ${orgQuotaEntitlements.status} = 'active'
+        AND ${orgQuotaEntitlements.startsAt} <= ${nowMs}
+        AND (${orgQuotaEntitlements.expiresAt} IS NULL OR ${orgQuotaEntitlements.expiresAt} > ${nowMs})`,
+    )
+
+  return Number(rows[0]?.bytes ?? 0)
 }
 
 export async function hasQuotaForBytes(db: Database, orgId: string, bytes: number): Promise<boolean> {
@@ -93,7 +118,7 @@ export async function consumeTrafficIfQuotaAllows(
       .where(
         sql`${orgQuotas.orgId} = ${orgId}
           AND ${orgQuotas.trafficPeriod} != ${period}
-          AND (${orgQuotas.trafficQuota} = 0 OR ${bytes} <= ${orgQuotas.trafficQuota})`,
+          AND (${orgQuotas.trafficQuota} = 0 OR ${bytes} <= ${effectiveTrafficQuotaSql(orgId, now)})`,
       )
       .returning({ id: orgQuotas.id })
     if (updated.length > 0) return true
@@ -105,7 +130,7 @@ export async function consumeTrafficIfQuotaAllows(
     .where(
       sql`${orgQuotas.orgId} = ${orgId}
         AND ${orgQuotas.trafficPeriod} = ${period}
-        AND (${orgQuotas.trafficQuota} = 0 OR ${orgQuotas.trafficUsed} + ${bytes} <= ${orgQuotas.trafficQuota})`,
+        AND (${orgQuotas.trafficQuota} = 0 OR ${orgQuotas.trafficUsed} + ${bytes} <= ${effectiveTrafficQuotaSql(orgId, now)})`,
     )
     .returning({ id: orgQuotas.id })
 
@@ -138,7 +163,7 @@ export async function incrementUsageIfEffectiveQuotaAllows(
         .set({ used: sql`${orgQuotas.used} + ${bytes}` })
         .where(
           sql`${orgQuotas.orgId} = ${orgId}
-            AND (${orgQuotas.quota} = 0 OR ${orgQuotas.used} + ${bytes} <= ${orgQuotas.quota})`,
+            AND (${orgQuotas.quota} = 0 OR ${orgQuotas.used} + ${bytes} <= ${effectiveStorageQuotaSql(orgId)})`,
         )
         .returning({ id: orgQuotas.id })
 
@@ -152,4 +177,30 @@ export async function incrementUsageIfEffectiveQuotaAllows(
     .where(eq(storages.id, storageId))
 
   return true
+}
+
+function effectiveStorageQuotaSql(orgId: string) {
+  const nowMs = Date.now()
+  return activeEntitlementQuotaSql(orgId, 'storage', nowMs, orgQuotas.quota)
+}
+
+function effectiveTrafficQuotaSql(orgId: string, now: Date) {
+  return activeEntitlementQuotaSql(orgId, 'traffic', now.getTime(), orgQuotas.trafficQuota)
+}
+
+function activeEntitlementQuotaSql(
+  orgId: string,
+  resourceType: 'storage' | 'traffic',
+  nowMs: number,
+  baseColumn: typeof orgQuotas.quota | typeof orgQuotas.trafficQuota,
+) {
+  return sql`${baseColumn} + COALESCE((
+    SELECT SUM(${orgQuotaEntitlements.bytes})
+    FROM ${orgQuotaEntitlements}
+    WHERE ${orgQuotaEntitlements.orgId} = ${orgId}
+      AND ${orgQuotaEntitlements.resourceType} = ${resourceType}
+      AND ${orgQuotaEntitlements.status} = 'active'
+      AND ${orgQuotaEntitlements.startsAt} <= ${nowMs}
+      AND (${orgQuotaEntitlements.expiresAt} IS NULL OR ${orgQuotaEntitlements.expiresAt} > ${nowMs})
+  ), 0)`
 }

--- a/server/services/quota-change-event.ts
+++ b/server/services/quota-change-event.ts
@@ -1,0 +1,17 @@
+import type { CloudOrderQuotaChange } from '@shared/schemas'
+
+export function quotaChangeMetadata(event: CloudOrderQuotaChange) {
+  return JSON.stringify({
+    eventId: event.eventId,
+    eventType: event.eventType,
+    direction: event.direction,
+    storageBytes: event.storageBytes,
+    trafficBytes: event.trafficBytes,
+    cloudOrderId: event.cloudOrderId ?? null,
+    packageId: event.packageId ?? null,
+  })
+}
+
+export function quotaChangeDate(event: CloudOrderQuotaChange) {
+  return new Date(event.occurredAt ?? Date.now())
+}

--- a/server/services/quota-entitlement-queries.ts
+++ b/server/services/quota-entitlement-queries.ts
@@ -1,0 +1,19 @@
+import type { CloudOrderQuotaChange } from '@shared/schemas'
+import { and, eq, sql } from 'drizzle-orm'
+import { orgQuotaEntitlements } from '../db/schema'
+
+export function cloudOrderEntitlementIncreaseBytes(bytes: number) {
+  return sql`CASE
+    WHEN ${orgQuotaEntitlements.status} = 'active' THEN ${orgQuotaEntitlements.bytes} + ${bytes}
+    ELSE ${bytes}
+  END`
+}
+
+export function cloudOrderEntitlementWhere(event: CloudOrderQuotaChange, resourceType: 'storage' | 'traffic') {
+  return and(
+    eq(orgQuotaEntitlements.orgId, event.targetOrgId),
+    eq(orgQuotaEntitlements.resourceType, resourceType),
+    eq(orgQuotaEntitlements.source, 'cloud_order'),
+    eq(orgQuotaEntitlements.sourceId, event.cloudOrderId),
+  )
+}

--- a/server/services/quota-entitlements.ts
+++ b/server/services/quota-entitlements.ts
@@ -1,0 +1,294 @@
+import type { CloudOrderQuotaChange } from '@shared/schemas'
+import { and, asc, eq, sql } from 'drizzle-orm'
+import { nanoid } from 'nanoid'
+import { orgQuotaEntitlements, orgQuotas } from '../db/schema'
+import type { Database } from '../platform/interface'
+import { quotaChangeDate, quotaChangeMetadata } from './quota-change-event'
+import { cloudOrderEntitlementIncreaseBytes, cloudOrderEntitlementWhere } from './quota-entitlement-queries'
+import {
+  ensureTargetQuota,
+  ensureTargetQuotaSync,
+  storageQuotaDecreaseValues,
+  trafficQuotaUpdateValues,
+} from './quota-target'
+
+type QuotaResourceType = 'storage' | 'traffic'
+export async function applyQuotaChange(db: Database, event: CloudOrderQuotaChange): Promise<void> {
+  await ensureTargetQuota(db, event.targetOrgId)
+  if (event.storageBytes > 0) await applyResourceQuotaChange(db, event, 'storage', event.storageBytes)
+  if (event.trafficBytes > 0) await applyTrafficQuotaChange(db, event)
+}
+
+export function applyQuotaChangeSync(db: Database, event: CloudOrderQuotaChange): void {
+  ensureTargetQuotaSync(db, event.targetOrgId)
+  if (event.storageBytes > 0) applyResourceQuotaChangeSync(db, event, 'storage', event.storageBytes)
+  if (event.trafficBytes > 0) applyTrafficQuotaChangeSync(db, event)
+}
+
+async function applyResourceQuotaChange(
+  db: Database,
+  event: CloudOrderQuotaChange,
+  resourceType: QuotaResourceType,
+  bytes: number,
+) {
+  if (event.direction === 'increase') {
+    await upsertCloudOrderEntitlement(db, event, resourceType, bytes)
+    return
+  }
+
+  const rows = await matchingCloudOrderEntitlementRows(db, event, resourceType)
+  if (rows.length > 0) {
+    const activeRows = rows.filter((row) => row.status === 'active')
+    if (activeRows.length === 0) return
+
+    const remaining = await applyEntitlementReduction(db, activeRows, bytes)
+    if (remaining > 0) await reverseLegacyQuotaChange(db, event.targetOrgId, remaining)
+    return
+  }
+
+  const remaining = await reduceActiveEntitlements(db, event.targetOrgId, resourceType, bytes, quotaChangeDate(event))
+  if (remaining > 0) await reverseLegacyQuotaChange(db, event.targetOrgId, remaining)
+}
+
+function applyResourceQuotaChangeSync(
+  db: Database,
+  event: CloudOrderQuotaChange,
+  resourceType: QuotaResourceType,
+  bytes: number,
+) {
+  if (event.direction === 'increase') {
+    upsertCloudOrderEntitlementSync(db, event, resourceType, bytes)
+    return
+  }
+
+  const rows = matchingCloudOrderEntitlementRowsSync(db, event, resourceType)
+  if (rows.length > 0) {
+    const activeRows = rows.filter((row) => row.status === 'active')
+    if (activeRows.length === 0) return
+
+    const remaining = applyEntitlementReductionSync(db, activeRows, bytes)
+    if (remaining > 0) reverseLegacyQuotaChangeSync(db, event.targetOrgId, remaining)
+    return
+  }
+
+  const remaining = reduceActiveEntitlementsSync(db, event.targetOrgId, resourceType, bytes, quotaChangeDate(event))
+  if (remaining > 0) reverseLegacyQuotaChangeSync(db, event.targetOrgId, remaining)
+}
+
+async function applyTrafficQuotaChange(db: Database, event: CloudOrderQuotaChange) {
+  await db
+    .update(orgQuotas)
+    .set(trafficQuotaUpdateValues(event.direction, event.trafficBytes))
+    .where(eq(orgQuotas.orgId, event.targetOrgId))
+}
+
+function applyTrafficQuotaChangeSync(db: Database, event: CloudOrderQuotaChange) {
+  ;(
+    db
+      .update(orgQuotas)
+      .set(trafficQuotaUpdateValues(event.direction, event.trafficBytes))
+      .where(eq(orgQuotas.orgId, event.targetOrgId)) as {
+      run(): void
+    }
+  ).run()
+}
+
+async function upsertCloudOrderEntitlement(
+  db: Database,
+  event: CloudOrderQuotaChange,
+  resourceType: QuotaResourceType,
+  bytes: number,
+) {
+  await db
+    .insert(orgQuotaEntitlements)
+    .values(cloudOrderEntitlementValues(event, resourceType, bytes))
+    .onConflictDoUpdate({
+      target: [
+        orgQuotaEntitlements.orgId,
+        orgQuotaEntitlements.resourceType,
+        orgQuotaEntitlements.source,
+        orgQuotaEntitlements.sourceId,
+      ],
+      set: {
+        bytes: cloudOrderEntitlementIncreaseBytes(bytes),
+        status: 'active',
+        expiresAt: null,
+        metadata: quotaChangeMetadata(event),
+        updatedAt: new Date(),
+      },
+    })
+}
+
+function upsertCloudOrderEntitlementSync(
+  db: Database,
+  event: CloudOrderQuotaChange,
+  resourceType: QuotaResourceType,
+  bytes: number,
+) {
+  ;(
+    db
+      .insert(orgQuotaEntitlements)
+      .values(cloudOrderEntitlementValues(event, resourceType, bytes))
+      .onConflictDoUpdate({
+        target: [
+          orgQuotaEntitlements.orgId,
+          orgQuotaEntitlements.resourceType,
+          orgQuotaEntitlements.source,
+          orgQuotaEntitlements.sourceId,
+        ],
+        set: {
+          bytes: cloudOrderEntitlementIncreaseBytes(bytes),
+          status: 'active',
+          expiresAt: null,
+          metadata: quotaChangeMetadata(event),
+          updatedAt: new Date(),
+        },
+      }) as { run(): void }
+  ).run()
+}
+
+async function matchingCloudOrderEntitlementRows(
+  db: Database,
+  event: CloudOrderQuotaChange,
+  resourceType: QuotaResourceType,
+) {
+  return db
+    .select({ id: orgQuotaEntitlements.id, bytes: orgQuotaEntitlements.bytes, status: orgQuotaEntitlements.status })
+    .from(orgQuotaEntitlements)
+    .where(cloudOrderEntitlementWhere(event, resourceType))
+}
+
+function matchingCloudOrderEntitlementRowsSync(
+  db: Database,
+  event: CloudOrderQuotaChange,
+  resourceType: QuotaResourceType,
+) {
+  return (
+    db
+      .select({ id: orgQuotaEntitlements.id, bytes: orgQuotaEntitlements.bytes, status: orgQuotaEntitlements.status })
+      .from(orgQuotaEntitlements)
+      .where(cloudOrderEntitlementWhere(event, resourceType)) as {
+      all(): Array<{ id: string; bytes: number; status: string }>
+    }
+  ).all()
+}
+
+async function reduceActiveEntitlements(
+  db: Database,
+  orgId: string,
+  resourceType: QuotaResourceType,
+  bytes: number,
+  now: Date,
+) {
+  const rows = await activeEntitlementRows(db, orgId, resourceType, now)
+  return applyEntitlementReduction(db, rows, bytes)
+}
+
+function reduceActiveEntitlementsSync(
+  db: Database,
+  orgId: string,
+  resourceType: QuotaResourceType,
+  bytes: number,
+  now: Date,
+) {
+  const rows = (
+    activeEntitlementRows(db, orgId, resourceType, now) as unknown as {
+      all(): Array<{ id: string; bytes: number }>
+    }
+  ).all()
+  return applyEntitlementReductionSync(db, rows, bytes)
+}
+
+function activeEntitlementRows(db: Database, orgId: string, resourceType: QuotaResourceType, now: Date) {
+  const nowMs = now.getTime()
+  return db
+    .select({ id: orgQuotaEntitlements.id, bytes: orgQuotaEntitlements.bytes })
+    .from(orgQuotaEntitlements)
+    .where(
+      and(
+        eq(orgQuotaEntitlements.orgId, orgId),
+        eq(orgQuotaEntitlements.resourceType, resourceType),
+        eq(orgQuotaEntitlements.source, 'cloud_order'),
+        eq(orgQuotaEntitlements.status, 'active'),
+        sql`${orgQuotaEntitlements.startsAt} <= ${nowMs}`,
+        sql`(${orgQuotaEntitlements.expiresAt} IS NULL OR ${orgQuotaEntitlements.expiresAt} > ${nowMs})`,
+      ),
+    )
+    .orderBy(asc(orgQuotaEntitlements.createdAt))
+}
+
+async function applyEntitlementReduction(
+  db: Database,
+  rows: Array<{ id: string; bytes: number }>,
+  bytes: number,
+): Promise<number> {
+  let remaining = bytes
+  for (const row of rows) {
+    if (remaining === 0) return 0
+    await reduceEntitlementRow(db, row, remaining)
+    remaining = Math.max(0, remaining - row.bytes)
+  }
+  return remaining
+}
+
+function applyEntitlementReductionSync(db: Database, rows: Array<{ id: string; bytes: number }>, bytes: number) {
+  let remaining = bytes
+  for (const row of rows) {
+    if (remaining === 0) return 0
+    reduceEntitlementRowSync(db, row, remaining)
+    remaining = Math.max(0, remaining - row.bytes)
+  }
+  return remaining
+}
+
+async function reduceEntitlementRow(db: Database, row: { id: string; bytes: number }, bytes: number) {
+  await db
+    .update(orgQuotaEntitlements)
+    .set(entitlementReductionValues(row.bytes, bytes))
+    .where(eq(orgQuotaEntitlements.id, row.id))
+}
+
+function reduceEntitlementRowSync(db: Database, row: { id: string; bytes: number }, bytes: number) {
+  ;(
+    db
+      .update(orgQuotaEntitlements)
+      .set(entitlementReductionValues(row.bytes, bytes))
+      .where(eq(orgQuotaEntitlements.id, row.id)) as { run(): void }
+  ).run()
+}
+
+function entitlementReductionValues(rowBytes: number, bytes: number) {
+  const now = new Date()
+  if (rowBytes > bytes) return { bytes: rowBytes - bytes, updatedAt: now }
+  return { status: 'revoked', expiresAt: now, updatedAt: now }
+}
+
+async function reverseLegacyQuotaChange(db: Database, orgId: string, bytes: number) {
+  await db.update(orgQuotas).set(storageQuotaDecreaseValues(bytes)).where(eq(orgQuotas.orgId, orgId))
+}
+
+function reverseLegacyQuotaChangeSync(db: Database, orgId: string, bytes: number) {
+  ;(
+    db.update(orgQuotas).set(storageQuotaDecreaseValues(bytes)).where(eq(orgQuotas.orgId, orgId)) as {
+      run(): void
+    }
+  ).run()
+}
+
+function cloudOrderEntitlementValues(event: CloudOrderQuotaChange, resourceType: QuotaResourceType, bytes: number) {
+  const now = quotaChangeDate(event)
+  return {
+    id: nanoid(),
+    orgId: event.targetOrgId,
+    resourceType,
+    source: 'cloud_order',
+    sourceId: event.cloudOrderId,
+    bytes,
+    startsAt: now,
+    expiresAt: null,
+    status: 'active',
+    metadata: quotaChangeMetadata(event),
+    createdAt: now,
+    updatedAt: now,
+  }
+}

--- a/server/services/quota-target.ts
+++ b/server/services/quota-target.ts
@@ -1,0 +1,27 @@
+import type { CloudOrderQuotaChange } from '@shared/schemas'
+import { eq, sql } from 'drizzle-orm'
+import { orgQuotas } from '../db/schema'
+import type { Database } from '../platform/interface'
+
+export async function ensureTargetQuota(db: Database, orgId: string): Promise<void> {
+  const rows = await db.select({ id: orgQuotas.id }).from(orgQuotas).where(eq(orgQuotas.orgId, orgId)).limit(1)
+  if (rows.length === 0) throw new Error('target_quota_missing')
+}
+
+export function ensureTargetQuotaSync(db: Database, orgId: string): void {
+  const rows = (
+    db.select({ id: orgQuotas.id }).from(orgQuotas).where(eq(orgQuotas.orgId, orgId)).limit(1) as {
+      all(): Array<{ id: string }>
+    }
+  ).all()
+  if (rows.length === 0) throw new Error('target_quota_missing')
+}
+
+export function trafficQuotaUpdateValues(direction: CloudOrderQuotaChange['direction'], bytes: number) {
+  if (direction === 'increase') return { trafficQuota: sql`${orgQuotas.trafficQuota} + ${bytes}` }
+  return { trafficQuota: sql`MAX(0, ${orgQuotas.trafficQuota} - ${bytes})` }
+}
+
+export function storageQuotaDecreaseValues(bytes: number) {
+  return { quota: sql`MAX(0, ${orgQuotas.quota} - ${bytes})` }
+}

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -137,6 +137,24 @@ const APP_SCHEMA_SQL = `
     traffic_used INTEGER NOT NULL DEFAULT 0,
     traffic_period TEXT NOT NULL DEFAULT '1970-01'
   );
+  CREATE TABLE IF NOT EXISTS org_quota_entitlements (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL,
+    resource_type TEXT NOT NULL,
+    source TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    bytes INTEGER NOT NULL,
+    starts_at INTEGER NOT NULL,
+    expires_at INTEGER,
+    status TEXT NOT NULL,
+    metadata TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  );
+  CREATE UNIQUE INDEX IF NOT EXISTS org_quota_entitlements_source_uniq
+    ON org_quota_entitlements(org_id, resource_type, source, source_id);
+  CREATE INDEX IF NOT EXISTS org_quota_entitlements_effective_idx
+    ON org_quota_entitlements(org_id, resource_type, status, starts_at, expires_at);
   CREATE TABLE IF NOT EXISTS webhook_events (
     id TEXT PRIMARY KEY,
     source TEXT NOT NULL,

--- a/shared/schemas/cloud-store.ts
+++ b/shared/schemas/cloud-store.ts
@@ -77,7 +77,7 @@ export const cloudOrderQuotaChangeSchema = z
     trafficBytes: z.number().int().min(0).default(0),
     source: z.string().min(1).optional(),
     packageId: z.string().min(1).optional(),
-    occurredAt: z.string().min(1).optional(),
+    occurredAt: z.string().datetime().optional(),
     terminalUserId: z.string().optional(),
     terminalUserEmail: z.string().email().optional(),
   })


### PR DESCRIPTION
## Summary
- add generated org_quota_entitlements schema and migration for quota entitlement rows
- calculate effective storage quota from base org_quotas quota plus active storage entitlements
- move Cloud storage order quota changes to entitlement create/reduce/revoke semantics while keeping Cloud traffic changes on local traffic_quota mutation
- enforce effective quota in upload confirm and copy paths, with cleanup on copy failure
- expand quota, webhook, admin listing, upload, and copy coverage

## Verification
- npm run lint
- npm run typecheck
- npm test
- npm run test:cf
- delegated test-writer and clean-code reviewer passes