### PR TITLE
test: document metered storage plan flow

### DIFF
--- a/docs/roadmap/v2.6.md
+++ b/docs/roadmap/v2.6.md
@@ -88,7 +88,7 @@ Ownership:
 - **The ZPan operator defines the package catalog per instance.** Package name, description, bytes, amount, currency, active state, and sort order are configured in ZPan admin.
 - **Terminal buyers do not need Cloud accounts.** ZPan creates checkout requests through the existing Pro Cloud binding and sends the user to Cloud only for checkout handling.
 - **Purchased storage and traffic are delivered as Cloud entitlements in v2.6.** ZPan keeps admin base quota separate from Cloud-delivered storage and traffic entitlements, then exposes effective quota as `base + entitlement`. Editing the admin base quota changes only the local base quota. The existing `0` base quota sentinel means unlimited only when no active Cloud entitlement exists for that resource.
-- **Monthly storage package subscriptions stay Cloud-owned.** Cloud owns Stripe subscriptions and sends authenticated `order.quota_changed` deliveries for each subscription period or reversal. ZPan records those deliveries idempotently under the Cloud order/source id and recomputes effective quota from active entitlements.
+- **Monthly storage package subscriptions stay Cloud-owned.** Cloud owns Stripe subscriptions and sends authenticated `order.quota_changed` deliveries only for the initial entitlement, positive create/update deltas, and terminal reversals. Normal renewals are billed in Cloud and do not send ZPan webhooks or change ZPan quota. ZPan records deliveries idempotently under a stable subscription entitlement id such as `stripe_subscription:<subscriptionId>:<orgId>` and recomputes effective quota from active entitlements.
 - **Metered traffic billing is usage-event based.** ZPan increments local monthly traffic usage before issuing a presigned download URL, reports `traffic_egress` usage to Cloud with an idempotency key, and denies the request if Cloud returns the user-configured overage cap response.
 - **Store Cloud communication is automatic through the Pro binding.** ZPan resolves Cloud from `ZPAN_CLOUD_URL` or the built-in default, authenticates catalog sync, checkout with the bound instance refresh token, and sends normal JSON request bodies that include `boundLicenseId`.
 - **Webhook auth uses Cloud-signed event tokens.** Cloud order quota-change webhook attempts include `x-zpan-cloud-event-token`, a PASETO token signed by Cloud. ZPan verifies it with the built-in Cloud public keys and requires the current issuer, an audience equal to the target instance/license id, the bound license id claim, order quota-change event id, raw-body payload hash, and short expiry.
@@ -107,11 +107,12 @@ Terminal-user flow:
 2. User selects a personal or team target org they belong to
 3. Checkout calls `POST /api/store/checkouts`, which validates target access and creates a Cloud checkout using the Pro binding refresh token
 4. Cloud creates Stripe Checkout from the package snapshot
-5. Stripe paid event marks the Cloud order paid, or a monthly subscription period is billed
+5. Stripe paid event marks the initial subscription checkout paid, or Cloud accepts a positive subscription update delta
 6. Cloud sends one authenticated quota-change webhook to ZPan
-7. ZPan verifies the Cloud event token and raw payload hash, records the order quota-change event idempotently, and stores storage and traffic as active Cloud entitlements for the target org
-8. The quota meter and order history refresh
-9. If the user had a draft upload blocked by quota, confirm/upload can be retried while the draft still exists
+7. ZPan verifies the Cloud event token and raw payload hash, records the order quota-change event idempotently under the stable subscription entitlement id, and stores storage and traffic as active Cloud entitlements for the target org
+8. Normal subscription renewals are billed in Cloud only; they do not send ZPan webhooks and cannot stack quota
+9. The quota meter and order history refresh
+10. If the user had a draft upload blocked by quota, confirm/upload can be retried while the draft still exists
 
 Metered traffic caveats:
 

--- a/docs/roadmap/v2.6.md
+++ b/docs/roadmap/v2.6.md
@@ -87,7 +87,9 @@ Ownership:
 - **Cloud is merchant of record in v2.6.** Cloud owns Stripe Checkout, Stripe paid webhooks, gift-card balance, order state, and webhook retries.
 - **The ZPan operator defines the package catalog per instance.** Package name, description, bytes, amount, currency, active state, and sort order are configured in ZPan admin.
 - **Terminal buyers do not need Cloud accounts.** ZPan creates checkout requests through the existing Pro Cloud binding and sends the user to Cloud only for checkout handling.
