### PR TITLE
feat: add local archive background jobs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",
+        "fflate": "^0.8.2",
         "hono": "^4.12.18",
         "i18next": "^26.0.3",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -12162,6 +12163,12 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-selector": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",
+    "fflate": "^0.8.2",
     "hono": "^4.12.18",
     "i18next": "^26.0.3",
     "i18next-browser-languagedetector": "^8.2.1",

--- a/server/routes/background-jobs.integration.test.ts
+++ b/server/routes/background-jobs.integration.test.ts
@@ -1,11 +1,12 @@
 import { sql } from 'drizzle-orm'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   cancelBackgroundJob,
   createBackgroundJob,
   getBackgroundJob,
   updateBackgroundJob,
 } from '../services/background-jobs'
+import { S3Service } from '../services/s3'
 import { authedHeaders, createTestApp } from '../test/setup.js'
 
 type TestDb = Awaited<ReturnType<typeof createTestApp>>['db']
@@ -28,6 +29,105 @@ async function getUserOrg(db: TestDb, email: string): Promise<UserOrg> {
 }
 
 describe('background jobs API', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('creates archive jobs through POST and returns the final job state', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await authedHeaders(app, 'jobs-create@example.com')
+    const { orgId } = await getUserOrg(db, 'jobs-create@example.com')
+    await seedStorage(db)
+    const now = Date.now()
+    await db.run(sql`
+      INSERT INTO matters (id, org_id, alias, name, type, size, dirtype, parent, object, storage_id, status, created_at, updated_at)
+      VALUES ('route-zip', ${orgId}, 'route-zip-alias', 'route.zip', 'application/zip', 200, 0, '', 'route/source.zip', 'route-storage', 'active', ${now}, ${now})
+    `)
+
+    const objectStore = new Map<string, Uint8Array>([['route/source.zip', createZip({ 'route.txt': bytes('ok') })]])
+    const putKeys: string[] = []
+    vi.spyOn(S3Service.prototype, 'getObjectBytes').mockImplementation(async (_storage, key) => {
+      const bytes = objectStore.get(key)
+      if (!bytes) throw new Error(`missing ${key}`)
+      return bytes
+    })
+    vi.spyOn(S3Service.prototype, 'putObject').mockImplementation(async (_storage, key, body) => {
+      objectStore.set(key, body instanceof Uint8Array ? body : new Uint8Array(await new Response(body).arrayBuffer()))
+      putKeys.push(key)
+    })
+
+    const res = await app.request('/api/background-jobs', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'archive_extract', matterId: 'route-zip' }),
+    })
+
+    expect(res.status).toBe(201)
+    await expect(res.json()).resolves.toMatchObject({
+      orgId,
+      type: 'archive_extract',
+      status: 'completed',
+      progress: { outputBytes: 2, fileCount: 1 },
+    })
+    expect(putKeys).toHaveLength(1)
+  })
+
+  it('returns a failed archive job for a missing explicit target folder', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await authedHeaders(app, 'jobs-missing-target@example.com')
+    const { orgId } = await getUserOrg(db, 'jobs-missing-target@example.com')
+    await seedStorage(db)
+    const now = Date.now()
+    await db.run(sql`
+      INSERT INTO matters (id, org_id, alias, name, type, size, dirtype, parent, object, storage_id, status, created_at, updated_at)
+      VALUES ('route-file', ${orgId}, 'route-file-alias', 'file.txt', 'text/plain', 5, 0, '', 'route/file.txt', 'route-storage', 'active', ${now}, ${now})
+    `)
+
+    const res = await app.request('/api/background-jobs', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'archive_compress', matterIds: ['route-file'], targetFolder: 'missing' }),
+    })
+
+    expect(res.status).toBe(201)
+    await expect(res.json()).resolves.toMatchObject({
+      orgId,
+      type: 'archive_compress',
+      status: 'failed',
+      errorMessage: 'Target folder not found',
+    })
+  })
+
+  it('returns a failed archive job when explicit target folder points to a file', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await authedHeaders(app, 'jobs-file-target@example.com')
+    const { orgId } = await getUserOrg(db, 'jobs-file-target@example.com')
+    await seedStorage(db)
+    const now = Date.now()
+    await db.run(sql`
+      INSERT INTO matters (id, org_id, alias, name, type, size, dirtype, parent, object, storage_id, status, created_at, updated_at)
+      VALUES ('route-zip-target', ${orgId}, 'route-zip-target-alias', 'route.zip', 'application/zip', 200, 0, '', 'route/source.zip', 'route-storage', 'active', ${now}, ${now})
+    `)
+    await db.run(sql`
+      INSERT INTO matters (id, org_id, alias, name, type, size, dirtype, parent, object, storage_id, status, created_at, updated_at)
+      VALUES ('route-file-target', ${orgId}, 'route-file-target-alias', 'target.txt', 'text/plain', 1, 0, '', 'route/target.txt', 'route-storage', 'active', ${now}, ${now})
+    `)
+
+    const res = await app.request('/api/background-jobs', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'archive_extract', matterId: 'route-zip-target', targetFolder: 'target.txt' }),
+    })
+
+    expect(res.status).toBe(201)
+    await expect(res.json()).resolves.toMatchObject({
+      orgId,
+      type: 'archive_extract',
+      status: 'failed',
+      errorMessage: 'Target folder must be a folder',
+    })
+  })
+
   it('lists current org jobs with status/type filters and pagination', async () => {
     const { app, db } = await createTestApp()
     const headers = await authedHeaders(app, 'jobs-list@example.com')
@@ -124,3 +224,89 @@ describe('background jobs API', () => {
     expect(res.status).toBe(500)
   })
 })
+
+async function seedStorage(db: TestDb): Promise<void> {
+  const now = Date.now()
+  await db.run(sql`
+    INSERT INTO storages (id, title, mode, bucket, endpoint, region, access_key, secret_key, file_path, custom_host, capacity, used, status, created_at, updated_at)
+    VALUES ('route-storage', 'Route Storage', 'private', 'bucket', 'https://s3.example.com', 'auto', 'ak', 'sk', '', '', 0, 0, 'active', ${now}, ${now})
+  `)
+}
+
+function createZip(files: Record<string, Uint8Array>): Uint8Array {
+  const encoder = new TextEncoder()
+  const localParts: Uint8Array[] = []
+  const centralParts: Uint8Array[] = []
+  let offset = 0
+
+  for (const [name, data] of Object.entries(files)) {
+    const filename = encoder.encode(name)
+    const crc = crc32(data)
+    const local = new Uint8Array(30 + filename.length + data.length)
+    write32(local, 0, 0x04034b50)
+    write16(local, 6, 0x0800)
+    write32(local, 14, crc)
+    write32(local, 18, data.length)
+    write32(local, 22, data.length)
+    write16(local, 26, filename.length)
+    local.set(filename, 30)
+    local.set(data, 30 + filename.length)
+    localParts.push(local)
+
+    const central = new Uint8Array(46 + filename.length)
+    write32(central, 0, 0x02014b50)
+    write16(central, 8, 0x0800)
+    write32(central, 16, crc)
+    write32(central, 20, data.length)
+    write32(central, 24, data.length)
+    write16(central, 28, filename.length)
+    write32(central, 42, offset)
+    central.set(filename, 46)
+    centralParts.push(central)
+    offset += local.length
+  }
+
+  const centralSize = centralParts.reduce((sum, part) => sum + part.length, 0)
+  const eocd = new Uint8Array(22)
+  write32(eocd, 0, 0x06054b50)
+  write16(eocd, 8, centralParts.length)
+  write16(eocd, 10, centralParts.length)
+  write32(eocd, 12, centralSize)
+  write32(eocd, 16, offset)
+  return concat([...localParts, ...centralParts, eocd])
+}
+
+function bytes(value: string): Uint8Array {
+  return new TextEncoder().encode(value)
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const out = new Uint8Array(parts.reduce((sum, part) => sum + part.length, 0))
+  let offset = 0
+  for (const part of parts) {
+    out.set(part, offset)
+    offset += part.length
+  }
+  return out
+}
+
+function write16(bytes: Uint8Array, offset: number, value: number): void {
+  bytes[offset] = value & 0xff
+  bytes[offset + 1] = (value >>> 8) & 0xff
+}
+
+function write32(bytes: Uint8Array, offset: number, value: number): void {
+  bytes[offset] = value & 0xff
+  bytes[offset + 1] = (value >>> 8) & 0xff
+  bytes[offset + 2] = (value >>> 16) & 0xff
+  bytes[offset + 3] = (value >>> 24) & 0xff
+}
+
+function crc32(data: Uint8Array): number {
+  let crc = 0xffffffff
+  for (const byte of data) {
+    crc ^= byte
+    for (let i = 0; i < 8; i += 1) crc = crc & 1 ? 0xedb88320 ^ (crc >>> 1) : crc >>> 1
+  }
+  return (crc ^ 0xffffffff) >>> 0
+}

