### PR TITLE
docs: add v2.7 release verification notes

### DIFF
--- a/docs/roadmap/v2.7.md
+++ b/docs/roadmap/v2.7.md
@@ -218,3 +218,27 @@ Remote download:
 - WebDAV protocol access — shipped as Community external-client compatibility
 - Remote URL download — shipped as Community orchestration through Aria2, qBittorrent, and future compatible download adapters
 - Archive compression/extraction — shipped as bounded Community file processing
+
+## Release Verification Notes
+
+Run the focused local checks before broadening to full test suites:
+
+```sh
+npm run test -- server/routes/webdav.integration.test.ts
+npm run test -- server/services/archive-processing.test.ts server/services/background-jobs.test.ts server/routes/background-jobs.integration.test.ts
+npm run test -- src/lib/api.test.ts
+npm run typecheck
+```
+
+The WebDAV checks must cover API-key-only authentication, PROPFIND mount and folder responses, GET/HEAD file access, PUT create/update behavior, MKCOL folder creation, MOVE/COPY/DELETE behavior within organization scope, quota rollback paths, and traversal or encoded-path rejection.
+
+The archive checks must cover ZIP compression and extraction golden paths, target-folder validation, quota failures, unsafe ZIP paths, declared-size limits, file-count limits, unsupported ZIP entries, and failure before any extracted output write.
+
+Cloudflare preview verification is required for any PR that changes UI or API behavior. For v2.7, the preview report should include:
+
+- WebDAV smoke test against `/dav/` with a dedicated API key: mount-root PROPFIND, workspace-folder PROPFIND, PUT then GET/HEAD of a small text file, MKCOL, MOVE, COPY, and DELETE.
+- Archive UI flow screenshots: compress selected files/folders, extract a small `.zip`, show the resulting background job, and show a failed invalid or oversized archive job.
+- Generic `/tasks` screenshots: active, completed, failed, cancelable, and retryable jobs, with archive jobs displayed by generic job type/status/progress instead of archive-only UI.
+- Evidence that invalid archive extraction does not create partial files in the selected folder.
+
+Release gap as of this verification pass: the backend WebDAV and archive job APIs are present, but the generic `/tasks` page and file-manager archive actions are not present in the current branch. Those UI flows must land before the archive UI preview checklist can be completed.


### PR DESCRIPTION
## Summary
- Added v2.7 release verification notes to the roadmap.
- Captured focused local commands for WebDAV, archive/background jobs, API wrappers, and typecheck.
- Documented required Cloudflare preview flows and the current release gap: the generic /tasks page and file-manager archive actions are not present in this branch.

## Local Verification
- npm run test -- server/routes/webdav.integration.test.ts: 14 passed
- npm run test -- server/services/archive-processing.test.ts server/services/background-jobs.test.ts server/routes/background-jobs.integration.test.ts: 32 passed
- npm run test -- src/lib/api.test.ts: 251 passed
- npm run typecheck: passed
- Husky pre-commit typecheck: passed

## Checklist Mapping
- WebDAV auth, PROPFIND, PUT/GET, MKCOL, MOVE/COPY/DELETE: verified by server/routes/webdav.integration.test.ts.
- ZIP compression/extraction golden paths: verified by server/services/archive-processing.test.ts.
- Invalid ZIP path/limit cases fail before output writes: verified by archive-processing tests for unsafe paths, declared size, file count, unsupported entries, quota, and write rollback.
- Generic /tasks page shows archive jobs and remains type-generic: not satisfied in current branch; no /tasks route, background-job UI wrappers, or file-manager archive actions are present. Handoff attempted but platform prevented creating/assigning a frontend task from this session.
- npm run typecheck: passed.
- PR notes include preview verification instructions: included below and in docs/roadmap/v2.7.md.

## Cloudflare Preview Verification Required Before Merge
For this docs-only PR, no UI/API behavior changed. For the v2.7 feature release PR(s), reviewers must verify in Cloudflare preview and post a PR comment with screenshots/evidence for:
- WebDAV smoke test against /dav/ using a dedicated API key: mount-root PROPFIND, workspace-folder PROPFIND, PUT then GET/HEAD of a small text file, MKCOL, MOVE, COPY, and DELETE.
- Archive UI flows: compress selected files/folders, extract a small .zip, show the resulting background job, and show a failed invalid or oversized archive job.
- Generic /tasks page states: active, completed, failed, cancelable, and retryable jobs, with archive jobs displayed generically by type/status/progress.
- Evidence that invalid archive extraction creates no partial files in the selected folder.