-- **Purchased storage and traffic are applied directly to the target org quota in v2.6.** Editing the admin base quota writes the current org quota value directly. The existing `0` quota sentinel still means unlimited.
+- **Purchased storage and traffic are delivered as Cloud entitlements in v2.6.** ZPan keeps admin base quota separate from Cloud-delivered storage and traffic entitlements, then exposes effective quota as `base + entitlement`. Editing the admin base quota changes only the local base quota. The existing `0` base quota sentinel means unlimited only when no active Cloud entitlement exists for that resource.
+- **Monthly storage package subscriptions stay Cloud-owned.** Cloud owns Stripe subscriptions and sends authenticated `order.quota_changed` deliveries for each subscription period or reversal. ZPan records those deliveries idempotently under the Cloud order/source id and recomputes effective quota from active entitlements.
+- **Metered traffic billing is usage-event based.** ZPan increments local monthly traffic usage before issuing a presigned download URL, reports `traffic_egress` usage to Cloud with an idempotency key, and denies the request if Cloud returns the user-configured overage cap response.
 - **Store Cloud communication is automatic through the Pro binding.** ZPan resolves Cloud from `ZPAN_CLOUD_URL` or the built-in default, authenticates catalog sync, checkout with the bound instance refresh token, and sends normal JSON request bodies that include `boundLicenseId`.
 - **Webhook auth uses Cloud-signed event tokens.** Cloud order quota-change webhook attempts include `x-zpan-cloud-event-token`, a PASETO token signed by Cloud. ZPan verifies it with the built-in Cloud public keys and requires the current issuer, an audience equal to the target instance/license id, the bound license id claim, order quota-change event id, raw-body payload hash, and short expiry.
 
@@ -96,20 +98,26 @@ Admin flow:
 1. Pro admin opens `Settings -> Quota Store`
 2. Admin enables the store from the operator settings panel
 3. Admin creates active storage packages
-4. ZPan syncs the catalog to Cloud through `POST /api/store/packages/sync` using `boundLicenseId` and the active Pro binding credentials
+4. ZPan proxies catalog writes to Cloud through the admin package endpoints using the active Pro binding credentials
 5. Admin confirms each package has synced Cloud status before it becomes purchasable
 
 Terminal-user flow:
 
 1. User opens the ZPan Store from the quota meter without signing in to Cloud
 2. User selects a personal or team target org they belong to
-3. Checkout calls `POST /api/quota-store/checkouts`, which validates target access and creates a Cloud checkout using the Pro binding refresh token
+3. Checkout calls `POST /api/store/checkouts`, which validates target access and creates a Cloud checkout using the Pro binding refresh token
 4. Cloud creates Stripe Checkout from the package snapshot
-5. Stripe paid event marks the Cloud order paid
+5. Stripe paid event marks the Cloud order paid, or a monthly subscription period is billed
 6. Cloud sends one authenticated quota-change webhook to ZPan
-7. ZPan verifies the Cloud event token and raw payload hash, records the order quota-change event idempotently, and applies storage and traffic directly to the target org quota
+7. ZPan verifies the Cloud event token and raw payload hash, records the order quota-change event idempotently, and stores storage and traffic as active Cloud entitlements for the target org
 8. The quota meter and order history refresh
 9. If the user had a draft upload blocked by quota, confirm/upload can be retried while the draft still exists
+
+Metered traffic caveats:
+
+- ZPan meters download traffic when it issues a presigned URL. S3 serves the object directly afterward, so ZPan cannot observe partial downloads, canceled transfers, range requests, cache hits, or repeated use of an already-issued URL.
+- Cloud cap denial happens before ZPan returns the presigned URL. If Cloud rejects usage with `overage_cap_exceeded`, ZPan refunds the local traffic counter for that attempt and returns `429`.
+- Local monthly traffic quota is still enforced before Cloud reporting. Cloud metering is for billing and overage caps, not a replacement for local quota checks.
 
 Gift card checkout:
 