--- a/server/routes/background-jobs.ts
+++ b/server/routes/background-jobs.ts
@@ -2,9 +2,10 @@ import { zValidator } from '@hono/zod-validator'
 import type { BackgroundJob } from '@shared/types'
 import type { Context } from 'hono'
 import { Hono } from 'hono'
-import { listBackgroundJobsQuerySchema } from '../../shared/schemas'
+import { createBackgroundJobRequestSchema, listBackgroundJobsQuerySchema } from '../../shared/schemas'
 import { requireAuth } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
+import { createArchiveJob } from '../services/archive-processing'
 import {
   BackgroundJobError,
   cancelBackgroundJob,
@@ -24,6 +25,22 @@ const backgroundJobs = new Hono<Env>()
     const result = await listBackgroundJobs(db, orgId, query)
     return c.json({ ...result, page: query.page, pageSize: query.pageSize })
   })
+  .post('/', zValidator('json', createBackgroundJobRequestSchema), async (c) =>
+    backgroundJobResponse(
+      c,
+      async () => {
+        const orgId = requireOrg(c)
+        const userId = c.get('userId')
+        if (!userId) throw new BackgroundJobError('not_found')
+        return createArchiveJob(c.get('platform').db, {
+          orgId,
+          userId,
+          request: c.req.valid('json'),
+        })
+      },
+      201,
+    ),
+  )
   .get('/:id', async (c) =>
     backgroundJobResponse(c, async () => {
       const orgId = requireOrg(c)

--- a/server/services/archive-processing.test.ts
+++ b/server/services/archive-processing.test.ts
@@ -1,0 +1,657 @@
+import { sql } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+import { createTestApp } from '../test/setup.js'
+import { createArchiveJob } from './archive-processing'
+import type { S3Service } from './s3'
+import { collectCompressionPlan } from './zip-compress'
+import { validateAndExtractZip } from './zip-extract'
+
+type TestDb = Awaited<ReturnType<typeof createTestApp>>['db']
+
+const ORG_ID = 'archive-org'
+const USER_ID = 'archive-user'
+const STORAGE_ID = 'archive-storage'
+
+class MemoryS3 {
+  objects = new Map<string, Uint8Array>()
+  putKeys: string[] = []
+
+  async getObjectBytes(_storage: unknown, key: string): Promise<Uint8Array> {
+    const bytes = this.objects.get(key)
+    if (!bytes) throw new Error(`Object not found: ${key}`)
+    return bytes
+  }
+
+  async putObject(_storage: unknown, key: string, body: Uint8Array | ReadableStream): Promise<void> {
+    const bytes = body instanceof Uint8Array ? body : new Uint8Array(await new Response(body).arrayBuffer())
+    this.objects.set(key, bytes)
+    this.putKeys.push(key)
+  }
+
+  async deleteObject(_storage: unknown, key: string): Promise<void> {
+    this.objects.delete(key)
+  }
+
+  async deleteObjects(_storage: unknown, keys: string[]): Promise<void> {
+    for (const key of keys) this.objects.delete(key)
+  }
+}
+
+class FailingPutS3 extends MemoryS3 {
+  async putObject(): Promise<void> {
+    throw new Error('S3 put failed')
+  }
+}
+
+class FailAfterPutS3 extends MemoryS3 {
+  private attempts = 0
+
+  constructor(private readonly failAt: number) {
+    super()
+  }
+
+  override async putObject(storage: unknown, key: string, body: Uint8Array | ReadableStream): Promise<void> {
+    this.attempts += 1
+    if (this.attempts === this.failAt) throw new Error('S3 put failed')
+    await super.putObject(storage, key, body)
+  }
+}
+
+describe('archive processing', () => {
+  it('extracts a small ZIP into folder and file matters and writes objects', async () => {
+    const { db } = await createTestApp()
+    await seedStorage(db)
+    await seedMatter(db, { id: 'zip-matter', name: 'archive.zip', object: 'source/archive.zip', size: 200 })
+
+    const s3 = new MemoryS3()
+    s3.objects.set('source/archive.zip', createZip({ 'docs/hello.txt': bytes('hello') }))
+
+    const job = await createArchiveJob(db, {
+      orgId: ORG_ID,
+      userId: USER_ID,
+      request: { type: 'archive_extract', matterId: 'zip-matter' },
+      s3: s3 as unknown as S3Service,
+    })
+
+    expect(job).toMatchObject({ status: 'completed', type: 'archive_extract' })
+    expect(job.progress).toMatchObject({ outputBytes: 5, fileCount: 1 })
+    const rows = await db.all<{ name: string; parent: string; dirtype: number; size: number; object: string }>(sql`
+      SELECT name, parent, dirtype, size, object FROM matters
+      WHERE org_id = ${ORG_ID} AND status = 'active'
+      ORDER BY dirtype DESC, name ASC
+    `)
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'docs', parent: '', dirtype: 1, size: 0 }),
+        expect.objectContaining({ name: 'hello.txt', parent: 'docs', dirtype: 0, size: 5 }),
+      ]),
+    )
+    expect(s3.putKeys).toHaveLength(1)
+  })
+
+  it('compresses selected matters into a ZIP matter and object', async () => {
+    const { db } = await createTestApp()
+    await seedStorage(db)
+    await seedMatter(db, { id: 'file-a', name: 'a.txt', object: 'objects/a.txt', size: 5 })
+
+    const s3 = new MemoryS3()
+    s3.objects.set('objects/a.txt', bytes('hello'))
+
+    const job = await createArchiveJob(db, {
+      orgId: ORG_ID,
+      userId: USER_ID,
+      request: { type: 'archive_compress', matterIds: ['file-a'] },
+      s3: s3 as unknown as S3Service,
+    })
+
+    expect(job).toMatchObject({ status: 'completed', type: 'archive_compress' })
+    expect(job.resultMetadata).toMatchObject({ outputName: 'a.txt.zip' })
+    const zipMatter = await db.all<{ name: string; type: string; size: number; object: string }>(sql`
+      SELECT name, type, size, object FROM matters
+      WHERE org_id = ${ORG_ID} AND name = 'a.txt.zip' AND status = 'active'
+    `)
+    expect(zipMatter).toHaveLength(1)
+    expect(zipMatter[0].type).toBe('application/zip')
+    expect(s3.objects.get(zipMatter[0].object)?.length).toBe(zipMatter[0].size)
+  })
+
+  it('compresses an empty selected folder as a ZIP directory entry', async () => {
+    const { db } = await createTestApp()
+    await seedStorage(db)
+    await seedMatter(db, { id: 'empty-folder', name: 'Empty', object: '', size: 0, dirtype: 1 })
+
+    const s3 = new MemoryS3()
+
+    const job = await createArchiveJob(db, {
+      orgId: ORG_ID,
+      userId: USER_ID,
+      request: { type: 'archive_compress', matterIds: ['empty-folder'] },
+      s3: s3 as unknown as S3Service,
+    })
+
+    expect(job).toMatchObject({ status: 'completed', type: 'archive_compress' })
+    const zipMatter = await db.all<{ object: string }>(sql`
+      SELECT object FROM matters
+      WHERE org_id = ${ORG_ID} AND name = 'Empty.zip' AND status = 'active'
+    `)
+    const archive = validateAndExtractZip(s3.objects.get(zipMatter[0].object)!)
+    expect(archive.folders).toEqual(['Empty'])
+    expect(archive.files).toEqual([])
+  })
+
+  it('compresses a folder with an empty subfolder as nested ZIP directory entries', async () => {
+    const { db } = await createTestApp()
+    await seedStorage(db)
+    await seedMatter(db, { id: 'parent-folder', name: 'Parent', object: '', size: 0, dirtype: 1 })
+    await seedMatter(db, { id: 'child-folder', name: 'Child', parent: 'Parent', object: '', size: 0, dirtype: 1 })
+
+    const s3 = new MemoryS3()
+
+    const job = await createArchiveJob(db, {
+      orgId: ORG_ID,
+      userId: USER_ID,
+      request: { type: 'archive_compress', matterIds: ['parent-folder'] },
+      s3: s3 as unknown as S3Service,
+    })
+
+    expect(job).toMatchObject({ status: 'completed', type: 'archive_compress' })
+    const zipMatter = await db.all<{ object: string }>(sql`
+      SELECT object FROM matters
+      WHERE org_id = ${ORG_ID} AND name = 'Parent.zip' AND status = 'active'
+    `)
+    const archive = validateAndExtractZip(s3.objects.get(zipMatter[0].object)!)
+    expect(archive.folders).toEqual(['Parent', 'Parent/Child'])
+    expect(archive.files).toEqual([])
+  })
+
+  it('fails validation before writing output for unsafe ZIP paths', async () => {
+    const { db } = await createTestApp()
+    await seedStorage(db)
+    await seedMatter(db, { id: 'bad-zip', name: 'bad.zip', object: 'source/bad.zip', size: 200 })
+
+    const s3 = new MemoryS3()
+    s3.objects.set('source/bad.zip', createZip({ '../evil.txt': bytes('no') }))
+
+    const job = await createArchiveJob(db, {
+      orgId: ORG_ID,
+      userId: USER_ID,
+      request: { type: 'archive_extract', matterId: 'bad-zip' },
+      s3: s3 as unknown as S3Service,
+    })
+
+    expect(job.status).toBe('failed')
+    expect(job.errorMessage).toBe('ZIP paths cannot contain ..')
+    expect(s3.putKeys).toHaveLength(0)
+    await expect(activeMatterCount(db)).resolves.toBe(1)
+  })
+
+  it('enforces extraction limits with specific job failure errors', async () => {
+    const { db } = await createTestApp()
+    await seedStorage(db)
+    await seedMatter(db, { id: 'large-zip', name: 'large.zip', object: 'source/large.zip', size: 200 })
+
+    const s3 = new MemoryS3()
+    s3.objects.set(
+      'source/large.zip',
+      createZip({ 'large.bin': bytes('x') }, { declaredSizes: { 'large.bin': 25 * 1024 * 1024 + 1 } }),
+    )
+
+    const job = await createArchiveJob(db, {
+      orgId: ORG_ID,
+      userId: USER_ID,
+      request: { type: 'archive_extract', matterId: 'large-zip' },
+      s3: s3 as unknown as S3Service,
+    })
+
+    expect(job).toMatchObject({
+      status: 'failed',
+      errorMessage: 'ZIP entry exceeds 26214400 bytes',
+    })
+    expect(s3.putKeys).toHaveLength(0)
+  })
+
+  it('fails quota checks without creating visible extracted output', async () => {
+    const { db } = await createTestApp()
+    await seedStorage(db)
+    await db.run(sql`
+      INSERT INTO org_quotas (id, org_id, quota, used, traffic_quota, traffic_used, traffic_period)
+      VALUES ('archive-quota', ${ORG_ID}, 4, 0, 0, 0, '1970-01')
+    `)
+    await seedMatter(db, { id: 'quota-zip', name: 'quota.zip', object: 'source/quota.zip', size: 200 })
+
+    const s3 = new MemoryS3()
+    s3.objects.set('source/quota.zip', createZip({ 'hello.txt': bytes('hello') }))
+
+    const job = await createArchiveJob(db, {
+      orgId: ORG_ID,
+      userId: USER_ID,
+      request: { type: 'archive_extract', matterId: 'quota-zip' },
+      s3: s3 as unknown as S3Service,
+    })
+
+    expect(job.status).toBe('failed')
+    expect(job.errorMessage).toBe('Quota exceeded for extracted ZIP contents')
+    expect(s3.putKeys).toHaveLength(0)
+    await expect(activeMatterCount(db)).resolves.toBe(1)
+  })
+
+  it('fails compression quota checks before writing output', async () => {
+    const { db } = await createTestApp()
+    await seedStorage(db)
+    await db.run(sql`
+      INSERT INTO org_quotas (id, org_id, quota, used, traffic_quota, traffic_used, traffic_period)
+      VALUES ('archive-compress-quota', ${ORG_ID}, 4, 0, 0, 0, '1970-01')
+    `)
+    await seedMatter(db, { id: 'file-a', name: 'a.txt', object: 'objects/a.txt', size: 5 })
+
+    const s3 = new MemoryS3()
+    s3.objects.set('objects/a.txt', bytes('hello'))
+
+    const job = await createArchiveJob(db, {
+      orgId: ORG_ID,
+      userId: USER_ID,
+      request: { type: 'archive_compress', matterIds: ['file-a'] },
+      s3: s3 as unknown as S3Service,
+    })
+
+    expect(job.status).toBe('failed')
+    expect(job.errorMessage).toBe('Quota exceeded for generated ZIP archive')
+    expect(s3.putKeys).toHaveLength(0)
+    await expect(activeMatterCount(db)).resolves.toBe(1)
+  })
+
+  it('rejects compression output when an explicit target folder is missing or a file', async () => {
+    const { db } = await createTestApp()
+    await seedStorage(db)
+    await seedMatter(db, { id: 'file-a', name: 'a.txt', object: 'objects/a.txt', size: 5 })
+    await seedMatter(db, { id: 'file-target', name: 'target.txt', object: 'objects/target.txt', size: 1 })
+
+    const s3 = new MemoryS3()
+
+    const missingTarget = await createArchiveJob(db, {
+      orgId: ORG_ID,
+      userId: USER_ID,
+      request: { type: 'archive_compress', matterIds: ['file-a'], targetFolder: 'missing' },
+      s3: s3 as unknown as S3Service,
+    })
+    const fileTarget = await createArchiveJob(db, {
+      orgId: ORG_ID,
+      userId: USER_ID,
+      request: { type: 'archive_compress', matterIds: ['file-a'], targetFolder: 'target.txt' },
+      s3: s3 as unknown as S3Service,
+    })
+
+    expect(missingTarget).toMatchObject({ status: 'failed', errorMessage: 'Target folder not found' })
+    expect(fileTarget).toMatchObject({ status: 'failed', errorMessage: 'Target folder must be a folder' })
+    expect(s3.putKeys).toHaveLength(0)
+  })
+
+  it('fails extraction source validation for missing and non-ZIP matters', async () => {
+    const { db } = await createTestApp()
+    await seedStorage(db)
+    await seedMatter(db, { id: 'plain-file', name: 'plain.txt', object: 'objects/plain.txt', size: 5 })
+
+    const s3 = new MemoryS3()
+
+    const missingJob = await createArchiveJob(db, {
+      orgId: ORG_ID,
+      userId: USER_ID,
+      request: { type: 'archive_extract', matterId: 'missing-zip' },
+      s3: s3 as unknown as S3Service,
+    })
+    const plainJob = await createArchiveJob(db, {
+      orgId: ORG_ID,
+      userId: USER_ID,
+      request: { type: 'archive_extract', matterId: 'plain-file' },
+      s3: s3 as unknown as S3Service,
+    })
+
+    expect(missingJob).toMatchObject({ status: 'failed', errorMessage: 'ZIP matter not found' })
+    expect(plainJob).toMatchObject({ status: 'failed', errorMessage: 'Extraction source must be a .zip file' })
+  })
+
+  it('rejects extraction output when an explicit target folder is missing or a file', async () => {
+    const { db } = await createTestApp()
+    await seedStorage(db)
+    await seedMatter(db, { id: 'zip-matter', name: 'archive.zip', object: 'source/archive.zip', size: 200 })
+    await seedMatter(db, { id: 'file-target', name: 'target.txt', object: 'objects/target.txt', size: 1 })
+
+    const s3 = new MemoryS3()
+
+    const missingTarget = await createArchiveJob(db, {
+      orgId: ORG_ID,
+      userId: USER_ID,
+      request: { type: 'archive_extract', matterId: 'zip-matter', targetFolder: 'missing' },
+      s3: s3 as unknown as S3Service,
+    })
+    const fileTarget = await createArchiveJob(db, {
+      orgId: ORG_ID,
+      userId: USER_ID,
+      request: { type: 'archive_extract', matterId: 'zip-matter', targetFolder: 'target.txt' },
+      s3: s3 as unknown as S3Service,
+    })
+
+    expect(missingTarget).toMatchObject({ status: 'failed', errorMessage: 'Target folder not found' })
+    expect(fileTarget).toMatchObject({ status: 'failed', errorMessage: 'Target folder must be a folder' })
+    expect(s3.putKeys).toHaveLength(0)
+  })
+
+  it('fails clearly when archive source storage is missing', async () => {
+    const { db } = await createTestApp()
+    await seedMatter(db, { id: 'zip-matter', name: 'archive.zip', object: 'source/archive.zip', size: 200 })
+
+    const job = await createArchiveJob(db, {
+      orgId: ORG_ID,
+      userId: USER_ID,
+      request: { type: 'archive_extract', matterId: 'zip-matter' },
+      s3: new MemoryS3() as unknown as S3Service,
+    })
+
+    expect(job).toMatchObject({ status: 'failed', errorMessage: 'Storage not found' })
+  })
+
+  it('rolls back extraction quota usage when object writing fails', async () => {
+    const { db } = await createTestApp()
+    await seedStorage(db)
+    await seedMatter(db, { id: 'zip-matter', name: 'archive.zip', object: 'source/archive.zip', size: 200 })
+
+    const s3 = new FailingPutS3()
+    s3.objects.set('source/archive.zip', createZip({ 'hello.txt': bytes('hello') }))
+
+    const job = await createArchiveJob(db, {
+      orgId: ORG_ID,
+      userId: USER_ID,
+      request: { type: 'archive_extract', matterId: 'zip-matter' },
+      s3: s3 as unknown as S3Service,
+    })
+
+    expect(job).toMatchObject({ status: 'failed', errorMessage: 'S3 put failed' })
+    await expect(activeMatterCount(db)).resolves.toBe(1)
+    const usage = await db.all<{ used: number }>(sql`SELECT used FROM storages WHERE id = ${STORAGE_ID}`)
+    expect(usage[0].used).toBe(0)
+  })
+
+  it('removes generated folders when nested extraction write fails', async () => {
+    const { db } = await createTestApp()
+    await seedStorage(db)
+    await seedMatter(db, { id: 'zip-matter', name: 'archive.zip', object: 'source/archive.zip', size: 200 })
+
+    const s3 = new FailingPutS3()
+    s3.objects.set('source/archive.zip', createZip({ 'docs/hello.txt': bytes('hello') }))
+
+    const job = await createArchiveJob(db, {
+      orgId: ORG_ID,
+      userId: USER_ID,
+      request: { type: 'archive_extract', matterId: 'zip-matter' },
+      s3: s3 as unknown as S3Service,
+    })
+
+    expect(job).toMatchObject({ status: 'failed', errorMessage: 'S3 put failed' })
+    await expect(activeMatterCount(db)).resolves.toBe(1)
+    const usage = await db.all<{ used: number }>(sql`SELECT used FROM storages WHERE id = ${STORAGE_ID}`)
+    expect(usage[0].used).toBe(0)
+  })
+
+  it('removes generated file matters and objects when a later extraction write fails', async () => {
+    const { db } = await createTestApp()
+    await seedStorage(db)
+    await seedMatter(db, { id: 'zip-matter', name: 'archive.zip', object: 'source/archive.zip', size: 200 })
+
+    const s3 = new FailAfterPutS3(2)
+    s3.objects.set(
+      'source/archive.zip',
+      createZip({
+        'a.txt': bytes('first'),
+        'b.txt': bytes('second'),
+      }),
+    )
+
+    const job = await createArchiveJob(db, {
+      orgId: ORG_ID,
+      userId: USER_ID,
+      request: { type: 'archive_extract', matterId: 'zip-matter' },
+      s3: s3 as unknown as S3Service,
+    })
+
+    expect(job).toMatchObject({ status: 'failed', errorMessage: 'S3 put failed' })
+    await expect(activeMatterCount(db)).resolves.toBe(1)
+    expect(s3.putKeys).toHaveLength(1)
+    expect(s3.objects.size).toBe(1)
+    expect([...s3.objects.keys()]).toEqual(['source/archive.zip'])
+    const usage = await db.all<{ used: number }>(sql`SELECT used FROM storages WHERE id = ${STORAGE_ID}`)
+    expect(usage[0].used).toBe(0)
+  })
+
+  it('validates compression source ownership, status, limits, and archive paths', async () => {
+    const { db } = await createTestApp()
+    await seedStorage(db)
+    await seedMatter(db, {
+      id: 'inactive-file',
+      name: 'inactive.txt',
+      object: 'objects/inactive.txt',
+      size: 1,
+      status: 'trashed',
+    })
+    await seedMatter(db, {
+      id: 'large-file',
+      name: 'large.bin',
+      object: 'objects/large.bin',
+      size: 25 * 1024 * 1024 + 1,
+    })
+    await seedMatter(db, {
+      id: 'deep-file',
+      name: 'a/b/c/d/e/f/g/h/i/j/k/file.txt',
+      object: 'objects/deep.txt',
+      size: 1,
+    })
+    await seedMatter(db, { id: 'same-a', name: 'same.txt', parent: 'a', object: 'objects/same-a.txt', size: 1 })
+    await seedMatter(db, { id: 'same-b', name: 'same.txt', parent: 'b', object: 'objects/same-b.txt', size: 1 })
+
+    await expect(collectCompressionPlan(db, ORG_ID, ['missing'])).rejects.toThrow(
+      'Some archive source IDs do not belong to this organization',
+    )
+    await expect(collectCompressionPlan(db, ORG_ID, ['inactive-file'])).rejects.toThrow(
+      'Only active matters can be archived',
+    )
+    await expect(collectCompressionPlan(db, ORG_ID, ['large-file'])).rejects.toThrow(
+      'Compression source file exceeds 26214400 bytes',
+    )
+    await expect(collectCompressionPlan(db, ORG_ID, ['deep-file'])).rejects.toThrow(
+      'Compression directory depth exceeds 10',
+    )
+    await expect(collectCompressionPlan(db, ORG_ID, ['same-a', 'same-b'])).rejects.toThrow(
+      'Duplicate archive path: same.txt',
+    )
+  })
+
+  it('collects folder compression with the selected folder as the archive root', async () => {
+    const { db } = await createTestApp()
+    await seedStorage(db)
+    await seedMatter(db, { id: 'photos', name: 'Photos', object: '', size: 0, dirtype: 1 })
+    await seedMatter(db, { id: 'photo-a', name: 'a.jpg', parent: 'Photos', object: 'objects/a.jpg', size: 1 })
+
+    const plan = await collectCompressionPlan(db, ORG_ID, ['photos'], { outputName: 'backup' })
+
+    expect(plan).toMatchObject({ outputName: 'backup.zip', targetFolder: '' })
+    expect(plan.directories.map((directory) => directory.archivePath)).toEqual(['Photos'])
+    expect(plan.files.map((file) => file.archivePath)).toEqual(['Photos/a.jpg'])
+  })
+
+  it('enforces compression file count limits', async () => {
+    const { db } = await createTestApp()
+    await seedStorage(db)
+    const ids: string[] = []
+    for (let index = 0; index < 201; index += 1) {
+      const id = `many-${index}`
+      ids.push(id)
+      await seedMatter(db, { id, name: `${id}.txt`, object: `objects/${id}.txt`, size: 1 })
+    }
+
+    await expect(collectCompressionPlan(db, ORG_ID, ids)).rejects.toThrow('Compression file count exceeds 200')
+  })
+
+  it('rejects unsafe and unsupported ZIP entries during validation', () => {
+    expect(() => validateAndExtractZip(new Uint8Array())).toThrow('Invalid ZIP archive')
+    expect(() => validateAndExtractZip(createZip({ '/abs.txt': bytes('x') }))).toThrow('ZIP contains an absolute path')
+    expect(() => validateAndExtractZip(createZip({ 'a\\b.txt': bytes('x') }))).toThrow(
+      'ZIP paths must use forward slashes',
+    )
+    expect(() => validateAndExtractZip(createZip({ 'a//b.txt': bytes('x') }))).toThrow(
+      'ZIP contains an empty path segment',
+    )
+    expect(() =>
+      validateAndExtractZip(createZip({ 'secret.txt': bytes('x') }, { flags: { 'secret.txt': 1 } })),
+    ).toThrow('Encrypted ZIP archives are not supported')
+    expect(() =>
+      validateAndExtractZip(createZip({ 'unsupported.txt': bytes('x') }, { compression: { 'unsupported.txt': 14 } })),
+    ).toThrow('ZIP contains unsupported compression method')
+    expect(() =>
+      validateAndExtractZip(
+        createZip({ 'link.txt': bytes('x') }, { externalAttributes: { 'link.txt': 0o120000 << 16 } }),
+      ),
+    ).toThrow('ZIP contains unsupported entry type')
+    expect(() => validateAndExtractZip(createZip({ 'a/b/c/d/e/f/g/h/i/j/k/file.txt': bytes('x') }))).toThrow(
+      'ZIP directory depth exceeds 10',
+    )
+  })
+
+  it('enforces ZIP validation count and total output limits from metadata', () => {
+    const manyEntries = Object.fromEntries(Array.from({ length: 201 }, (_, index) => [`file-${index}.txt`, bytes('x')]))
+    expect(() => validateAndExtractZip(createZip(manyEntries))).toThrow('ZIP file count exceeds 200')
+    const totalLimitEntries = Object.fromEntries(
+      Array.from({ length: 5 }, (_, index) => [`total-${index}`, bytes('x')]),
+    )
+    const totalLimitSizes = Object.fromEntries(
+      Array.from({ length: 5 }, (_, index) => [`total-${index}`, 21 * 1024 * 1024]),
+    )
+    expect(() => validateAndExtractZip(createZip(totalLimitEntries, { declaredSizes: totalLimitSizes }))).toThrow(
+      'ZIP extraction output exceeds 104857600 bytes',
+    )
+  })
+})
+
+async function seedStorage(db: TestDb): Promise<void> {
+  const now = Date.now()
+  await db.run(sql`
+    INSERT INTO storages (id, title, mode, bucket, endpoint, region, access_key, secret_key, file_path, custom_host, capacity, used, status, created_at, updated_at)
+    VALUES (${STORAGE_ID}, 'Archive Storage', 'private', 'bucket', 'https://s3.example.com', 'auto', 'ak', 'sk', '', '', 0, 0, 'active', ${now}, ${now})
+  `)
+}
+
+async function seedMatter(
+  db: TestDb,
+  opts: {
+    id: string
+    name: string
+    object: string
+    size: number
+    parent?: string
+    type?: string
+    status?: string
+    dirtype?: number
+  },
+): Promise<void> {
+  const now = Date.now()
+  await db.run(sql`
+    INSERT INTO matters (id, org_id, alias, name, type, size, dirtype, parent, object, storage_id, status, created_at, updated_at)
+    VALUES (${opts.id}, ${ORG_ID}, ${`${opts.id}-alias`}, ${opts.name}, ${opts.type ?? 'text/plain'}, ${opts.size}, ${opts.dirtype ?? 0}, ${opts.parent ?? ''}, ${opts.object}, ${STORAGE_ID}, ${opts.status ?? 'active'}, ${now}, ${now})
+  `)
+}
+
+async function activeMatterCount(db: TestDb): Promise<number> {
+  const rows = await db.all<{ count: number }>(sql`
+    SELECT COUNT(*) AS count FROM matters WHERE org_id = ${ORG_ID} AND status = 'active'
+  `)
+  return rows[0]?.count ?? 0
+}
+
+interface ZipFixtureOptions {
+  declaredSizes?: Record<string, number>
+  flags?: Record<string, number>
+  compression?: Record<string, number>
+  externalAttributes?: Record<string, number>
+}
+
+function createZip(files: Record<string, Uint8Array>, opts: ZipFixtureOptions = {}): Uint8Array {
+  const encoder = new TextEncoder()
+  const localParts: Uint8Array[] = []
+  const centralParts: Uint8Array[] = []
+  let offset = 0
+
+  for (const [name, data] of Object.entries(files)) {
+    const filename = encoder.encode(name)
+    const crc = crc32(data)
+    const declaredSize = opts.declaredSizes?.[name] ?? data.length
+    const flags = opts.flags?.[name] ?? 0x0800
+    const compression = opts.compression?.[name] ?? 0
+    const local = new Uint8Array(30 + filename.length + data.length)
+    write32(local, 0, 0x04034b50)
+    write16(local, 6, flags)
+    write16(local, 8, compression)
+    write32(local, 14, crc)
+    write32(local, 18, data.length)
+    write32(local, 22, declaredSize)
+    write16(local, 26, filename.length)
+    local.set(filename, 30)
+    local.set(data, 30 + filename.length)
+    localParts.push(local)
+
+    const central = new Uint8Array(46 + filename.length)
+    write32(central, 0, 0x02014b50)
+    write16(central, 8, flags)
+    write16(central, 10, compression)
+    write32(central, 16, crc)
+    write32(central, 20, data.length)
+    write32(central, 24, declaredSize)
+    write16(central, 28, filename.length)
+    write32(central, 38, opts.externalAttributes?.[name] ?? 0)
+    write32(central, 42, offset)
+    central.set(filename, 46)
+    centralParts.push(central)
+    offset += local.length
+  }
+
+  const centralSize = centralParts.reduce((sum, part) => sum + part.length, 0)
+  const eocd = new Uint8Array(22)
+  write32(eocd, 0, 0x06054b50)
+  write16(eocd, 8, centralParts.length)
+  write16(eocd, 10, centralParts.length)
+  write32(eocd, 12, centralSize)
+  write32(eocd, 16, offset)
+  return concat([...localParts, ...centralParts, eocd])
+}
+
+function bytes(value: string): Uint8Array {
+  return new TextEncoder().encode(value)
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const out = new Uint8Array(parts.reduce((sum, part) => sum + part.length, 0))
+  let offset = 0
+  for (const part of parts) {
+    out.set(part, offset)
+    offset += part.length
+  }
+  return out
+}
+
+function write16(bytes: Uint8Array, offset: number, value: number): void {
+  bytes[offset] = value & 0xff
+  bytes[offset + 1] = (value >>> 8) & 0xff
+}
+
+function write32(bytes: Uint8Array, offset: number, value: number): void {
+  bytes[offset] = value & 0xff
+  bytes[offset + 1] = (value >>> 8) & 0xff
+  bytes[offset + 2] = (value >>> 16) & 0xff
+  bytes[offset + 3] = (value >>> 24) & 0xff
+}
+
+function crc32(data: Uint8Array): number {
+  let crc = 0xffffffff
+  for (const byte of data) {
+    crc ^= byte
+    for (let i = 0; i < 8; i += 1) crc = crc & 1 ? 0xedb88320 ^ (crc >>> 1) : crc >>> 1
+  }
+  return (crc ^ 0xffffffff) >>> 0
+}

