### PR TITLE
feat: add background job foundation

### DIFF
--- a/migrations/0031_talented_skullbuster.sql
+++ b/migrations/0031_talented_skullbuster.sql
@@ -1,0 +1,28 @@
+CREATE TABLE `background_jobs` (
+	`id` text PRIMARY KEY NOT NULL,
+	`org_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`type` text NOT NULL,
+	`status` text NOT NULL,
+	`target_folder` text,
+	`target_path` text,
+	`metadata` text,
+	`input_bytes` integer DEFAULT 0 NOT NULL,
+	`output_bytes` integer DEFAULT 0 NOT NULL,
+	`processed_bytes` integer DEFAULT 0 NOT NULL,
+	`file_count` integer DEFAULT 0 NOT NULL,
+	`current_filename` text,
+	`error_message` text,
+	`result_metadata` text,
+	`retryable` integer DEFAULT false NOT NULL,
+	`cancelable` integer DEFAULT true NOT NULL,
+	`retried_from_job_id` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`started_at` integer,
+	`finished_at` integer
+);
+--> statement-breakpoint
+CREATE INDEX `background_jobs_org_created_idx` ON `background_jobs` (`org_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `background_jobs_org_status_idx` ON `background_jobs` (`org_id`,`status`);--> statement-breakpoint
+CREATE INDEX `background_jobs_org_type_idx` ON `background_jobs` (`org_id`,`type`);

--- a/migrations/meta/0031_snapshot.json
+++ b/migrations/meta/0031_snapshot.json
@@ -1,0 +1,2851 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c0b41ef0-1076-40cd-aeca-cbb1d7240062",
+  "prevId": "5b582181-3f03-4c31-bcd1-6db6d55f34ba",
+  "tables": {
+    "activity_events": {
+      "name": "activity_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "announcements": {
+      "name": "announcements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "announcements_status_priority_idx": {
+          "name": "announcements_status_priority_idx",
+          "columns": [
+            "status",
+            "priority"
+          ],
+          "isUnique": false
+        },
+        "announcements_published_idx": {
+          "name": "announcements_published_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "background_jobs": {
+      "name": "background_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_folder": {
+          "name": "target_folder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_bytes": {
+          "name": "input_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_bytes": {
+          "name": "output_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "processed_bytes": {
+          "name": "processed_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "current_filename": {
+          "name": "current_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_metadata": {
+          "name": "result_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retryable": {
+          "name": "retryable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cancelable": {
+          "name": "cancelable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "retried_from_job_id": {
+          "name": "retried_from_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "background_jobs_org_created_idx": {
+          "name": "background_jobs_org_created_idx",
+          "columns": [
+            "org_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "background_jobs_org_status_idx": {
+          "name": "background_jobs_org_status_idx",
+          "columns": [
+            "org_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "background_jobs_org_type_idx": {
+          "name": "background_jobs_org_type_idx",
+          "columns": [
+            "org_id",
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cloud_traffic_reports": {
+      "name": "cloud_traffic_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cloud_traffic_reports_event_uniq": {
+          "name": "cloud_traffic_reports_event_uniq",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": true
+        },
+        "cloud_traffic_reports_org_period_idx": {
+          "name": "cloud_traffic_reports_org_period_idx",
+          "columns": [
+            "org_id",
+            "period"
+          ],
+          "isUnique": false
+        },
+        "cloud_traffic_reports_status_idx": {
+          "name": "cloud_traffic_reports_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "image_hosting_configs": {
+      "name": "image_hosting_configs",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_domain": {
+          "name": "custom_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cf_hostname_id": {
+          "name": "cf_hostname_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "domain_verified_at": {
+          "name": "domain_verified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referer_allowlist": {
+          "name": "referer_allowlist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "image_hosting_configs_custom_domain_unique": {
+          "name": "image_hosting_configs_custom_domain_unique",
+          "columns": [
+            "custom_domain"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "image_hosting_configs_org_id_organization_id_fk": {
+          "name": "image_hosting_configs_org_id_organization_id_fk",
+          "tableFrom": "image_hosting_configs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "image_hostings": {
+      "name": "image_hostings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "image_hostings_token_unique": {
+          "name": "image_hostings_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "image_hostings_org_path_uniq": {
+          "name": "image_hostings_org_path_uniq",
+          "columns": [
+            "org_id",
+            "path"
+          ],
+          "isUnique": true
+        },
+        "image_hostings_org_created_idx": {
+          "name": "image_hostings_org_created_idx",
+          "columns": [
+            "org_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "image_hostings_token_idx": {
+          "name": "image_hostings_token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "image_hostings_org_id_organization_id_fk": {
+          "name": "image_hostings_org_id_organization_id_fk",
+          "tableFrom": "image_hostings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "image_hostings_storage_id_storages_id_fk": {
+          "name": "image_hostings_storage_id_storages_id_fk",
+          "tableFrom": "image_hostings",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invite_codes": {
+      "name": "invite_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invite_codes_code_unique": {
+          "name": "invite_codes_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "license_bindings": {
+      "name": "license_bindings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_binding_id": {
+          "name": "cloud_binding_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_store_id": {
+          "name": "cloud_store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_account_id": {
+          "name": "cloud_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_account_email": {
+          "name": "cloud_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cached_certificate": {
+          "name": "cached_certificate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cached_certificate_expires_at": {
+          "name": "cached_certificate_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bound_at": {
+          "name": "bound_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disconnected_at": {
+          "name": "disconnected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refresh_at": {
+          "name": "last_refresh_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refresh_error": {
+          "name": "last_refresh_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "license_bindings_active_uniq": {
+          "name": "license_bindings_active_uniq",
+          "columns": [
+            "status"
+          ],
+          "isUnique": true,
+          "where": "status = 'active'"
+        },
+        "license_bindings_cloud_binding_idx": {
+          "name": "license_bindings_cloud_binding_idx",
+          "columns": [
+            "cloud_binding_id"
+          ],
+          "isUnique": false
+        },
+        "license_bindings_instance_idx": {
+          "name": "license_bindings_instance_idx",
+          "columns": [
+            "instance_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "matters": {
+      "name": "matters",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dirtype": {
+          "name": "dirtype",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "parent": {
+          "name": "parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "trashed_at": {
+          "name": "trashed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "matters_alias_unique": {
+          "name": "matters_alias_unique",
+          "columns": [
+            "alias"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "notifications_user_read_idx": {
+          "name": "notifications_user_read_idx",
+          "columns": [
+            "user_id",
+            "read_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "org_quota_entitlements": {
+      "name": "org_quota_entitlements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "org_quota_entitlements_org_resource_idx": {
+          "name": "org_quota_entitlements_org_resource_idx",
+          "columns": [
+            "org_id",
+            "resource_type",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "org_quota_entitlements_source_resource_uniq": {
+          "name": "org_quota_entitlements_source_resource_uniq",
+          "columns": [
+            "source",
+            "source_id",
+            "resource_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "org_quotas": {
+      "name": "org_quotas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quota": {
+          "name": "quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "traffic_quota": {
+          "name": "traffic_quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "traffic_used": {
+          "name": "traffic_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "traffic_period": {
+          "name": "traffic_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1970-01'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_recipients": {
+      "name": "share_recipients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "share_id": {
+          "name": "share_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "share_recipients_share_id_idx": {
+          "name": "share_recipients_share_id_idx",
+          "columns": [
+            "share_id"
+          ],
+          "isUnique": false
+        },
+        "share_recipients_user_id_idx": {
+          "name": "share_recipients_user_id_idx",
+          "columns": [
+            "recipient_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shares": {
+      "name": "shares",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matter_id": {
+          "name": "matter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_limit": {
+          "name": "download_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "downloads": {
+          "name": "downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "shares_token_unique": {
+          "name": "shares_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "shares_creator_status_created_idx": {
+          "name": "shares_creator_status_created_idx",
+          "columns": [
+            "creator_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_invitations": {
+      "name": "site_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "site_invitations_token_unique": {
+          "name": "site_invitations_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "site_invitations_email_idx": {
+          "name": "site_invitations_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "site_invitations_created_idx": {
+          "name": "site_invitations_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "site_invitations_expires_idx": {
+          "name": "site_invitations_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "storages": {
+      "name": "storages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'auto'"
+        },
+        "access_key": {
+          "name": "access_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_key": {
+          "name": "secret_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "custom_host": {
+          "name": "custom_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_options": {
+      "name": "system_options",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "public": {
+          "name": "public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_invite_links": {
+      "name": "team_invite_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_invite_links_token_unique": {
+          "name": "team_invite_links_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_events": {
+      "name": "webhook_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cloud'"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'order.quota_changed'"
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhook_events_source_event_uniq": {
+          "name": "webhook_events_source_event_uniq",
+          "columns": [
+            "source",
+            "event_id"
+          ],
+          "isUnique": true
+        },
+        "webhook_events_source_created_idx": {
+          "name": "webhook_events_source_created_idx",
+          "columns": [
+            "source",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "webhook_events_status_idx": {
+          "name": "webhook_events_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_config_id_idx": {
+          "name": "apikey_config_id_idx",
+          "columns": [
+            "config_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_reference_id_idx": {
+          "name": "apikey_reference_id_idx",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1778282818664,
       "tag": "0030_add-cloud-traffic-reports",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "6",
+      "when": 1778475474332,
+      "tag": "0031_talented_skullbuster",
+      "breakpoints": true
     }
   ]
 }

--- a/server/app.ts
+++ b/server/app.ts
@@ -10,6 +10,7 @@ import type { Platform } from './platform/interface'
 import { adminAnnouncements, announcements } from './routes/announcements'
 import { adminAudit } from './routes/audit'
 import { adminAuthProviders, publicAuthProviders } from './routes/auth-providers'
+import backgroundJobs from './routes/background-jobs'
 import { brandingAdmin, publicBranding } from './routes/branding'
 import { adminCloudStore, cloudStore, cloudStoreWebhooks } from './routes/cloud-store'
 import emailConfig from './routes/email-config'
@@ -92,6 +93,7 @@ export function createApp(platform: Platform, auth: Auth) {
   app.route('/api/system', system)
   app.route('/api/admin/auth-providers', adminAuthProviders)
   app.route('/api/notifications', notifications)
+  app.route('/api/background-jobs', backgroundJobs)
   app.route('/api/ihost', ihost)
   app.route('/api/ihost/config', ihostConfig)
   app.route('/api/licensing', licensingAdmin)
@@ -130,6 +132,7 @@ export type AdminCloudStoreRoute = typeof adminCloudStore
 export type TeamsRoute = typeof teams
 export type PublicTeamsRoute = typeof publicTeams
 export type NotificationsRoute = typeof notifications
+export type BackgroundJobsRoute = typeof backgroundJobs
 export type IhostRoute = typeof ihost
 export type IhostConfigRoute = typeof ihostConfig
 export type MeRoute = typeof me

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -207,6 +207,39 @@ export const notifications = sqliteTable(
   ],
 )
 
+export const backgroundJobs = sqliteTable(
+  'background_jobs',
+  {
+    id: text('id').primaryKey(),
+    orgId: text('org_id').notNull(),
+    userId: text('user_id').notNull(),
+    type: text('type').notNull(),
+    status: text('status').notNull(),
+    targetFolder: text('target_folder'),
+    targetPath: text('target_path'),
+    metadata: text('metadata'),
+    inputBytes: integer('input_bytes').notNull().default(0),
+    outputBytes: integer('output_bytes').notNull().default(0),
+    processedBytes: integer('processed_bytes').notNull().default(0),
+    fileCount: integer('file_count').notNull().default(0),
+    currentFilename: text('current_filename'),
+    errorMessage: text('error_message'),
+    resultMetadata: text('result_metadata'),
+    retryable: integer('retryable', { mode: 'boolean' }).notNull().default(false),
+    cancelable: integer('cancelable', { mode: 'boolean' }).notNull().default(true),
+    retriedFromJobId: text('retried_from_job_id'),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+    updatedAt: integer('updated_at', { mode: 'timestamp_ms' }).notNull(),
+    startedAt: integer('started_at', { mode: 'timestamp_ms' }),
+    finishedAt: integer('finished_at', { mode: 'timestamp_ms' }),
+  },
+  (t) => [
+    index('background_jobs_org_created_idx').on(t.orgId, t.createdAt),
+    index('background_jobs_org_status_idx').on(t.orgId, t.status),
+    index('background_jobs_org_type_idx').on(t.orgId, t.type),
+  ],
+)
+
 export const announcements = sqliteTable(
   'announcements',
   {

--- a/server/routes/background-jobs.integration.test.ts
+++ b/server/routes/background-jobs.integration.test.ts
@@ -1,0 +1,126 @@
+import { sql } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+import {
+  cancelBackgroundJob,
+  createBackgroundJob,
+  getBackgroundJob,
+  updateBackgroundJob,
+} from '../services/background-jobs'
+import { authedHeaders, createTestApp } from '../test/setup.js'
+
+type TestDb = Awaited<ReturnType<typeof createTestApp>>['db']
+
+type UserOrg = {
+  userId: string
+  orgId: string
+}
+
+async function getUserOrg(db: TestDb, email: string): Promise<UserOrg> {
+  const rows = await db.all<UserOrg>(sql`
+    SELECT u.id AS userId, m.organization_id AS orgId
+    FROM user u
+    INNER JOIN member m ON m.user_id = u.id
+    WHERE u.email = ${email}
+    LIMIT 1
+  `)
+  if (!rows[0]) throw new Error(`No user org found for ${email}`)
+  return rows[0]
+}
+
+describe('background jobs API', () => {
+  it('lists current org jobs with status/type filters and pagination', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await authedHeaders(app, 'jobs-list@example.com')
+    const { orgId, userId } = await getUserOrg(db, 'jobs-list@example.com')
+    await createBackgroundJob(db, { orgId, userId, type: 'archive_compress' })
+    const running = await createBackgroundJob(db, { orgId, userId, type: 'archive_extract' })
+    await updateBackgroundJob(db, orgId, running.id, { status: 'running' })
+
+    const res = await app.request('/api/background-jobs?status=running&type=archive_extract&page=1&pageSize=1', {
+      headers,
+    })
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toMatchObject({
+      total: 1,
+      page: 1,
+      pageSize: 1,
+      items: [{ id: running.id, orgId, type: 'archive_extract', status: 'running' }],
+    })
+  })
+
+  it('rejects detail access across organizations', async () => {
+    const { app, db } = await createTestApp()
+    await authedHeaders(app, 'jobs-owner@example.com')
+    const viewerHeaders = await authedHeaders(app, 'jobs-viewer@example.com')
+    const owner = await getUserOrg(db, 'jobs-owner@example.com')
+    const job = await createBackgroundJob(db, { orgId: owner.orgId, userId: owner.userId, type: 'archive_compress' })
+
+    const res = await app.request(`/api/background-jobs/${job.id}`, { headers: viewerHeaders })
+
+    expect(res.status).toBe(404)
+    await expect(res.json()).resolves.toEqual({ error: 'Not found' })
+  })
+
+  it('cancels only queued or running jobs', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await authedHeaders(app, 'jobs-cancel@example.com')
+    const { orgId, userId } = await getUserOrg(db, 'jobs-cancel@example.com')
+    const queued = await createBackgroundJob(db, { orgId, userId, type: 'archive_compress' })
+    const completed = await createBackgroundJob(db, { orgId, userId, type: 'archive_extract' })
+    await updateBackgroundJob(db, orgId, completed.id, { status: 'completed' })
+
+    const canceledRes = await app.request(`/api/background-jobs/${queued.id}/cancel`, { method: 'POST', headers })
+    const rejectedRes = await app.request(`/api/background-jobs/${completed.id}/cancel`, { method: 'POST', headers })
+
+    expect(canceledRes.status).toBe(200)
+    await expect(canceledRes.json()).resolves.toMatchObject({ id: queued.id, status: 'canceled' })
+    expect(rejectedRes.status).toBe(409)
+    await expect(rejectedRes.json()).resolves.toEqual({ error: 'Background job cannot be canceled' })
+  })
+
+  it('retries only failed retryable jobs without hiding the failed job', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await authedHeaders(app, 'jobs-retry@example.com')
+    const { orgId, userId } = await getUserOrg(db, 'jobs-retry@example.com')
+    const retryable = await createBackgroundJob(db, {
+      orgId,
+      userId,
+      type: 'archive_extract',
+      targetPath: '/imports/archive.zip',
+      retryable: true,
+    })
+    const notFailed = await createBackgroundJob(db, { orgId, userId, type: 'archive_compress', retryable: true })
+    await updateBackgroundJob(db, orgId, retryable.id, {
+      status: 'failed',
+      errorMessage: 'zip_crc_error',
+      progress: { inputBytes: 128, fileCount: 4 },
+    })
+
+    const retryRes = await app.request(`/api/background-jobs/${retryable.id}/retry`, { method: 'POST', headers })
+    const rejectedRes = await app.request(`/api/background-jobs/${notFailed.id}/retry`, { method: 'POST', headers })
+
+    expect(retryRes.status).toBe(201)
+    const retried = (await retryRes.json()) as { id: string; retriedFromJobId: string; status: string }
+    expect(retried).toMatchObject({ retriedFromJobId: retryable.id, status: 'queued' })
+    expect(retried.id).not.toBe(retryable.id)
+    expect(rejectedRes.status).toBe(409)
+    await expect(rejectedRes.json()).resolves.toEqual({ error: 'Background job cannot be retried' })
+
+    const original = await getBackgroundJob(db, orgId, retryable.id)
+    expect(original).toMatchObject({ status: 'failed', errorMessage: 'zip_crc_error', retriedFromJobId: null })
+    await expect(cancelBackgroundJob(db, orgId, retryable.id)).rejects.toMatchObject({ code: 'not_cancelable' })
+  })
+
+  it('lets non-domain service errors surface at the route boundary', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await authedHeaders(app, 'jobs-invalid-json@example.com')
+    const { orgId, userId } = await getUserOrg(db, 'jobs-invalid-json@example.com')
+    const job = await createBackgroundJob(db, { orgId, userId, type: 'archive_compress' })
+    await db.run(sql`UPDATE background_jobs SET metadata = '{invalid-json' WHERE id = ${job.id}`)
+
+    const res = await app.request(`/api/background-jobs/${job.id}`, { headers })
+
+    expect(res.status).toBe(500)
+  })
+})

--- a/server/routes/background-jobs.ts
+++ b/server/routes/background-jobs.ts
@@ -1,0 +1,80 @@
+import { zValidator } from '@hono/zod-validator'
+import type { BackgroundJob } from '@shared/types'
+import type { Context } from 'hono'
+import { Hono } from 'hono'
+import { listBackgroundJobsQuerySchema } from '../../shared/schemas'
+import { requireAuth } from '../middleware/auth'
+import type { Env } from '../middleware/platform'
+import {
+  BackgroundJobError,
+  cancelBackgroundJob,
+  getBackgroundJob,
+  listBackgroundJobs,
+  retryBackgroundJob,
+} from '../services/background-jobs'
+
+const backgroundJobs = new Hono<Env>()
+  .use(requireAuth)
+  .get('/', zValidator('query', listBackgroundJobsQuerySchema), async (c) => {
+    const db = c.get('platform').db
+    const orgId = c.get('orgId')
+    if (!orgId) return c.json({ error: 'No organization found' }, 404)
+
+    const query = c.req.valid('query')
+    const result = await listBackgroundJobs(db, orgId, query)
+    return c.json({ ...result, page: query.page, pageSize: query.pageSize })
+  })
+  .get('/:id', async (c) =>
+    backgroundJobResponse(c, async () => {
+      const orgId = requireOrg(c)
+      return getBackgroundJob(c.get('platform').db, orgId, c.req.param('id'))
+    }),
+  )
+  .post('/:id/cancel', async (c) =>
+    backgroundJobResponse(c, async () => {
+      const orgId = requireOrg(c)
+      return cancelBackgroundJob(c.get('platform').db, orgId, c.req.param('id'))
+    }),
+  )
+  .post('/:id/retry', async (c) =>
+    backgroundJobResponse(
+      c,
+      async () => {
+        const orgId = requireOrg(c)
+        return retryBackgroundJob(c.get('platform').db, orgId, c.req.param('id'))
+      },
+      201,
+    ),
+  )
+
+export default backgroundJobs
+
+function requireOrg(c: Context<Env>): string {
+  const orgId = c.get('orgId')
+  if (!orgId) throw new BackgroundJobError('not_found')
+  return orgId
+}
+
+async function backgroundJobResponse(
+  c: Context<Env>,
+  action: () => Promise<BackgroundJob>,
+  status: 200 | 201 = 200,
+): Promise<Response> {
+  try {
+    const job = await action()
+    return c.json(job, status)
+  } catch (error) {
+    if (error instanceof BackgroundJobError) return c.json(errorBody(error), errorStatus(error))
+    throw error
+  }
+}
+
+function errorStatus(error: BackgroundJobError): 404 | 409 {
+  return error.code === 'not_found' ? 404 : 409
+}
+
+function errorBody(error: BackgroundJobError): { error: string } {
+  if (error.code === 'not_cancelable') return { error: 'Background job cannot be canceled' }
+  if (error.code === 'not_retryable') return { error: 'Background job cannot be retried' }
+  return { error: 'Not found' }
+}

--- a/server/routes/cloud-store-helpers.test.ts
+++ b/server/routes/cloud-store-helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  cloudGiftCardCreateResponseSchema,
   cloudGiftCardsResponseSchema,
   cloudOrdersResponseSchema,
   cloudPackageResponseSchema,
@@ -162,6 +163,28 @@ describe('quota store helper schemas', () => {
       limit: 50,
       offset: 0,
     })
+  })
+
+  it('normalizes Cloud gift card create responses to generated cards', () => {
+    const card = {
+      id: 'gift-created',
+      storeId: 'store-1',
+      campaignId: null,
+      code: 'ZS-CREATED-1',
+      codeLast4: 'TED1',
+      amount: 500,
+      currency: 'usd',
+      status: 'active',
+      expiresAt: null,
+      createdAt: '2026-05-07T00:00:00.000Z',
+      updatedAt: '2026-05-07T00:00:00.000Z',
+      disabledAt: null,
+      revokedAt: null,
+      createdByAdmin: 'admin',
+    }
+
+    expect(cloudGiftCardCreateResponseSchema.parse([card])).toEqual([card])
+    expect(cloudGiftCardCreateResponseSchema.parse({ items: [card], total: 1, limit: 50, offset: 0 })).toEqual([card])
   })
 
   it('parses Cloud package responses', () => {

--- a/server/routes/cloud-store-helpers.ts
+++ b/server/routes/cloud-store-helpers.ts
@@ -37,6 +37,9 @@ export const cloudStoreOrdersQuerySchema = cloudOrdersQuerySchema
 export const cloudGiftCardSchema = storeGiftCardSchema
 export const cloudGiftCardsResponseSchema = giftCardListResponseSchema
 export const cloudGiftCardListSchema = z.array(storeGiftCardSchema)
+export const cloudGiftCardCreateResponseSchema = z
+  .union([cloudGiftCardListSchema, cloudGiftCardsResponseSchema])
+  .transform((response) => (Array.isArray(response) ? response : response.items))
 export const giftCardListQuerySchema = z.object({ status: giftCardStatusSchema.optional() })
 
 export async function getUserStoreSettings(db: Parameters<typeof getRequiredSettings>[0]) {

--- a/server/routes/cloud-store.integration.test.ts
+++ b/server/routes/cloud-store.integration.test.ts
@@ -1361,7 +1361,7 @@ describe('Quota Store API', () => {
     await expect(res.json()).resolves.toMatchObject({ total: 9, items: [{ code: 'ZS-PAGED-1' }] })
   })
 
-  it('returns admin gift card create responses from Cloud', async () => {
+  it('accepts paged admin gift card create responses from Cloud', async () => {
     const { app, db } = await createTestApp()
     await seedProLicense(db)
     const headers = await adminHeaders(app)
@@ -1369,7 +1369,12 @@ describe('Quota Store API', () => {
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: true,
       status: 201,
-      json: async () => [cloudGiftCard({ code: 'ZS-CREATED-1', codeLast4: 'TED1' })],
+      json: async () => ({
+        items: [cloudGiftCard({ code: 'ZS-PAGED-CREATE-1', codeLast4: 'TE-1' })],
+        total: 1,
+        limit: 50,
+        offset: 0,
+      }),
     } as Response)
 
     const res = await app.request('/api/admin/store/gift-cards', {
@@ -1383,7 +1388,7 @@ describe('Quota Store API', () => {
     })
 
     expect(res.status).toBe(201)
-    await expect(res.json()).resolves.toMatchObject([{ code: 'ZS-CREATED-1' }])
+    await expect(res.json()).resolves.toMatchObject([{ code: 'ZS-PAGED-CREATE-1' }])
   })
 
   it('disables admin gift cards through Cloud', async () => {

--- a/server/routes/cloud-store/admin.ts
+++ b/server/routes/cloud-store/admin.ts
@@ -12,7 +12,7 @@ import type { Env } from '../../middleware/platform'
 import { requireFeature } from '../../middleware/require-feature'
 import { getCloudStoreSettings, upsertCloudStoreSettings } from '../../services/cloud-store'
 import {
-  cloudGiftCardListSchema,
+  cloudGiftCardCreateResponseSchema,
   cloudGiftCardsResponseSchema,
   cloudOrdersQuerySchema,
   cloudPackageListResponseSchema,
@@ -128,7 +128,7 @@ export const adminCloudStore = new Hono<Env>()
     const result = await cloudRequest(c, async ({ client, storeId }) =>
       unwrapCloudResponse(
         await client.stores[':storeId']['gift-cards'].$post({ param: { storeId }, json: c.req.valid('json') }),
-        cloudGiftCardListSchema,
+        cloudGiftCardCreateResponseSchema,
       ),
     )
     if (isCloudError(result)) return c.json(result, 502)

--- a/server/services/background-jobs.test.ts
+++ b/server/services/background-jobs.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import { createTestApp } from '../test/setup.js'
+import {
+  cancelBackgroundJob,
+  createBackgroundJob,
+  getBackgroundJob,
+  listBackgroundJobs,
+  retryBackgroundJob,
+  updateBackgroundJob,
+} from './background-jobs'
+
+describe('background job service', () => {
+  it('creates, lists, and reads jobs with generic metadata and progress', async () => {
+    const { db } = await createTestApp()
+    const job = await createBackgroundJob(db, {
+      orgId: 'org-service',
+      userId: 'user-service',
+      type: 'remote_download',
+      targetFolder: 'folder-1',
+      targetPath: '/downloads/file.zip',
+      metadata: { sourceUrl: 'https://example.com/file.zip' },
+      progress: { inputBytes: 1024, currentFilename: 'file.zip' },
+    })
+
+    const listed = await listBackgroundJobs(db, 'org-service', { type: 'remote_download', page: 1, pageSize: 10 })
+    const loaded = await getBackgroundJob(db, 'org-service', job.id)
+
+    expect(listed).toMatchObject({ total: 1, items: [{ id: job.id }] })
+    expect(loaded).toMatchObject({
+      id: job.id,
+      type: 'remote_download',
+      targetFolder: 'folder-1',
+      targetPath: '/downloads/file.zip',
+      metadata: { sourceUrl: 'https://example.com/file.zip' },
+      progress: { inputBytes: 1024, currentFilename: 'file.zip' },
+    })
+  })
+
+  it('updates nullable fields and terminal timestamps explicitly', async () => {
+    const { db } = await createTestApp()
+    const job = await createBackgroundJob(db, {
+      orgId: 'org-update',
+      userId: 'user-update',
+      type: 'archive_compress',
+      progress: { currentFilename: 'old.txt' },
+    })
+    await updateBackgroundJob(db, 'org-update', job.id, {
+      status: 'failed',
+      errorMessage: 'first_failure',
+      progress: { currentFilename: null },
+      resultMetadata: { attempted: true },
+    })
+
+    const updated = await updateBackgroundJob(db, 'org-update', job.id, {
+      errorMessage: null,
+      resultMetadata: null,
+    })
+
+    expect(updated.status).toBe('failed')
+    expect(updated.finishedAt).not.toBeNull()
+    expect(updated.errorMessage).toBeNull()
+    expect(updated.resultMetadata).toBeNull()
+    expect(updated.progress.currentFilename).toBeNull()
+  })
+
+  it('cancels active cancelable jobs and rejects unsupported cancellation', async () => {
+    const { db } = await createTestApp()
+    const cancelable = await createBackgroundJob(db, {
+      orgId: 'org-cancel',
+      userId: 'user-cancel',
+      type: 'archive_extract',
+    })
+    const blocked = await createBackgroundJob(db, {
+      orgId: 'org-cancel',
+      userId: 'user-cancel',
+      type: 'archive_extract',
+      cancelable: false,
+    })
+
+    await expect(cancelBackgroundJob(db, 'org-cancel', cancelable.id)).resolves.toMatchObject({ status: 'canceled' })
+    await expect(cancelBackgroundJob(db, 'org-cancel', blocked.id)).rejects.toMatchObject({ code: 'not_cancelable' })
+  })
+
+  it('creates retries only for failed retryable jobs', async () => {
+    const { db } = await createTestApp()
+    const retryable = await createBackgroundJob(db, {
+      orgId: 'org-retry',
+      userId: 'user-retry',
+      type: 'archive_extract',
+      retryable: true,
+    })
+    const notRetryable = await createBackgroundJob(db, {
+      orgId: 'org-retry',
+      userId: 'user-retry',
+      type: 'archive_extract',
+    })
+    await updateBackgroundJob(db, 'org-retry', retryable.id, { status: 'failed', errorMessage: 'bad_zip' })
+    await updateBackgroundJob(db, 'org-retry', notRetryable.id, { status: 'failed', errorMessage: 'bad_zip' })
+
+    const retry = await retryBackgroundJob(db, 'org-retry', retryable.id)
+
+    expect(retry).toMatchObject({ status: 'queued', retriedFromJobId: retryable.id, errorMessage: null })
+    await expect(retryBackgroundJob(db, 'org-retry', notRetryable.id)).rejects.toMatchObject({
+      code: 'not_retryable',
+    })
+  })
+})

--- a/server/services/background-jobs.ts
+++ b/server/services/background-jobs.ts
@@ -1,0 +1,258 @@
+import type { BackgroundJob, BackgroundJobProgress, BackgroundJobStatus, BackgroundJobType } from '@shared/types'
+import { and, count, desc, eq, type SQL } from 'drizzle-orm'
+import { nanoid } from 'nanoid'
+import { backgroundJobs } from '../db/schema'
+import type { Database } from '../platform/interface'
+
+export type BackgroundJobMetadata = Record<string, unknown>
+
+export type CreateBackgroundJobInput = {
+  orgId: string
+  userId: string
+  type: BackgroundJobType
+  targetFolder?: string | null
+  targetPath?: string | null
+  metadata?: BackgroundJobMetadata | null
+  progress?: Partial<BackgroundJobProgress>
+  retryable?: boolean
+  cancelable?: boolean
+}
+
+export type ListBackgroundJobsOptions = {
+  status?: BackgroundJobStatus
+  type?: string
+  page: number
+  pageSize: number
+}
+
+export type UpdateBackgroundJobInput = {
+  status?: BackgroundJobStatus
+  progress?: Partial<BackgroundJobProgress>
+  errorMessage?: string | null
+  resultMetadata?: BackgroundJobMetadata | null
+  retryable?: boolean
+  cancelable?: boolean
+  startedAt?: Date | null
+  finishedAt?: Date | null
+}
+
+export class BackgroundJobError extends Error {
+  constructor(
+    readonly code: 'not_found' | 'not_cancelable' | 'not_retryable',
+    message = code,
+  ) {
+    super(message)
+    this.name = 'BackgroundJobError'
+  }
+}
+
+type BackgroundJobRow = typeof backgroundJobs.$inferSelect
+
+const ACTIVE_STATUSES: BackgroundJobStatus[] = ['queued', 'running']
+
+export async function createBackgroundJob(db: Database, input: CreateBackgroundJobInput): Promise<BackgroundJob> {
+  const now = new Date()
+  const row: typeof backgroundJobs.$inferInsert = {
+    id: nanoid(),
+    orgId: input.orgId,
+    userId: input.userId,
+    type: input.type,
+    status: 'queued',
+    targetFolder: input.targetFolder ?? null,
+    targetPath: input.targetPath ?? null,
+    metadata: stringifyMetadata(input.metadata),
+    inputBytes: input.progress?.inputBytes ?? 0,
+    outputBytes: input.progress?.outputBytes ?? 0,
+    processedBytes: input.progress?.processedBytes ?? 0,
+    fileCount: input.progress?.fileCount ?? 0,
+    currentFilename: input.progress?.currentFilename ?? null,
+    errorMessage: null,
+    resultMetadata: null,
+    retryable: input.retryable ?? false,
+    cancelable: input.cancelable ?? true,
+    retriedFromJobId: null,
+    createdAt: now,
+    updatedAt: now,
+    startedAt: null,
+    finishedAt: null,
+  }
+
+  await db.insert(backgroundJobs).values(row)
+  return toBackgroundJob(row as BackgroundJobRow)
+}
+
+export async function listBackgroundJobs(
+  db: Database,
+  orgId: string,
+  opts: ListBackgroundJobsOptions,
+): Promise<{ items: BackgroundJob[]; total: number }> {
+  const offset = (opts.page - 1) * opts.pageSize
+  const where = backgroundJobWhere(orgId, opts)
+
+  const [rows, totalRows] = await Promise.all([
+    db
+      .select()
+      .from(backgroundJobs)
+      .where(where)
+      .orderBy(desc(backgroundJobs.createdAt))
+      .limit(opts.pageSize)
+      .offset(offset),
+    db.select({ count: count() }).from(backgroundJobs).where(where),
+  ])
+
+  return {
+    items: rows.map(toBackgroundJob),
+    total: totalRows[0]?.count ?? 0,
+  }
+}
+
+export async function getBackgroundJob(db: Database, orgId: string, id: string): Promise<BackgroundJob> {
+  const row = await getBackgroundJobRow(db, orgId, id)
+  if (!row) throw new BackgroundJobError('not_found')
+  return toBackgroundJob(row)
+}
+
+export async function updateBackgroundJob(
+  db: Database,
+  orgId: string,
+  id: string,
+  input: UpdateBackgroundJobInput,
+): Promise<BackgroundJob> {
+  const row = await getBackgroundJobRow(db, orgId, id)
+  if (!row) throw new BackgroundJobError('not_found')
+
+  const nextStatus = input.status ?? row.status
+  const now = new Date()
+  const values: Partial<typeof backgroundJobs.$inferInsert> = {
+    status: nextStatus,
+    inputBytes: input.progress?.inputBytes ?? row.inputBytes,
+    outputBytes: input.progress?.outputBytes ?? row.outputBytes,
+    processedBytes: input.progress?.processedBytes ?? row.processedBytes,
+    fileCount: input.progress?.fileCount ?? row.fileCount,
+    currentFilename:
+      input.progress?.currentFilename === undefined ? row.currentFilename : input.progress.currentFilename,
+    errorMessage: input.errorMessage === undefined ? row.errorMessage : input.errorMessage,
+    resultMetadata: input.resultMetadata === undefined ? row.resultMetadata : stringifyMetadata(input.resultMetadata),
+    retryable: input.retryable ?? row.retryable,
+    cancelable: input.cancelable ?? row.cancelable,
+    startedAt: input.startedAt === undefined ? row.startedAt : input.startedAt,
+    finishedAt: input.finishedAt === undefined ? finishedAtFor(nextStatus, row.finishedAt, now) : input.finishedAt,
+    updatedAt: now,
+  }
+
+  await db.update(backgroundJobs).set(values).where(eq(backgroundJobs.id, id))
+  return getBackgroundJob(db, orgId, id)
+}
+
+export async function cancelBackgroundJob(db: Database, orgId: string, id: string): Promise<BackgroundJob> {
+  const row = await getBackgroundJobRow(db, orgId, id)
+  if (!row) throw new BackgroundJobError('not_found')
+  if (!ACTIVE_STATUSES.includes(row.status as BackgroundJobStatus) || !row.cancelable) {
+    throw new BackgroundJobError('not_cancelable')
+  }
+
+  const now = new Date()
+  await db
+    .update(backgroundJobs)
+    .set({ status: 'canceled', updatedAt: now, finishedAt: now })
+    .where(eq(backgroundJobs.id, id))
+
+  return getBackgroundJob(db, orgId, id)
+}
+
+export async function retryBackgroundJob(db: Database, orgId: string, id: string): Promise<BackgroundJob> {
+  const row = await getBackgroundJobRow(db, orgId, id)
+  if (!row) throw new BackgroundJobError('not_found')
+  if (row.status !== 'failed' || !row.retryable) throw new BackgroundJobError('not_retryable')
+
+  const now = new Date()
+  const retry: typeof backgroundJobs.$inferInsert = {
+    id: nanoid(),
+    orgId: row.orgId,
+    userId: row.userId,
+    type: row.type,
+    status: 'queued',
+    targetFolder: row.targetFolder,
+    targetPath: row.targetPath,
+    metadata: row.metadata,
+    inputBytes: row.inputBytes,
+    outputBytes: 0,
+    processedBytes: 0,
+    fileCount: row.fileCount,
+    currentFilename: null,
+    errorMessage: null,
+    resultMetadata: null,
+    retryable: row.retryable,
+    cancelable: row.cancelable,
+    retriedFromJobId: row.id,
+    createdAt: now,
+    updatedAt: now,
+    startedAt: null,
+    finishedAt: null,
+  }
+
+  await db.insert(backgroundJobs).values(retry)
+  return toBackgroundJob(retry as BackgroundJobRow)
+}
+
+function backgroundJobWhere(orgId: string, opts: ListBackgroundJobsOptions): SQL | undefined {
+  const filters = [eq(backgroundJobs.orgId, orgId)]
+  if (opts.status) filters.push(eq(backgroundJobs.status, opts.status))
+  if (opts.type) filters.push(eq(backgroundJobs.type, opts.type))
+  return and(...filters)
+}
+
+async function getBackgroundJobRow(db: Database, orgId: string, id: string): Promise<BackgroundJobRow | null> {
+  const rows = await db
+    .select()
+    .from(backgroundJobs)
+    .where(and(eq(backgroundJobs.id, id), eq(backgroundJobs.orgId, orgId)))
+    .limit(1)
+  return rows[0] ?? null
+}
+
+function finishedAtFor(status: string, current: Date | null, now: Date): Date | null {
+  if (current) return current
+  return ['completed', 'failed', 'canceled'].includes(status) ? now : null
+}
+
+function stringifyMetadata(value: BackgroundJobMetadata | null | undefined): string | null {
+  return value == null ? null : JSON.stringify(value)
+}
+
+function parseMetadata(value: string | null): BackgroundJobMetadata | null {
+  return value == null ? null : (JSON.parse(value) as BackgroundJobMetadata)
+}
+
+function toIso(value: Date | null): string | null {
+  return value?.toISOString() ?? null
+}
+
+function toBackgroundJob(row: BackgroundJobRow): BackgroundJob {
+  return {
+    id: row.id,
+    orgId: row.orgId,
+    userId: row.userId,
+    type: row.type,
+    status: row.status as BackgroundJobStatus,
+    targetFolder: row.targetFolder,
+    targetPath: row.targetPath,
+    metadata: parseMetadata(row.metadata),
+    progress: {
+      inputBytes: row.inputBytes,
+      outputBytes: row.outputBytes,
+      processedBytes: row.processedBytes,
+      fileCount: row.fileCount,
+      currentFilename: row.currentFilename,
+    },
+    errorMessage: row.errorMessage,
+    resultMetadata: parseMetadata(row.resultMetadata),
+    retryable: row.retryable,
+    cancelable: row.cancelable,
+    retriedFromJobId: row.retriedFromJobId,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+    startedAt: toIso(row.startedAt),
+    finishedAt: toIso(row.finishedAt),
+  }
+}

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -305,6 +305,33 @@ const APP_SCHEMA_SQL = `
   );
   CREATE INDEX IF NOT EXISTS notifications_user_created_idx ON notifications(user_id, created_at);
   CREATE INDEX IF NOT EXISTS notifications_user_read_idx ON notifications(user_id, read_at);
+  CREATE TABLE IF NOT EXISTS background_jobs (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    type TEXT NOT NULL,
+    status TEXT NOT NULL,
+    target_folder TEXT,
+    target_path TEXT,
+    metadata TEXT,
+    input_bytes INTEGER NOT NULL DEFAULT 0,
+    output_bytes INTEGER NOT NULL DEFAULT 0,
+    processed_bytes INTEGER NOT NULL DEFAULT 0,
+    file_count INTEGER NOT NULL DEFAULT 0,
+    current_filename TEXT,
+    error_message TEXT,
+    result_metadata TEXT,
+    retryable INTEGER NOT NULL DEFAULT 0,
+    cancelable INTEGER NOT NULL DEFAULT 1,
+    retried_from_job_id TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    started_at INTEGER,
+    finished_at INTEGER
+  );
+  CREATE INDEX IF NOT EXISTS background_jobs_org_created_idx ON background_jobs(org_id, created_at);
+  CREATE INDEX IF NOT EXISTS background_jobs_org_status_idx ON background_jobs(org_id, status);
+  CREATE INDEX IF NOT EXISTS background_jobs_org_type_idx ON background_jobs(org_id, type);
   CREATE TABLE IF NOT EXISTS announcements (
     id TEXT PRIMARY KEY,
     title TEXT NOT NULL,

--- a/shared/schemas/background-jobs.ts
+++ b/shared/schemas/background-jobs.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+
+export const backgroundJobStatusSchema = z.enum(['queued', 'running', 'completed', 'failed', 'canceled'])
+export type BackgroundJobStatusInput = z.infer<typeof backgroundJobStatusSchema>
+
+export const backgroundJobTypeSchema = z.string().min(1).max(80)
+export type BackgroundJobTypeInput = z.infer<typeof backgroundJobTypeSchema>
+
+export const listBackgroundJobsQuerySchema = z.object({
+  status: backgroundJobStatusSchema.optional(),
+  type: backgroundJobTypeSchema.optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(20),
+})
+
+export type ListBackgroundJobsQuery = z.infer<typeof listBackgroundJobsQuerySchema>

--- a/shared/schemas/index.ts
+++ b/shared/schemas/index.ts
@@ -14,6 +14,8 @@ export {
 } from './announcement'
 export type { ListAdminAuditQuery } from './audit'
 export { listAdminAuditQuerySchema } from './audit'
+export type { BackgroundJobStatusInput, BackgroundJobTypeInput, ListBackgroundJobsQuery } from './background-jobs'
+export { backgroundJobStatusSchema, backgroundJobTypeSchema, listBackgroundJobsQuerySchema } from './background-jobs'
 export type {
   CheckoutInput,
   CloudOrder,

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -169,6 +169,39 @@ export interface PaginatedResponse<T> {
   pageSize: number
 }
 
+export type BackgroundJobStatus = 'queued' | 'running' | 'completed' | 'failed' | 'canceled'
+export type KnownBackgroundJobType = 'archive_compress' | 'archive_extract'
+export type BackgroundJobType = KnownBackgroundJobType | (string & {})
+
+export interface BackgroundJobProgress {
+  inputBytes: number
+  outputBytes: number
+  processedBytes: number
+  fileCount: number
+  currentFilename: string | null
+}
+
+export interface BackgroundJob {
+  id: string
+  orgId: string
+  userId: string
+  type: BackgroundJobType
+  status: BackgroundJobStatus
+  targetFolder: string | null
+  targetPath: string | null
+  metadata: Record<string, unknown> | null
+  progress: BackgroundJobProgress
+  errorMessage: string | null
+  resultMetadata: Record<string, unknown> | null
+  retryable: boolean
+  cancelable: boolean
+  retriedFromJobId: string | null
+  createdAt: string
+  updatedAt: string
+  startedAt: string | null
+  finishedAt: string | null
+}
+
 import type { ShareKind as _ShareKind } from '../schemas/share'
 
 export type { ShareKind } from '../schemas/share'


### PR DESCRIPTION
## Summary
- Add generic `background_jobs` schema, generated Drizzle migration, shared types, and query schemas.
- Add background job service primitives for create/list/get/update/cancel/retry with org scoping and retry rows linked to prior failures.
- Mount authenticated `/api/background-jobs` APIs and cover listing, cross-org detail access, cancel, and retry behavior.

## Verification
- `npm run db:generate`
- `npm run test -- server/routes/background-jobs.integration.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run test` (127 files, 3527 tests)