@@ -171,7 +179,7 @@ Everything else from v2.0–v2.5 stays Free:
 - **Token paste activation** — the old model of "purchase → receive token email → paste into ZPan" is deliberately replaced by account binding
 - **In-ZPan generic Pro purchase UI** — Pro subscription purchase flows live on `cloud.zpan.space`
 - **In-ZPan generic membership redemption input** — membership redemption lives on the cloud dashboard; only gift card checkout is accepted in the ZPan quota store
-- **Metered / usage-based billing** — quota packages are fixed additive credits in v2.6, not usage-metered subscriptions
+- **In-ZPan subscription billing engine** — storage package subscriptions, metered usage pricing, invoices, and payment operations stay on Cloud; ZPan only stores entitlement deliveries and reports traffic usage
 - **Team / Business tiers** — single Pro SKU only
 - **Multi-seat** — one Pro subscription binds one ZPan instance
 - **Multi-bind per account** — a single Pro subscription can only bind one active instance. Binding a second instance on the same Pro account requires unbinding the first, or a future Team plan

--- a/docs/v2.6-release-notes.md
+++ b/docs/v2.6-release-notes.md
@@ -44,7 +44,7 @@ The quota store lets a Pro instance operator sell monthly storage packages and m
 - **The ZPan operator defines the package catalog per instance.** Admins create packages in ZPan with name, description, bytes, price, currency, active state, and sort order.
 - **Terminal buyers do not need Cloud accounts.** ZPan creates binding-authenticated checkout requests through the Pro Cloud binding; Cloud uses those requests to create orders.
 - **Purchased storage and traffic are delivered as Cloud entitlements in v2.6.** ZPan keeps admin base quota separate from Cloud-delivered storage and traffic entitlements, then exposes the effective quota as `base + entitlement`. Editing the admin base quota changes only the local base quota. The existing `0` base quota sentinel means unlimited only when no active Cloud entitlement exists for that resource.
-- **Monthly storage package subscriptions are Cloud-owned.** ZPan does not run subscription billing locally. Cloud owns Stripe subscriptions and sends authenticated `order.quota_changed` deliveries for each subscription period or reversal. ZPan records those deliveries idempotently under the Cloud order/source id and recomputes the effective quota from active entitlements.
+- **Monthly storage package subscriptions are Cloud-owned.** ZPan does not run subscription billing locally. Cloud owns Stripe subscriptions and sends authenticated `order.quota_changed` deliveries only for the initial entitlement, positive create/update deltas, and terminal reversals. Normal renewals are billed in Cloud and do not send ZPan webhooks or change ZPan quota. ZPan records deliveries idempotently under a stable subscription entitlement id such as `stripe_subscription:<subscriptionId>:<orgId>` and recomputes the effective quota from active entitlements.
 - **Metered traffic billing is usage-event based.** ZPan increments local monthly traffic usage before issuing a presigned download URL, reports `traffic_egress` usage to Cloud with an idempotency key, and denies the request if Cloud returns the user-configured overage cap response.
 - **Generic Pro activation stays Cloud-owned.** Subscription purchase, membership redemption, and Pro entitlement activation remain in the Cloud dashboard.
 
@@ -66,8 +66,9 @@ The user-facing store remains unavailable while disabled, while Pro is missing, 
 1. A terminal user opens **Store** from the quota meter.
 2. The user chooses a personal or team target org.
 3. Checkout calls ZPan, then Cloud creates Stripe Checkout from the package snapshot associated with the bound instance.
-4. After Stripe marks the Cloud order paid, or after a monthly subscription period is billed, Cloud sends one authenticated order quota-change webhook to ZPan.
-5. ZPan records the webhook idempotently, stores storage and traffic as Cloud entitlements, and refreshes the quota meter and order history.
+4. After Stripe marks the initial subscription checkout paid, or after Cloud accepts a positive subscription update delta, Cloud sends one authenticated order quota-change webhook to ZPan.
+5. ZPan records the webhook idempotently under the stable subscription entitlement id, stores storage and traffic as Cloud entitlements, and refreshes the quota meter and order history.
+6. Normal subscription renewals are billed in Cloud only; they do not send ZPan webhooks and cannot stack quota.
 
 Users who previously hit quota can retry confirm/upload while the draft still exists after the quota change arrives.
 
@@ -94,12 +95,13 @@ The merged implementation covers:
 - Target org access checks for checkout
 - Anonymous Cloud checkout handoff from binding-authenticated ZPan Store requests
 - Stripe-paid Cloud order quota change through authenticated callback