--- a/server/services/archive-processing.ts
+++ b/server/services/archive-processing.ts
@@ -1,0 +1,242 @@
+import type { CreateBackgroundJobRequest } from '@shared/schemas'
+import type { BackgroundJob } from '@shared/types'
+import { and, eq } from 'drizzle-orm'
+import { DirType } from '../../shared/constants'
+import type { Storage as S3StorageType } from '../../shared/types'
+import { matters } from '../db/schema'
+import type { Database } from '../platform/interface'
+import { createBackgroundJob, updateBackgroundJob } from './background-jobs'
+import { createMatter, decrementUsage, getMatter, incrementUsageIfAllowed, purgeMatters } from './matter'
+import { buildObjectKey } from './path-template'
+import { S3Service } from './s3'
+import { getStorage, selectStorage } from './storage'
+import { collectCompressionPlan, createZipArchive } from './zip-compress'
+import { validateAndExtractZip } from './zip-extract'
+
+export interface CreateArchiveJobInput {
+  orgId: string
+  userId: string
+  request: CreateBackgroundJobRequest
+  s3?: S3Service
+}
+
+const ZIP_MIME = 'application/zip'
+const DEFAULT_FILE_MIME = 'application/octet-stream'
+
+export async function createArchiveJob(db: Database, input: CreateArchiveJobInput): Promise<BackgroundJob> {
+  const targetFolder = input.request.targetFolder ?? null
+  const job = await createBackgroundJob(db, {
+    orgId: input.orgId,
+    userId: input.userId,
+    type: input.request.type,
+    targetFolder,
+    metadata: input.request,
+    cancelable: false,
+  })
+
+  const s3 = input.s3 ?? new S3Service()
+  try {
+    await updateBackgroundJob(db, input.orgId, job.id, { status: 'running', startedAt: new Date() })
+    if (input.request.type === 'archive_compress') {
+      return await runCompressionJob(db, s3, job.id, input.orgId, input.userId, input.request)
+    }
+    return await runExtractionJob(db, s3, job.id, input.orgId, input.userId, input.request)
+  } catch (error) {
+    return updateBackgroundJob(db, input.orgId, job.id, {
+      status: 'failed',
+      errorMessage: (error as Error).message,
+      retryable: false,
+      cancelable: false,
+    })
+  }
+}
+
+async function runCompressionJob(
+  db: Database,
+  s3: S3Service,
+  jobId: string,
+  orgId: string,
+  userId: string,
+  request: Extract<CreateBackgroundJobRequest, { type: 'archive_compress' }>,
+): Promise<BackgroundJob> {
+  if (request.targetFolder !== undefined) await requireTargetFolder(db, orgId, request.targetFolder)
+  const plan = await collectCompressionPlan(db, orgId, request.matterIds, {
+    targetFolder: request.targetFolder,
+    outputName: request.outputName,
+  })
+  await updateBackgroundJob(db, orgId, jobId, {
+    progress: { inputBytes: plan.inputBytes, fileCount: plan.files.length },
+  })
+
+  const objects = []
+  for (const file of plan.files) {
+    const storage = await requireStorage(db, file.matter.storageId)
+    objects.push({ archivePath: file.archivePath, bytes: await s3.getObjectBytes(storage, file.matter.object) })
+  }
+
+  const zipBytes = createZipArchive(objects, plan.directories)
+  const targetStorage = (await selectStorage(db, 'private')) as unknown as S3StorageType
+  const allowed = await incrementUsageIfAllowed(db, orgId, targetStorage.id, zipBytes.length)
+  if (!allowed) throw new Error('Quota exceeded for generated ZIP archive')
+
+  const key = buildObjectKey({ uid: userId, orgId, rawExt: '.zip' })
+  let objectWritten = false
+  try {
+    await s3.putObject(targetStorage, key, zipBytes, ZIP_MIME)
+    objectWritten = true
+    const matter = await createMatter(db, {
+      orgId,
+      userId,
+      name: plan.outputName,
+      type: ZIP_MIME,
+      size: zipBytes.length,
+      dirtype: DirType.FILE,
+      parent: plan.targetFolder,
+      object: key,
+      storageId: targetStorage.id,
+      status: 'active',
+      onConflict: 'rename',
+    })
+
+    return updateBackgroundJob(db, orgId, jobId, {
+      status: 'completed',
+      progress: {
+        inputBytes: plan.inputBytes,
+        outputBytes: zipBytes.length,
+        processedBytes: plan.inputBytes,
+        fileCount: plan.files.length,
+        currentFilename: null,
+      },
+      resultMetadata: { matterId: matter.id, outputName: matter.name, outputBytes: zipBytes.length },
+      cancelable: false,
+    })
+  } catch (error) {
+    await decrementUsage(db, orgId, new Map([[targetStorage.id, zipBytes.length]]), zipBytes.length)
+    if (objectWritten) await s3.deleteObject(targetStorage, key)
+    throw error
+  }
+}
+
+async function runExtractionJob(
+  db: Database,
+  s3: S3Service,
+  jobId: string,
+  orgId: string,
+  userId: string,
+  request: Extract<CreateBackgroundJobRequest, { type: 'archive_extract' }>,
+): Promise<BackgroundJob> {
+  const zipMatter = await getMatter(db, request.matterId, orgId)
+  if (!zipMatter || zipMatter.status !== 'active') throw new Error('ZIP matter not found')
+  if (zipMatter.dirtype !== DirType.FILE || !zipMatter.name.toLowerCase().endsWith('.zip')) {
+    throw new Error('Extraction source must be a .zip file')
+  }
+
+  if (request.targetFolder !== undefined) await requireTargetFolder(db, orgId, request.targetFolder)
+  const sourceStorage = await requireStorage(db, zipMatter.storageId)
+  const zipBytes = await s3.getObjectBytes(sourceStorage, zipMatter.object)
+  const archive = validateAndExtractZip(zipBytes)
+  const targetFolder = request.targetFolder ?? zipMatter.parent
+  const targetStorage = (await selectStorage(db, 'private')) as unknown as S3StorageType
+  const allowed = await incrementUsageIfAllowed(db, orgId, targetStorage.id, archive.totalBytes)
+  if (!allowed) throw new Error('Quota exceeded for extracted ZIP contents')
+
+  const writtenKeys: string[] = []
+  const createdMatterIds: string[] = []
+  try {
+    const folderParents = new Map<string, string>()
+    for (const folderPath of archive.folders) {
+      const parts = folderPath.split('/')
+      const parentPath = parts.slice(0, -1).join('/')
+      const parent = parentPath ? folderParents.get(parentPath) : targetFolder
+      if (parent === undefined) throw new Error(`Missing parent folder for ${folderPath}`)
+      const folder = await createMatter(db, {
+        orgId,
+        userId,
+        name: parts[parts.length - 1],
+        type: 'folder',
+        size: 0,
+        dirtype: DirType.USER_FOLDER,
+        parent,
+        object: '',
+        storageId: targetStorage.id,
+        status: 'active',
+        onConflict: 'rename',
+      })
+      createdMatterIds.push(folder.id)
+      folderParents.set(folderPath, buildMatterPath(folder.parent, folder.name))
+    }
+
+    for (const file of archive.files) {
+      const parent = file.parentPath ? folderParents.get(file.parentPath) : targetFolder
+      if (parent === undefined) throw new Error(`Missing parent folder for ${file.path}`)
+      const key = buildObjectKey({ uid: userId, orgId, rawExt: extension(file.name) })
+      await s3.putObject(targetStorage, key, file.bytes, DEFAULT_FILE_MIME)
+      writtenKeys.push(key)
+      const matter = await createMatter(db, {
+        orgId,
+        userId,
+        name: file.name,
+        type: DEFAULT_FILE_MIME,
+        size: file.size,
+        dirtype: DirType.FILE,
+        parent,
+        object: key,
+        storageId: targetStorage.id,
+        status: 'active',
+        onConflict: 'rename',
+      })
+      createdMatterIds.push(matter.id)
+    }
+
+    return updateBackgroundJob(db, orgId, jobId, {
+      status: 'completed',
+      progress: {
+        inputBytes: zipMatter.size ?? zipBytes.length,
+        outputBytes: archive.totalBytes,
+        processedBytes: zipMatter.size ?? zipBytes.length,
+        fileCount: archive.files.length,
+        currentFilename: null,
+      },
+      resultMetadata: { matterIds: createdMatterIds, outputBytes: archive.totalBytes },
+      cancelable: false,
+    })
+  } catch (error) {
+    await purgeMatters(db, orgId, createdMatterIds)
+    await decrementUsage(db, orgId, new Map([[targetStorage.id, archive.totalBytes]]), archive.totalBytes)
+    await s3.deleteObjects(targetStorage, writtenKeys)
+    throw error
+  }
+}
+
+async function requireStorage(db: Database, storageId: string): Promise<S3StorageType> {
+  const storage = await getStorage(db, storageId)
+  if (!storage) throw new Error('Storage not found')
+  return storage as unknown as S3StorageType
+}
+
+async function requireTargetFolder(db: Database, orgId: string, targetFolder: string): Promise<void> {
+  if (targetFolder === '') return
+
+  const slash = targetFolder.lastIndexOf('/')
+  const parent = slash >= 0 ? targetFolder.slice(0, slash) : ''
+  const name = slash >= 0 ? targetFolder.slice(slash + 1) : targetFolder
+  const rows = await db
+    .select()
+    .from(matters)
+    .where(
+      and(eq(matters.orgId, orgId), eq(matters.parent, parent), eq(matters.name, name), eq(matters.status, 'active')),
+    )
+    .limit(1)
+  const target = rows[0]
+  if (!target) throw new Error('Target folder not found')
+  if (target.dirtype === DirType.FILE) throw new Error('Target folder must be a folder')
+}
+
+function buildMatterPath(parent: string, name: string): string {
+  return parent ? `${parent}/${name}` : name
+}
+
+function extension(name: string): string {
+  const dot = name.lastIndexOf('.')
+  return dot >= 0 ? name.slice(dot) : ''
+}