-- Monthly subscription-shaped Cloud quota-change delivery for both storage and traffic entitlements
+- Initial subscription-shaped Cloud quota-change delivery for both storage and traffic entitlements using a stable subscription source id
 - Duplicate Cloud quota-change webhook returning success without applying quota twice
 - Bad Cloud webhook auth returning `401`
 - Admin base quota edits staying separate from Cloud entitlements
 - Upload confirm quota checks using effective quota
 - Cloud metered traffic usage reporting, idempotency, cap denial, and local counter refund behavior
+- Normal subscription renewals not stacking quota by contract: Cloud sends no ZPan webhook for renewal-only billing, and ZPan duplicate-delivery coverage verifies stable entitlement replays do not apply twice
 - Gift card checkout using gift card checkout fields, not membership redemption
 
 Manual preview evidence required before merge:
@@ -117,7 +119,7 @@ Manual preview evidence required before merge:
 6. Force storage or traffic over cap and confirm the storage quota card or traffic usage card shows the over-cap state.
    - Screenshot: `/tmp/zpan-metered-storage-preview/over-cap-state.png`
 
-Backend verification covers duplicate Cloud quota-change webhooks not applying quota twice, bad webhook auth returning `401`, admin base quota separation, subscription-shaped entitlement delivery, Cloud metered traffic reporting, Cloud cap denial, and legacy one-time quota reversal compatibility.
+Backend verification covers duplicate Cloud quota-change webhooks not applying quota twice, bad webhook auth returning `401`, admin base quota separation, stable subscription-shaped entitlement delivery, Cloud metered traffic reporting, Cloud cap denial, and legacy one-time quota reversal compatibility.
 
 ---
 

--- a/docs/v2.6-release-notes.md
+++ b/docs/v2.6-release-notes.md
@@ -36,14 +36,16 @@ Manage in **Settings → Branding**.
 
 ## Pro Quota Store
 
-The quota store lets a Pro instance operator sell extra storage and download traffic to terminal users on that ZPan instance.
+The quota store lets a Pro instance operator sell monthly storage packages and metered download traffic capacity to terminal users on that ZPan instance.
 
 ### Direction and Ownership
 
 - **Cloud is merchant of record in v2.6.** Stripe Checkout, Stripe webhooks, Cloud order state, and gift-card balance run through ZPan Cloud.
 - **The ZPan operator defines the package catalog per instance.** Admins create packages in ZPan with name, description, bytes, price, currency, active state, and sort order.
 - **Terminal buyers do not need Cloud accounts.** ZPan creates binding-authenticated checkout requests through the Pro Cloud binding; Cloud uses those requests to create orders.
-- **Purchased storage and traffic are applied directly to the target org quota in v2.6.** Editing the admin base quota writes the current org quota value directly. The existing `0` quota sentinel still means unlimited.
+- **Purchased storage and traffic are delivered as Cloud entitlements in v2.6.** ZPan keeps admin base quota separate from Cloud-delivered storage and traffic entitlements, then exposes the effective quota as `base + entitlement`. Editing the admin base quota changes only the local base quota. The existing `0` base quota sentinel means unlimited only when no active Cloud entitlement exists for that resource.
+- **Monthly storage package subscriptions are Cloud-owned.** ZPan does not run subscription billing locally. Cloud owns Stripe subscriptions and sends authenticated `order.quota_changed` deliveries for each subscription period or reversal. ZPan records those deliveries idempotently under the Cloud order/source id and recomputes the effective quota from active entitlements.
+- **Metered traffic billing is usage-event based.** ZPan increments local monthly traffic usage before issuing a presigned download URL, reports `traffic_egress` usage to Cloud with an idempotency key, and denies the request if Cloud returns the user-configured overage cap response.
 - **Generic Pro activation stays Cloud-owned.** Subscription purchase, membership redemption, and Pro entitlement activation remain in the Cloud dashboard.
 
 ### Admin Setup
@@ -64,10 +66,16 @@ The user-facing store remains unavailable while disabled, while Pro is missing, 
 1. A terminal user opens **Store** from the quota meter.
 2. The user chooses a personal or team target org.
 3. Checkout calls ZPan, then Cloud creates Stripe Checkout from the package snapshot associated with the bound instance.
-4. After Stripe marks the Cloud order paid, Cloud sends one authenticated order quota-change webhook to ZPan.
-5. ZPan records the webhook idempotently, applies storage and traffic directly to org quota, and refreshes the quota meter and order history.
+4. After Stripe marks the Cloud order paid, or after a monthly subscription period is billed, Cloud sends one authenticated order quota-change webhook to ZPan.
+5. ZPan records the webhook idempotently, stores storage and traffic as Cloud entitlements, and refreshes the quota meter and order history.
 
 Users who previously hit quota can retry confirm/upload while the draft still exists after the quota change arrives.
+
+### Metered Traffic Caveats
+
+- ZPan meters download traffic at presigned URL issuance time. S3 serves the object directly afterward, so ZPan cannot observe partial downloads, canceled transfers, range requests, cache hits, or repeated use of an already-issued URL.
+- Cloud cap denial happens before ZPan returns the presigned URL. If Cloud rejects usage with `overage_cap_exceeded`, ZPan refunds the local traffic counter for that attempt and returns `429`.
+- Local monthly traffic quota is still enforced before Cloud reporting. Cloud metering is for billing and overage caps, not a replacement for ZPan's local quota checks.
 
 ### Gift Cards
 
@@ -86,24 +94,30 @@ The merged implementation covers:
 - Target org access checks for checkout
 - Anonymous Cloud checkout handoff from binding-authenticated ZPan Store requests
 - Stripe-paid Cloud order quota change through authenticated callback
+- Monthly subscription-shaped Cloud quota-change delivery for both storage and traffic entitlements
 - Duplicate Cloud quota-change webhook returning success without applying quota twice
 - Bad Cloud webhook auth returning `401`
-- Admin base quota edits writing org quota directly
-- Upload confirm quota checks using org quota
+- Admin base quota edits staying separate from Cloud entitlements
+- Upload confirm quota checks using effective quota
+- Cloud metered traffic usage reporting, idempotency, cap denial, and local counter refund behavior
 - Gift card checkout using gift card checkout fields, not membership redemption
 
-Manual preview evidence was captured in the quota-store UI work:
+Manual preview evidence required before merge:
 
-1. Open admin quota-store settings, enable the store, then create an active package and confirm Cloud sync status.
-   - Screenshot: `/tmp/zpan-quota-store-preview/admin-package-store.png`
-2. Open the terminal-user Store from the quota meter without a Cloud account, select a personal or team target org, and confirm active packages render.
-   - Screenshot: `/tmp/zpan-quota-store-preview/user-store-packages.png`
-3. Start checkout and confirm ZPan opens the Cloud/Stripe checkout URL returned by the binding-authenticated Cloud request.
-   - Screenshot: `/tmp/zpan-quota-store-preview/checkout-launch.png`
-4. Apply a gift card during checkout and confirm order history plus quota meter refresh.
-   - Screenshot: `/tmp/zpan-quota-store-preview/gift-card-order-update.png`
+1. Open admin quota-store settings, enable the store, then create an active monthly storage package and confirm Cloud sync status.
+   - Screenshot: `/tmp/zpan-metered-storage-preview/admin-package-store.png`
+2. Open **Storage**, confirm the quota panel shows base storage, Cloud storage entitlement, included traffic, current-period traffic, and wallet balance.
+   - Screenshot: `/tmp/zpan-metered-storage-preview/storage-quota-panel.png`
+3. Open the terminal-user Store from the quota meter without a Cloud account, select a personal or team target org, and confirm active packages render.
+   - Screenshot: `/tmp/zpan-metered-storage-preview/user-store-packages.png`
+4. Start checkout and confirm ZPan opens the Cloud/Stripe checkout URL returned by the binding-authenticated Cloud request.
+   - Screenshot: `/tmp/zpan-metered-storage-preview/checkout-launch.png`
+5. Deliver a Cloud quota-change event, then confirm order history plus the quota panel refresh without changing the admin base quota.
+   - Screenshot: `/tmp/zpan-metered-storage-preview/order-history-entitlement.png`
+6. Force storage or traffic over cap and confirm the storage quota card or traffic usage card shows the over-cap state.
+   - Screenshot: `/tmp/zpan-metered-storage-preview/over-cap-state.png`
 