--- a/server/services/s3.test.ts
+++ b/server/services/s3.test.ts
@@ -201,6 +201,61 @@ describe('S3Service', () => {
     })
   })
 
+  describe('getObjectBytes', () => {
+    it('returns bytes from Uint8Array bodies', async () => {
+      const bytes = new Uint8Array([1, 2, 3])
+      mockSend.mockResolvedValueOnce({ Body: bytes })
+
+      await expect(service.getObjectBytes(storage, 'test.bin')).resolves.toEqual(bytes)
+    })
+
+    it('returns bytes from ReadableStream bodies', async () => {
+      const bytes = new Uint8Array([4, 5, 6])
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(bytes)
+          controller.close()
+        },
+      })
+      mockSend.mockResolvedValueOnce({ Body: stream })
+
+      await expect(service.getObjectBytes(storage, 'test.bin')).resolves.toEqual(bytes)
+    })
+
+    it('returns bytes from transformToByteArray bodies', async () => {
+      const bytes = new Uint8Array([1, 2, 3])
+      mockSend.mockResolvedValueOnce({
+        Body: { transformToByteArray: async () => bytes },
+      })
+
+      await expect(service.getObjectBytes(storage, 'test.bin')).resolves.toEqual(bytes)
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({ input: { Bucket: 'my-bucket', Key: 'test.bin' } }),
+      )
+    })
+
+    it('returns bytes from arrayBuffer bodies', async () => {
+      const bytes = new Uint8Array([7, 8, 9])
+      mockSend.mockResolvedValueOnce({
+        Body: { arrayBuffer: async () => bytes.buffer },
+      })
+
+      await expect(service.getObjectBytes(storage, 'test.bin')).resolves.toEqual(bytes)
+    })
+
+    it('rejects empty object bodies', async () => {
+      mockSend.mockResolvedValueOnce({})
+
+      await expect(service.getObjectBytes(storage, 'missing.bin')).rejects.toThrow('Empty body from object')
+    })
+
+    it('rejects unsupported object bodies', async () => {
+      mockSend.mockResolvedValueOnce({ Body: {} })
+
+      await expect(service.getObjectBytes(storage, 'test.bin')).rejects.toThrow('Unsupported object body')
+    })
+  })
+
   describe('copyObject', () => {
     it('sends CopyObjectCommand with correct CopySource', async () => {
       mockSend.mockResolvedValueOnce({ $metadata: {} })

--- a/server/services/s3.ts
+++ b/server/services/s3.ts
@@ -81,6 +81,13 @@ export class S3Service {
     }
   }
 
+  async getObjectBytes(storage: Storage, key: string): Promise<Uint8Array> {
+    const client = this.createClient(storage)
+    const result = await client.send(new GetObjectCommand({ Bucket: storage.bucket, Key: key }))
+    if (!result.Body) throw new Error('Empty body from object')
+    return bodyToBytes(result.Body)
+  }
+
   async copyObject(srcStorage: Storage, srcKey: string, dstStorage: Storage, dstKey: string): Promise<void> {
     const client = this.createClient(dstStorage)
     await client.send(
@@ -150,4 +157,18 @@ export class S3Service {
     // Cloudflare Workers doesn't have DOMParser, so we delete one-by-one.
     await Promise.all(keys.map((key) => this.deleteObject(storage, key)))
   }
+}
+
+async function bodyToBytes(body: unknown): Promise<Uint8Array> {
+  if (body instanceof Uint8Array) return body
+  if (body instanceof ReadableStream) return new Uint8Array(await new Response(body).arrayBuffer())
+
+  const streamBody = body as {
+    transformToByteArray?: () => Promise<Uint8Array>
+    arrayBuffer?: () => Promise<ArrayBuffer>
+  }
+  if (streamBody.transformToByteArray) return streamBody.transformToByteArray()
+  if (streamBody.arrayBuffer) return new Uint8Array(await streamBody.arrayBuffer())
+
+  throw new Error('Unsupported object body')
 }

--- a/server/services/zip-compress.ts
+++ b/server/services/zip-compress.ts
@@ -1,0 +1,168 @@
+import { and, eq, like, or } from 'drizzle-orm'
+import { type Zippable, zipSync } from 'fflate'
+import { DirType } from '../../shared/constants'
+import { matters } from '../db/schema'
+import type { Database } from '../platform/interface'
+import type { Matter } from './matter'
+
+export const ZIP_COMPRESS_LIMITS = {
+  totalInputBytes: 50 * 1024 * 1024,
+  singleFileBytes: 25 * 1024 * 1024,
+  fileCount: 200,
+  directoryDepth: 10,
+} as const
+
+export interface CompressionSourceFile {
+  matter: Matter
+  archivePath: string
+}
+
+export interface CompressionSourceDirectory {
+  archivePath: string
+}
+
+export interface ZipSourceObject {
+  archivePath: string
+  bytes: Uint8Array
+}
+
+export interface CompressionPlan {
+  files: CompressionSourceFile[]
+  directories: CompressionSourceDirectory[]
+  inputBytes: number
+  outputName: string
+  targetFolder: string
+}
+
+export async function collectCompressionPlan(
+  db: Database,
+  orgId: string,
+  matterIds: string[],
+  opts: { targetFolder?: string; outputName?: string } = {},
+): Promise<CompressionPlan> {
+  const uniqueIds = [...new Set(matterIds)]
+  const roots = await db
+    .select()
+    .from(matters)
+    .where(and(eq(matters.orgId, orgId), or(...uniqueIds.map((id) => eq(matters.id, id)))))
+  if (roots.length !== uniqueIds.length) throw new Error('Some archive source IDs do not belong to this organization')
+  if (roots.some((matter) => matter.status !== 'active')) throw new Error('Only active matters can be archived')
+
+  const files: CompressionSourceFile[] = []
+  const directories: CompressionSourceDirectory[] = []
+  for (const root of roots) {
+    const entries = await collectRootEntries(db, orgId, root)
+    files.push(...entries.files)
+    directories.push(...entries.directories)
+  }
+  validateCompressionEntries(files, directories)
+
+  return {
+    files,
+    directories,
+    inputBytes: files.reduce((sum, file) => sum + (file.matter.size ?? 0), 0),
+    outputName: archiveOutputName(roots, opts.outputName),
+    targetFolder: opts.targetFolder ?? roots[0].parent,
+  }
+}
+
+export function createZipArchive(
+  objects: ZipSourceObject[],
+  directories: CompressionSourceDirectory[] = [],
+): Uint8Array {
+  const zippable: Zippable = {}
+  for (const directory of directories) zippable[`${directory.archivePath}/`] = new Uint8Array()
+  for (const object of objects) zippable[object.archivePath] = object.bytes
+  return zipSync(zippable, { level: 6 })
+}
+
+function validateCompressionEntries(files: CompressionSourceFile[], directories: CompressionSourceDirectory[]): void {
+  let totalBytes = 0
+  const paths = new Set<string>()
+
+  for (const directory of directories) {
+    if (directoryDepth(directory.archivePath) > ZIP_COMPRESS_LIMITS.directoryDepth) {
+      throw new Error(`Compression directory depth exceeds ${ZIP_COMPRESS_LIMITS.directoryDepth}`)
+    }
+    if (paths.has(directory.archivePath)) throw new Error(`Duplicate archive path: ${directory.archivePath}`)
+    paths.add(directory.archivePath)
+  }
+
+  for (const file of files) {
+    const bytes = file.matter.size ?? 0
+    totalBytes += bytes
+    if (bytes > ZIP_COMPRESS_LIMITS.singleFileBytes) {
+      throw new Error(`Compression source file exceeds ${ZIP_COMPRESS_LIMITS.singleFileBytes} bytes`)
+    }
+    if (totalBytes > ZIP_COMPRESS_LIMITS.totalInputBytes) {
+      throw new Error(`Compression input exceeds ${ZIP_COMPRESS_LIMITS.totalInputBytes} bytes`)
+    }
+    if (directoryDepth(file.archivePath) > ZIP_COMPRESS_LIMITS.directoryDepth) {
+      throw new Error(`Compression directory depth exceeds ${ZIP_COMPRESS_LIMITS.directoryDepth}`)
+    }
+    if (paths.has(file.archivePath)) throw new Error(`Duplicate archive path: ${file.archivePath}`)
+    paths.add(file.archivePath)
+  }
+
+  if (files.length > ZIP_COMPRESS_LIMITS.fileCount) {
+    throw new Error(`Compression file count exceeds ${ZIP_COMPRESS_LIMITS.fileCount}`)
+  }
+}
+
+async function collectRootEntries(
+  db: Database,
+  orgId: string,
+  root: Matter,
+): Promise<{ files: CompressionSourceFile[]; directories: CompressionSourceDirectory[] }> {
+  if (root.dirtype === DirType.FILE) return { files: [{ matter: root, archivePath: root.name }], directories: [] }
+
+  const rootPath = buildPath(root.parent, root.name)
+  const rows = await db
+    .select()
+    .from(matters)
+    .where(
+      and(
+        eq(matters.orgId, orgId),
+        eq(matters.status, 'active'),
+        or(eq(matters.parent, rootPath), like(matters.parent, `${rootPath}/%`)),
+      ),
+    )
+  const directories = [
+    { archivePath: relativeArchivePath(rootPath, root) },
+    ...rows
+      .filter((matter) => matter.dirtype !== DirType.FILE)
+      .map((matter) => ({ archivePath: relativeArchivePath(rootPath, matter) })),
+  ].sort(
+    (a, b) =>
+      directoryDepth(a.archivePath) - directoryDepth(b.archivePath) || a.archivePath.localeCompare(b.archivePath),
+  )
+  const files = rows
+    .filter((matter) => matter.dirtype === DirType.FILE)
+    .map((matter) => ({ matter, archivePath: relativeArchivePath(rootPath, matter) }))
+
+  return { files, directories }
+}
+
+function relativeArchivePath(rootPath: string, matter: Matter): string {
+  const path = buildPath(matter.parent, matter.name)
+  const rootParent = rootPath.slice(0, Math.max(0, rootPath.lastIndexOf('/')))
+  return rootParent ? path.slice(rootParent.length + 1) : path
+}
+
+function archiveOutputName(roots: Matter[], requestedName?: string): string {
+  const name = requestedName ?? (roots.length === 1 ? `${baseZipName(roots[0].name)}.zip` : 'selection.zip')
+  return name.toLowerCase().endsWith('.zip') ? name : `${name}.zip`
+}
+
+function baseZipName(name: string): string {
+  return name.toLowerCase().endsWith('.zip') ? name.slice(0, -4) : name
+}
+
+function directoryDepth(path: string): number {
+  const parts = path.split('/').filter((part) => part.length > 0)
+  return Math.max(0, parts.length - 1)
+}
+
+function buildPath(parent: string, name: string): string {
+  return parent ? `${parent}/${name}` : name
+}

--- a/server/services/zip-extract.ts
+++ b/server/services/zip-extract.ts
@@ -1,0 +1,178 @@
+import { unzipSync } from 'fflate'
+
+export const ZIP_EXTRACT_LIMITS = {
+  totalOutputBytes: 100 * 1024 * 1024,
+  singleFileBytes: 25 * 1024 * 1024,
+  fileCount: 200,
+  directoryDepth: 10,
+} as const
+
+export interface ExtractedZipEntry {
+  path: string
+  name: string
+  parentPath: string
+  bytes: Uint8Array
+  size: number
+}
+
+interface CentralDirectoryEntry {
+  name: string
+  flags: number
+  compression: number
+  compressedSize: number
+  uncompressedSize: number
+  externalAttributes: number
+}
+
+export interface ValidatedZip {
+  files: ExtractedZipEntry[]
+  folders: string[]
+  totalBytes: number
+}
+
+const textDecoder = new TextDecoder()
+
+export function validateAndExtractZip(data: Uint8Array): ValidatedZip {
+  const entries = readCentralDirectory(data)
+  validateEntries(entries)
+
+  const fileNames = new Set(entries.filter((entry) => !isDirectoryEntry(entry)).map((entry) => entry.name))
+  const unzipped = unzipSync(data, { filter: (file) => fileNames.has(file.name) })
+  const folders = collectFolders(entries)
+  const files = Object.entries(unzipped).map(([path, bytes]) => {
+    const parts = pathParts(path)
+    return {
+      path,
+      name: parts[parts.length - 1],
+      parentPath: parts.slice(0, -1).join('/'),
+      bytes,
+      size: bytes.length,
+    }
+  })
+
+  const totalBytes = files.reduce((sum, file) => sum + file.size, 0)
+  if (totalBytes > ZIP_EXTRACT_LIMITS.totalOutputBytes) {
+    throw new Error(`ZIP extraction output exceeds ${ZIP_EXTRACT_LIMITS.totalOutputBytes} bytes`)
+  }
+
+  return { files, folders, totalBytes }
+}
+
+function validateEntries(entries: CentralDirectoryEntry[]): void {
+  let fileCount = 0
+  let totalBytes = 0
+
+  for (const entry of entries) {
+    validatePath(entry.name)
+    if ((entry.flags & 1) === 1) throw new Error('Encrypted ZIP archives are not supported')
+    if (isUnsupportedUnixType(entry.externalAttributes)) throw new Error('ZIP contains unsupported entry type')
+    if (entry.compression !== 0 && entry.compression !== 8)
+      throw new Error('ZIP contains unsupported compression method')
+
+    const directory = isDirectoryEntry(entry)
+    const depth = directoryDepth(entry.name, directory)
+    if (depth > ZIP_EXTRACT_LIMITS.directoryDepth) {
+      throw new Error(`ZIP directory depth exceeds ${ZIP_EXTRACT_LIMITS.directoryDepth}`)
+    }
+
+    if (!directory) {
+      fileCount += 1
+      totalBytes += entry.uncompressedSize
+      if (entry.uncompressedSize > ZIP_EXTRACT_LIMITS.singleFileBytes) {
+        throw new Error(`ZIP entry exceeds ${ZIP_EXTRACT_LIMITS.singleFileBytes} bytes`)
+      }
+      if (fileCount > ZIP_EXTRACT_LIMITS.fileCount) {
+        throw new Error(`ZIP file count exceeds ${ZIP_EXTRACT_LIMITS.fileCount}`)
+      }
+      if (totalBytes > ZIP_EXTRACT_LIMITS.totalOutputBytes) {
+        throw new Error(`ZIP extraction output exceeds ${ZIP_EXTRACT_LIMITS.totalOutputBytes} bytes`)
+      }
+    }
+  }
+}
+
+function readCentralDirectory(data: Uint8Array): CentralDirectoryEntry[] {
+  const eocd = findEndOfCentralDirectory(data)
+  const entryCount = uint16(data, eocd + 10)
+  let offset = uint32(data, eocd + 16)
+  const entries: CentralDirectoryEntry[] = []
+
+  for (let i = 0; i < entryCount; i += 1) {
+    if (uint32(data, offset) !== 0x02014b50) throw new Error('Invalid ZIP central directory')
+
+    const flags = uint16(data, offset + 8)
+    const compression = uint16(data, offset + 10)
+    const compressedSize = uint32(data, offset + 20)
+    const uncompressedSize = uint32(data, offset + 24)
+    const nameLength = uint16(data, offset + 28)
+    const extraLength = uint16(data, offset + 30)
+    const commentLength = uint16(data, offset + 32)
+    const externalAttributes = uint32(data, offset + 38)
+    const nameStart = offset + 46
+    const name = textDecoder.decode(data.subarray(nameStart, nameStart + nameLength))
+    entries.push({ name, flags, compression, compressedSize, uncompressedSize, externalAttributes })
+    offset = nameStart + nameLength + extraLength + commentLength
+  }
+
+  return entries
+}
+
+function findEndOfCentralDirectory(data: Uint8Array): number {
+  const minOffset = Math.max(0, data.length - 65557)
+  for (let offset = data.length - 22; offset >= minOffset; offset -= 1) {
+    if (uint32(data, offset) === 0x06054b50) return offset
+  }
+  throw new Error('Invalid ZIP archive')
+}
+
+function collectFolders(entries: CentralDirectoryEntry[]): string[] {
+  const folders = new Set<string>()
+  for (const entry of entries) {
+    const parts = pathParts(entry.name)
+    const max = isDirectoryEntry(entry) ? parts.length : parts.length - 1
+    for (let i = 1; i <= max; i += 1) folders.add(parts.slice(0, i).join('/'))
+  }
+  return [...folders].sort((a, b) => pathParts(a).length - pathParts(b).length || a.localeCompare(b))
+}
+
+function validatePath(path: string): void {
+  if (path.length === 0) throw new Error('ZIP contains an empty path')
+  if (path.includes('\\')) throw new Error('ZIP paths must use forward slashes')
+  if (path.startsWith('/') || /^[A-Za-z]:\//.test(path)) {
+    throw new Error('ZIP contains an absolute path')
+  }
+  const parts = path.split('/')
+  const lastIndex = parts.length - 1
+  if (parts.some((part, index) => part.length === 0 && index !== lastIndex)) {
+    throw new Error('ZIP contains an empty path segment')
+  }
+  if (parts.length === 0) throw new Error('ZIP contains an empty path')
+  if (parts.some((part) => part === '..')) throw new Error('ZIP paths cannot contain ..')
+}
+
+function isDirectoryEntry(entry: CentralDirectoryEntry): boolean {
+  return entry.name.endsWith('/')
+}
+
+function isUnsupportedUnixType(externalAttributes: number): boolean {
+  const mode = externalAttributes >>> 16
+  const type = mode & 0o170000
+  return type !== 0 && type !== 0o100000 && type !== 0o040000
+}
+
+function directoryDepth(path: string, directory: boolean): number {
+  const parts = pathParts(path)
+  return directory ? parts.length : Math.max(0, parts.length - 1)
+}
+
+function pathParts(path: string): string[] {
+  return path.split('/').filter((part) => part.length > 0)
+}
+
+function uint16(data: Uint8Array, offset: number): number {
+  return data[offset] | (data[offset + 1] << 8)
+}
+
+function uint32(data: Uint8Array, offset: number): number {
+  return (data[offset] | (data[offset + 1] << 8) | (data[offset + 2] << 16) | (data[offset + 3] << 24)) >>> 0
+}

--- a/shared/schemas/background-jobs.ts
+++ b/shared/schemas/background-jobs.ts
@@ -6,6 +6,30 @@ export type BackgroundJobStatusInput = z.infer<typeof backgroundJobStatusSchema>
 export const backgroundJobTypeSchema = z.string().min(1).max(80)
 export type BackgroundJobTypeInput = z.infer<typeof backgroundJobTypeSchema>
 
+const matterIdSchema = z.string().min(1)
+
+export const archiveCompressJobRequestSchema = z.object({
+  type: z.literal('archive_compress'),
+  matterIds: z.array(matterIdSchema).min(1).max(200),
+  targetFolder: z.string().optional(),
+  outputName: z.string().min(1).max(255).optional(),
+})
+
+export const archiveExtractJobRequestSchema = z.object({
+  type: z.literal('archive_extract'),
+  matterId: matterIdSchema,
+  targetFolder: z.string().optional(),
+})
+
+export const createBackgroundJobRequestSchema = z.discriminatedUnion('type', [
+  archiveCompressJobRequestSchema,
+  archiveExtractJobRequestSchema,
+])
+
+export type ArchiveCompressJobRequest = z.infer<typeof archiveCompressJobRequestSchema>
+export type ArchiveExtractJobRequest = z.infer<typeof archiveExtractJobRequestSchema>
+export type CreateBackgroundJobRequest = z.infer<typeof createBackgroundJobRequestSchema>
+
 export const listBackgroundJobsQuerySchema = z.object({
   status: backgroundJobStatusSchema.optional(),
   type: backgroundJobTypeSchema.optional(),

--- a/shared/schemas/index.ts
+++ b/shared/schemas/index.ts
@@ -14,8 +14,22 @@ export {
 } from './announcement'
 export type { ListAdminAuditQuery } from './audit'
 export { listAdminAuditQuerySchema } from './audit'
-export type { BackgroundJobStatusInput, BackgroundJobTypeInput, ListBackgroundJobsQuery } from './background-jobs'
-export { backgroundJobStatusSchema, backgroundJobTypeSchema, listBackgroundJobsQuerySchema } from './background-jobs'
+export type {
+  ArchiveCompressJobRequest,
+  ArchiveExtractJobRequest,
+  BackgroundJobStatusInput,
+  BackgroundJobTypeInput,
+  CreateBackgroundJobRequest,
+  ListBackgroundJobsQuery,
+} from './background-jobs'
+export {
+  archiveCompressJobRequestSchema,
+  archiveExtractJobRequestSchema,
+  backgroundJobStatusSchema,
+  backgroundJobTypeSchema,
+  createBackgroundJobRequestSchema,
+  listBackgroundJobsQuerySchema,
+} from './background-jobs'
 export type {
   CheckoutInput,
   CloudOrder,


### PR DESCRIPTION
## Summary
- add POST /api/background-jobs support for archive_compress and archive_extract requests
- implement bounded local ZIP validation, extraction, compression, object writes, quota checks, and job progress/result updates
- add object read helper for S3 and focused service/route coverage

## Verification
- npm run typecheck
- npm run lint
- npm run test
- npm run test -- server/services/archive-processing.test.ts server/routes/background-jobs.integration.test.ts server/services/s3.test.ts