-Backend verification covered duplicate Cloud quota-change webhooks not applying quota twice, bad webhook auth returning `401`, and admin base quota edits writing org quota directly.
+Backend verification covers duplicate Cloud quota-change webhooks not applying quota twice, bad webhook auth returning `401`, admin base quota separation, subscription-shaped entitlement delivery, Cloud metered traffic reporting, Cloud cap denial, and legacy one-time quota reversal compatibility.
 
 ---
 
@@ -169,7 +183,7 @@ None at release time.
 - `feat(quota-store)`: Pro-gated admin package catalog and store settings with Cloud sync status
 - `feat(quota-store)`: Terminal-user storage checkout, target org selection, gift card checkout, and order history
 - `feat(quota-store)`: Authenticated Cloud quota-change webhook with idempotent order quota changes
-- `feat(quota-store)`: Effective quota now includes direct org quota changes
+- `feat(quota-store)`: Effective quota now combines admin base quota with Cloud storage and traffic entitlements
 - `feat(gates)`: Open registration gated behind `open_registration` Pro feature
 - `feat(gates)`: Team creation blocked after 1 extra team for Free (`teams_unlimited` required for the 3rd org)
 - `feat(gates)`: Storage creation blocked at 3 for Free (`storages_unlimited` required for the 4th storage)

--- a/server/routes/cloud-store.integration.test.ts
+++ b/server/routes/cloud-store.integration.test.ts
@@ -1695,16 +1695,17 @@ describe('Quota Store API', () => {
     expect(JSON.parse(audit[0].metadata)).toMatchObject({ eventId: 'evt-1', storageBytes: 4096, trafficBytes: 0 })
   })
 
-  it('delivers monthly subscription storage and traffic entitlements without changing base quotas', async () => {
+  it('delivers initial subscription storage and traffic entitlements under a stable source id', async () => {
     const { app, db } = await createTestApp()
     await seedProLicense(db)
     const headers = await adminHeaders(app)
     await seedSettings(app, headers)
     const orgId = await getFirstOrgId(db)
     await db.run(sql`UPDATE org_quotas SET quota = 8192, traffic_quota = 1024 WHERE org_id = ${orgId}`)
+    const subscriptionSourceId = `stripe_subscription:sub_metered_123:${orgId}`
     const payload = JSON.stringify({
-      eventId: 'evt-subscription-monthly-entitlement',
-      cloudOrderId: 'sub-item-2026-05',
+      eventId: 'evt-subscription-initial-entitlement',
+      cloudOrderId: subscriptionSourceId,
       targetOrgId: orgId,
       eventType: 'order.quota_changed',
       direction: 'increase',
@@ -1726,13 +1727,13 @@ describe('Quota Store API', () => {
     await expect(duplicate.json()).resolves.toMatchObject({
       success: true,
       duplicate: true,
-      eventId: 'evt-subscription-monthly-entitlement',
+      eventId: 'evt-subscription-initial-entitlement',
     })
 
     const entitlements = await db.all<{ resourceType: string; bytes: number; startsAt: number; metadata: string }>(sql`
       SELECT resource_type AS resourceType, bytes, starts_at AS startsAt, metadata
       FROM org_quota_entitlements
-      WHERE source_id = 'sub-item-2026-05'
+      WHERE source_id = ${subscriptionSourceId}
       ORDER BY resource_type
     `)
     expect(entitlements).toHaveLength(2)
@@ -1742,7 +1743,7 @@ describe('Quota Store API', () => {
     ])
     expect(new Date(entitlements[0].startsAt).toISOString()).toBe('2026-05-01T00:00:00.000Z')
     expect(JSON.parse(entitlements[0].metadata)).toMatchObject({
-      eventId: 'evt-subscription-monthly-entitlement',
+      eventId: 'evt-subscription-initial-entitlement',
       source: 'stripe_subscription',
       packageId: 'pkg-monthly-storage-traffic',
       terminalUserId: 'buyer-1',

--- a/server/routes/cloud-store.integration.test.ts
+++ b/server/routes/cloud-store.integration.test.ts
@@ -1695,6 +1695,79 @@ describe('Quota Store API', () => {
     expect(JSON.parse(audit[0].metadata)).toMatchObject({ eventId: 'evt-1', storageBytes: 4096, trafficBytes: 0 })
   })
 
+  it('delivers monthly subscription storage and traffic entitlements without changing base quotas', async () => {
+    const { app, db } = await createTestApp()
+    await seedProLicense(db)
+    const headers = await adminHeaders(app)
+    await seedSettings(app, headers)
+    const orgId = await getFirstOrgId(db)
+    await db.run(sql`UPDATE org_quotas SET quota = 8192, traffic_quota = 1024 WHERE org_id = ${orgId}`)
+    const payload = JSON.stringify({
+      eventId: 'evt-subscription-monthly-entitlement',
+      cloudOrderId: 'sub-item-2026-05',
+      targetOrgId: orgId,
+      eventType: 'order.quota_changed',
+      direction: 'increase',
+      storageBytes: 4096,
+      trafficBytes: 2048,
+      source: 'stripe_subscription',
+      packageId: 'pkg-monthly-storage-traffic',
+      occurredAt: '2026-05-01T00:00:00.000Z',
+      terminalUserId: 'buyer-1',
+      terminalUserEmail: 'buyer@example.com',
+    })
+
+    const first = await postWebhook(app, payload)
+    const duplicate = await postWebhook(app, payload)
+
+    expect(first.status).toBe(200)
+    await expect(first.json()).resolves.toMatchObject({ success: true, duplicate: false })
+    expect(duplicate.status).toBe(200)
+    await expect(duplicate.json()).resolves.toMatchObject({
+      success: true,
+      duplicate: true,
+      eventId: 'evt-subscription-monthly-entitlement',
+    })
+
+    const entitlements = await db.all<{ resourceType: string; bytes: number; startsAt: number; metadata: string }>(sql`
+      SELECT resource_type AS resourceType, bytes, starts_at AS startsAt, metadata
+      FROM org_quota_entitlements
+      WHERE source_id = 'sub-item-2026-05'
+      ORDER BY resource_type
+    `)
+    expect(entitlements).toHaveLength(2)
+    expect(entitlements.map((row) => ({ resourceType: row.resourceType, bytes: row.bytes }))).toEqual([
+      { resourceType: 'storage', bytes: 4096 },
+      { resourceType: 'traffic', bytes: 2048 },
+    ])
+    expect(new Date(entitlements[0].startsAt).toISOString()).toBe('2026-05-01T00:00:00.000Z')
+    expect(JSON.parse(entitlements[0].metadata)).toMatchObject({
+      eventId: 'evt-subscription-monthly-entitlement',
+      source: 'stripe_subscription',
+      packageId: 'pkg-monthly-storage-traffic',
+      terminalUserId: 'buyer-1',
+      terminalUserEmail: 'buyer@example.com',
+    })
+
+    const quotaRes = await app.request('/api/quotas/me', { headers })
+    const quota = (await quotaRes.json()) as {
+      baseQuota: number
+      entitlementQuota: number
+      quota: number
+      baseTrafficQuota: number
+      entitlementTrafficQuota: number
+      trafficQuota: number
+    }
+    expect(quota).toMatchObject({
+      baseQuota: 8192,
+      entitlementQuota: 4096,
+      quota: 12288,
+      baseTrafficQuota: 1024,
+      entitlementTrafficQuota: 2048,
+      trafficQuota: 3072,
+    })
+  })
+
   it('accumulates repeated Cloud increases for the same order and resource', async () => {
     const { app, db } = await createTestApp()
     await seedProLicense(db)


### PR DESCRIPTION
## Summary
- Add ZPan-side integration coverage for monthly subscription-shaped Cloud quota deliveries that create storage and traffic entitlements without mutating base quotas.
- Document v2.6 storage package subscriptions, Cloud-owned metered traffic billing, quota source separation, presigned URL metering caveats, and preview screenshot expectations.

## Verification
- npm run typecheck
- npm run lint
- npx vitest run server/routes/cloud-store.integration.test.ts
- npx vitest run server/routes/cloud-store.integration.test.ts server/services/effective-quota.test.ts server/services/cloud-traffic-metering.test.ts server/routes/cloud-traffic-metering.integration.test.ts server/routes/objects-quota.integration.test.ts src/routes/_authenticated/storage.test.tsx src/components/layout/quota-panel.test.tsx
- Delegated test-writer pass: 4 focused backend suites, 110 tests
- Delegated clean-code-reviewer pass: no remaining findings