### PR TITLE
feat: harden WebDAV client compatibility

### DIFF
--- a/server/routes/webdav.integration.test.ts
+++ b/server/routes/webdav.integration.test.ts
@@ -19,6 +19,7 @@ const storage = {
 beforeEach(() => {
   vi.restoreAllMocks()
   vi.spyOn(S3Service.prototype, 'presignDownload').mockResolvedValue('https://download.example.com/file.txt')
+  vi.spyOn(S3Service.prototype, 'getObjectBytes').mockResolvedValue(new TextEncoder().encode('hello webdav'))
   vi.spyOn(S3Service.prototype, 'putObject').mockResolvedValue(undefined)
   vi.spyOn(S3Service.prototype, 'copyObject').mockResolvedValue(undefined)
 })
@@ -169,6 +170,19 @@ describe('WebDAV API', () => {
     const xml = await docs.text()
     expect(xml).toContain(`/dav/${workspace.slug}/Docs/`)
     expect(xml).toContain(`/dav/${workspace.slug}/Docs/readme.txt`)
+    for (const property of [
+      'displayname',
+      'creationdate',
+      'getetag',
+      'getcontentlength',
+      'getcontenttype',
+      'getlastmodified',
+      'resourcetype',
+      'supportedlock',
+      'lockdiscovery',
+    ]) {
+      expect(xml).toContain(`<D:${property}`)
+    }
 
     const byId = await app.request(`/dav/${workspace.id}/`, {
       method: 'PROPFIND',
@@ -200,7 +214,7 @@ describe('WebDAV API', () => {
     expect(hiddenRes.status).toBe(404)
   })
 
-  it('GET redirects to storage and HEAD returns file headers', async () => {
+  it('GET returns file bytes directly and HEAD returns coherent file headers', async () => {
     const { app, db, auth } = await createTestApp()
     await authedHeaders(app)
     await seedStorage(db)
@@ -216,13 +230,122 @@ describe('WebDAV API', () => {
     expect(head.status).toBe(200)
     expect(head.headers.get('Content-Type')).toBe('text/plain')
     expect(head.headers.get('Content-Length')).toBe('12')
+    expect(head.headers.get('ETag')).toMatch(/^"readme-12-\d+"$/)
+    expect(head.headers.get('Last-Modified')).toBeTruthy()
 
     const get = await app.request(`/dav/${workspace.slug}/readme.txt`, {
       method: 'GET',
       headers: basicHeaders(account.email, key),
     })
-    expect(get.status).toBe(302)
-    expect(get.headers.get('Location')).toBe('https://download.example.com/file.txt')
+    expect(get.status).toBe(200)
+    expect(get.headers.get('Content-Type')).toBe('text/plain')
+    expect(get.headers.get('Content-Length')).toBe('12')
+    expect(get.headers.get('ETag')).toBe(head.headers.get('ETag'))
+    expect(get.headers.get('Last-Modified')).toBe(head.headers.get('Last-Modified'))
+    expect(get.headers.get('Location')).toBeNull()
+    expect(await get.text()).toBe('hello webdav')
+    expect(S3Service.prototype.presignDownload).not.toHaveBeenCalled()
+    expect(S3Service.prototype.getObjectBytes).toHaveBeenCalledWith(
+      expect.objectContaining({ id: storage.id }),
+      'objects/readme.txt',
+    )
+  })
+
+  it('GET supports valid byte ranges and rejects invalid ranges', async () => {
+    const { app, db, auth } = await createTestApp()
+    await authedHeaders(app)
+    await seedStorage(db)
+    const workspace = await org(db)
+    const account = await userAccount(db)
+    const key = await apiKey(auth, account.id, { webdav: ['read'] })
+    await file(db, workspace.id, { id: 'range', name: 'range.txt', size: 12 })
+    vi.mocked(S3Service.prototype.getObjectBytes).mockResolvedValueOnce(new TextEncoder().encode('hello'))
+
+    const partial = await app.request(`/dav/${workspace.slug}/range.txt`, {
+      method: 'GET',
+      headers: basicHeaders(account.email, key, { Range: 'bytes=0-4' }),
+    })
+    expect(partial.status).toBe(206)
+    expect(partial.headers.get('Content-Range')).toBe('bytes 0-4/12')
+    expect(partial.headers.get('Content-Length')).toBe('5')
+    expect(await partial.text()).toBe('hello')
+    expect(S3Service.prototype.getObjectBytes).toHaveBeenCalledWith(
+      expect.objectContaining({ id: storage.id }),
+      'objects/range.txt',
+      'bytes=0-4',
+    )
+
+    const invalid = await app.request(`/dav/${workspace.slug}/range.txt`, {
+      method: 'GET',
+      headers: basicHeaders(account.email, key, { Range: 'bytes=99-100' }),
+    })
+    expect(invalid.status).toBe(416)
+    expect(invalid.headers.get('Content-Range')).toBe('bytes */12')
+
+    vi.mocked(S3Service.prototype.getObjectBytes).mockResolvedValueOnce(new TextEncoder().encode('dav'))
+    const suffix = await app.request(`/dav/${workspace.slug}/range.txt`, {
+      method: 'GET',
+      headers: basicHeaders(account.email, key, { Range: 'bytes=-3' }),
+    })
+    expect(suffix.status).toBe(206)
+    expect(suffix.headers.get('Content-Range')).toBe('bytes 9-11/12')
+    expect(await suffix.text()).toBe('dav')
+  })
+
+  it('honors ETag preconditions and changes ETag after overwrite', async () => {
+    const { app, db, auth } = await createTestApp()
+    await authedHeaders(app)
+    await seedStorage(db)
+    const workspace = await org(db)
+    const account = await userAccount(db)
+    const key = await apiKey(auth, account.id, { webdav: ['read', 'write'] })
+    await file(db, workspace.id, { id: 'precondition', name: 'precondition.txt', size: 12 })
+
+    const head = await app.request(`/dav/${workspace.slug}/precondition.txt`, {
+      method: 'HEAD',
+      headers: basicHeaders(account.email, key),
+    })
+    const etag = head.headers.get('ETag')
+    expect(etag).toBeTruthy()
+
+    const matched = await app.request(`/dav/${workspace.slug}/precondition.txt`, {
+      method: 'HEAD',
+      headers: basicHeaders(account.email, key, { 'If-Match': etag ?? '' }),
+    })
+    expect(matched.status).toBe(200)
+
+    const notModified = await app.request(`/dav/${workspace.slug}/precondition.txt`, {
+      method: 'GET',
+      headers: basicHeaders(account.email, key, { 'If-None-Match': etag ?? '' }),
+    })
+    expect(notModified.status).toBe(304)
+
+    const rejected = await app.request(`/dav/${workspace.slug}/precondition.txt`, {
+      method: 'PUT',
+      headers: basicHeaders(account.email, key, { 'If-Match': '"stale"', 'Content-Type': 'text/plain' }),
+      body: 'new bytes',
+    })
+    expect(rejected.status).toBe(412)
+
+    const noneMatchRejected = await app.request(`/dav/${workspace.slug}/precondition.txt`, {
+      method: 'PUT',
+      headers: basicHeaders(account.email, key, { 'If-None-Match': etag ?? '', 'Content-Type': 'text/plain' }),
+      body: 'new bytes',
+    })
+    expect(noneMatchRejected.status).toBe(412)
+
+    const overwrite = await app.request(`/dav/${workspace.slug}/precondition.txt`, {
+      method: 'PUT',
+      headers: basicHeaders(account.email, key, { 'If-Match': etag ?? '', 'Content-Type': 'text/plain' }),
+      body: 'new bytes',
+    })
+    expect(overwrite.status).toBe(204)
+
+    const updated = await app.request(`/dav/${workspace.slug}/precondition.txt`, {
+      method: 'HEAD',
+      headers: basicHeaders(account.email, key),
+    })
+    expect(updated.headers.get('ETag')).not.toBe(etag)
   })
 
   it('OPTIONS advertises DAV methods', async () => {
@@ -461,9 +584,107 @@ describe('WebDAV API', () => {
 
     const existing = await app.request(`/dav/${workspace.slug}/source.txt`, {
       method: 'COPY',
-      headers: basicHeaders(account.email, key, { Destination: `http://localhost/dav/${workspace.slug}/target.txt` }),
+      headers: basicHeaders(account.email, key, {
+        Destination: `http://localhost/dav/${workspace.slug}/target.txt`,
+        Overwrite: 'F',
+      }),
     })
     expect(existing.status).toBe(412)
+  })
+
+  it('returns WebDAV path errors for missing GET and DELETE targets', async () => {
+    const { app, db, auth } = await createTestApp()
+    await authedHeaders(app)
+    const workspace = await org(db)
+    const account = await userAccount(db)
+    const key = await apiKey(auth, account.id, { webdav: ['read', 'write'] })
+
+    const missingGet = await app.request(`/dav/${workspace.slug}/missing.txt`, {
+      method: 'GET',
+      headers: basicHeaders(account.email, key),
+    })
+    expect(missingGet.status).toBe(404)
+
+    const missingDelete = await app.request(`/dav/${workspace.slug}/missing.txt`, {
+      method: 'DELETE',
+      headers: basicHeaders(account.email, key),
+    })
+    expect(missingDelete.status).toBe(404)
+  })
+
+  it('MOVE honors Overwrite header for existing destinations', async () => {
+    const { app, db, auth } = await createTestApp()
+    await authedHeaders(app)
+    await seedStorage(db)
+    const workspace = await org(db)
+    const account = await userAccount(db)
+    const key = await apiKey(auth, account.id, { webdav: ['write'] })
+    await file(db, workspace.id, { id: 'move-source', name: 'move-source.txt' })
+    await file(db, workspace.id, { id: 'move-target', name: 'move-target.txt' })
+
+    const blocked = await app.request(`/dav/${workspace.slug}/move-source.txt`, {
+      method: 'MOVE',
+      headers: basicHeaders(account.email, key, {
+        Destination: `http://localhost/dav/${workspace.slug}/move-target.txt`,
+        Overwrite: 'F',
+      }),
+    })
+    expect(blocked.status).toBe(412)
+
+    const replaced = await app.request(`/dav/${workspace.slug}/move-source.txt`, {
+      method: 'MOVE',
+      headers: basicHeaders(account.email, key, {
+        Destination: `http://localhost/dav/${workspace.slug}/move-target.txt`,
+      }),
+    })
+    expect(replaced.status).toBe(201)
+    const rows = await db.all<{ id: string; name: string; status: string }>(
+      sql`SELECT id, name, status FROM matters WHERE id IN ('move-source', 'move-target') ORDER BY id`,
+    )
+    expect(rows).toEqual([
+      { id: 'move-source', name: 'move-target.txt', status: 'active' },
+      { id: 'move-target', name: 'move-target.txt', status: 'trashed' },
+    ])
+  })
+
+  it('COPY honors Overwrite header for existing destinations and rejects collection copy explicitly', async () => {
+    const { app, db, auth } = await createTestApp()
+    await authedHeaders(app)
+    await seedStorage(db)
+    const workspace = await org(db)
+    const account = await userAccount(db)
+    const key = await apiKey(auth, account.id, { webdav: ['write'] })
+    await file(db, workspace.id, { id: 'copy-source', name: 'copy-source.txt', size: 12 })
+    await file(db, workspace.id, { id: 'copy-target', name: 'copy-target.txt' })
+    await folder(db, workspace.id, { id: 'copy-folder', name: 'Copy Folder' })
+
+    const blocked = await app.request(`/dav/${workspace.slug}/copy-source.txt`, {
+      method: 'COPY',
+      headers: basicHeaders(account.email, key, {
+        Destination: `http://localhost/dav/${workspace.slug}/copy-target.txt`,
+        Overwrite: 'F',
+      }),
+    })
+    expect(blocked.status).toBe(412)
+
+    const replaced = await app.request(`/dav/${workspace.slug}/copy-source.txt`, {
+      method: 'COPY',
+      headers: basicHeaders(account.email, key, {
+        Destination: `http://localhost/dav/${workspace.slug}/copy-target.txt`,
+      }),
+    })
+    expect(replaced.status).toBe(201)
+    const rows = await db.all<{ status: string }>(sql`SELECT status FROM matters WHERE id = 'copy-target'`)
+    expect(rows[0]?.status).toBe('trashed')
+
+    const collection = await app.request(`/dav/${workspace.slug}/Copy%20Folder`, {
+      method: 'COPY',
+      headers: basicHeaders(account.email, key, {
+        Destination: `http://localhost/dav/${workspace.slug}/Copied%20Folder`,
+      }),
+    })
+    expect(collection.status).toBe(403)
+    expect(await collection.text()).toContain('Collection COPY is not supported')
   })
 
   it('COPY rolls back quota reservation when storage copy fails', async () => {

--- a/server/routes/webdav.ts
+++ b/server/routes/webdav.ts
@@ -28,7 +28,7 @@ import {
   WebDavPathError,
   type WebDavTarget,
 } from '../services/webdav-path'
-import { matterEntry, mountRootEntry, multistatus, workspaceEntry } from '../services/webdav-xml'
+import { davEtag, matterEntry, mountRootEntry, multistatus, workspaceEntry } from '../services/webdav-xml'
 
 const s3 = new S3Service()
 const READ_METHODS = new Set(['OPTIONS', 'PROPFIND', 'GET', 'HEAD'])
@@ -145,6 +145,87 @@ function requireWorkspace(target: WebDavTarget) {
   return target.workspace
 }
 
+function matterEtag(matter: NonNullable<WebDavTarget['matter']>): string {
+  return davEtag(matter.id, matter.size ?? 0, matter.updatedAt)
+}
+
+function fileHeaders(matter: NonNullable<WebDavTarget['matter']>): Headers {
+  return new Headers({
+    'Content-Type': matter.type,
+    'Content-Length': String(matter.size ?? 0),
+    ETag: matterEtag(matter),
+    'Last-Modified': matter.updatedAt.toUTCString(),
+    'Accept-Ranges': 'bytes',
+  })
+}
+
+function validatorHeaders(matter: NonNullable<WebDavTarget['matter']>): Headers {
+  return new Headers({ ETag: matterEtag(matter), 'Last-Modified': matter.updatedAt.toUTCString() })
+}
+
+function etagMatches(header: string, etag: string): boolean {
+  return header
+    .split(',')
+    .map((value) => value.trim())
+    .some((value) => value === '*' || value === etag)
+}
+
+function preconditionResponse(c: DavContext, matter: NonNullable<WebDavTarget['matter']>): Response | null {
+  const etag = matterEtag(matter)
+  const ifMatch = c.req.header('If-Match')
+  if (ifMatch && !etagMatches(ifMatch, etag)) return new Response(null, { status: 412 })
+
+  const ifNoneMatch = c.req.header('If-None-Match')
+  if (!ifNoneMatch || !etagMatches(ifNoneMatch, etag)) return null
+
+  if (c.req.method.toUpperCase() === 'GET' || c.req.method.toUpperCase() === 'HEAD') {
+    return new Response(null, { status: 304, headers: validatorHeaders(matter) })
+  }
+  return new Response(null, { status: 412 })
+}
+
+function missingPreconditionResponse(c: DavContext): Response | null {
+  if (c.req.header('If-Match')) return new Response(null, { status: 412 })
+  return null
+}
+
+interface ByteRange {
+  start: number
+  end: number
+}
+
+function parseByteRange(header: string | undefined, size: number): ByteRange | null {
+  if (!header) return { start: 0, end: size - 1 }
+  const match = /^bytes=(\d*)-(\d*)$/.exec(header)
+  if (!match || size <= 0) return null
+
+  const [, rawStart, rawEnd] = match
+  if (!rawStart && !rawEnd) return null
+
+  if (!rawStart) {
+    const suffix = Number(rawEnd)
+    if (!Number.isSafeInteger(suffix) || suffix <= 0) return null
+    return { start: Math.max(size - suffix, 0), end: size - 1 }
+  }
+
+  const start = Number(rawStart)
+  const end = rawEnd ? Number(rawEnd) : size - 1
+  if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end) || start > end || start >= size) return null
+  return { start, end: Math.min(end, size - 1) }
+}
+
+function rangeNotSatisfiable(size: number): Response {
+  return new Response(null, { status: 416, headers: { 'Content-Range': `bytes */${size}` } })
+}
+
+function overwriteAllowed(c: DavContext): boolean {
+  return (c.req.header('Overwrite') ?? 'T').toUpperCase() !== 'F'
+}
+
+function bytesBody(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer
+}
+
 const app = new Hono<Env>().on(
   ['OPTIONS', 'PROPFIND', 'GET', 'HEAD', 'PUT', 'DELETE', 'MKCOL', 'MOVE', 'COPY'],
   '/*',
@@ -215,17 +296,30 @@ async function readFile(c: DavContext, auth: DavAuth): Promise<Response> {
     const { matter } = await resolveExistingWebDavPath(db, auth.userId, davPath(c))
     if (!matter) throw new WebDavPathError('Not found', 404)
     if (matter.dirtype !== DirType.FILE) return c.text('Cannot read collection as file', 405)
+    const precondition = preconditionResponse(c, matter)
+    if (precondition) return precondition
+
     const storage = (await getStorage(db, matter.storageId)) as unknown as S3Storage | null
     if (!storage) return c.text('Storage not found', 404)
+    const headers = fileHeaders(matter)
 
     if (c.req.method.toUpperCase() === 'HEAD') {
-      return new Response(null, {
-        headers: { 'Content-Type': matter.type, 'Content-Length': String(matter.size ?? 0), ETag: matter.id },
-      })
+      return new Response(null, { headers })
     }
 
-    const url = await s3.presignDownload(storage, matter.object, matter.name)
-    return c.redirect(url, 302)
+    const size = matter.size ?? 0
+    const rangeHeader = c.req.header('Range')
+    if (!rangeHeader) {
+      const bytes = await s3.getObjectBytes(storage, matter.object)
+      return new Response(bytesBody(bytes), { headers })
+    }
+
+    const range = parseByteRange(rangeHeader, size)
+    if (!range) return rangeNotSatisfiable(size)
+    const bytes = await s3.getObjectBytes(storage, matter.object, `bytes=${range.start}-${range.end}`)
+    headers.set('Content-Length', String(range.end - range.start + 1))
+    headers.set('Content-Range', `bytes ${range.start}-${range.end}/${size}`)
+    return new Response(bytesBody(bytes), { status: 206, headers })
   } catch (e) {
     return davError(c, e)
   }
@@ -239,6 +333,8 @@ async function putFile(c: DavContext, auth: DavAuth): Promise<Response> {
     if (!target.name) return c.text('Cannot PUT a collection root', 405)
     if (target.matter && target.matter.dirtype !== DirType.FILE)
       return c.text('Cannot replace collection with file', 409)
+    const precondition = target.matter ? preconditionResponse(c, target.matter) : missingPreconditionResponse(c)
+    if (precondition) return precondition
     await ensureParentCollection(db, auth.userId, workspace.slug, target.parent)
 
     const bytes = new Uint8Array(await c.req.arrayBuffer())
@@ -342,14 +438,20 @@ async function moveMatter(c: DavContext, auth: DavAuth): Promise<Response> {
     const source = await resolveExistingWebDavPath(db, auth.userId, davPath(c))
     const sourceWorkspace = requireWorkspace(source)
     if (!source.matter) throw new WebDavPathError('Not found', 404)
+    const precondition = preconditionResponse(c, source.matter)
+    if (precondition) return precondition
     const destination = destinationPath(c)
     if (destination instanceof Response) return destination
     const target = await resolveWebDavPath(db, auth.userId, destination)
     const targetWorkspace = requireWorkspace(target)
     if (sourceWorkspace.id !== targetWorkspace.id) return c.text('Cross-workspace MOVE is not supported', 403)
     if (!target.name) return c.text('Cannot move to collection root', 405)
-    if (target.matter) return c.text('Already exists', 412)
+    if (target.matter) {
+      if (target.matter.id === source.matter.id) return new Response(null, { status: 204 })
+      if (!overwriteAllowed(c)) return c.text('Already exists', 412)
+    }
     await ensureParentCollection(db, auth.userId, targetWorkspace.slug, target.parent)
+    if (target.matter) await trashMatter(db, targetWorkspace.id, target.matter.id, auth.userId)
     await updateMatter(
       db,
       source.matter.id,
@@ -369,13 +471,16 @@ async function copyMatterRoute(c: DavContext, auth: DavAuth): Promise<Response> 
     const source = await resolveExistingWebDavPath(db, auth.userId, davPath(c))
     const sourceWorkspace = requireWorkspace(source)
     if (!source.matter) throw new WebDavPathError('Not found', 404)
+    const precondition = preconditionResponse(c, source.matter)
+    if (precondition) return precondition
+    if (source.matter.dirtype !== DirType.FILE) return c.text('Collection COPY is not supported', 403)
     const destination = destinationPath(c)
     if (destination instanceof Response) return destination
     const target = await resolveWebDavPath(db, auth.userId, destination)
     const targetWorkspace = requireWorkspace(target)
     if (sourceWorkspace.id !== targetWorkspace.id) return c.text('Cross-workspace COPY is not supported', 403)
     if (!target.name) return c.text('Cannot copy to collection root', 405)
-    if (target.matter) return c.text('Already exists', 412)
+    if (target.matter && !overwriteAllowed(c)) return c.text('Already exists', 412)
     await ensureParentCollection(db, auth.userId, targetWorkspace.slug, target.parent)
 
     let newObject = ''
@@ -394,6 +499,7 @@ async function copyMatterRoute(c: DavContext, auth: DavAuth): Promise<Response> 
         await s3.copyObject(storage, source.matter.object, storage, newObject)
       }
 
+      if (target.matter) await trashMatter(db, targetWorkspace.id, target.matter.id, auth.userId)
       const copy = await copyMatter(db, { ...source.matter, name: target.name }, target.parent, newObject, {
         onConflict: 'fail',
         userId: auth.userId,

--- a/server/services/s3.ts
+++ b/server/services/s3.ts
@@ -81,9 +81,10 @@ export class S3Service {
     }
   }
 
-  async getObjectBytes(storage: Storage, key: string): Promise<Uint8Array> {
+  async getObjectBytes(storage: Storage, key: string, range?: string): Promise<Uint8Array> {
     const client = this.createClient(storage)
-    const result = await client.send(new GetObjectCommand({ Bucket: storage.bucket, Key: key }))
+    const input = range ? { Bucket: storage.bucket, Key: key, Range: range } : { Bucket: storage.bucket, Key: key }
+    const result = await client.send(new GetObjectCommand(input))
     if (!result.Body) throw new Error('Empty body from object')
     return bodyToBytes(result.Body)
   }

--- a/server/services/webdav-xml.ts
+++ b/server/services/webdav-xml.ts
@@ -5,29 +5,40 @@ import { matterHref, workspaceHref } from './webdav-path'
 
 interface DavEntry {
   href: string
+  displayName: string
   collection: boolean
   contentType: string
   contentLength: number
+  createdAt: Date
   updatedAt: Date
+  etag: string
 }
 
 export function workspaceEntry(workspace: WebDavWorkspace): DavEntry {
+  const now = new Date()
   return {
     href: workspaceHref(workspace),
+    displayName: workspace.name,
     collection: true,
     contentType: 'httpd/unix-directory',
     contentLength: 0,
-    updatedAt: new Date(),
+    createdAt: now,
+    updatedAt: now,
+    etag: davEtag(workspace.id, 0, now),
   }
 }
 
 export function mountRootEntry(): DavEntry {
+  const now = new Date()
   return {
     href: '/dav/',
+    displayName: 'dav',
     collection: true,
     contentType: 'httpd/unix-directory',
     contentLength: 0,
-    updatedAt: new Date(),
+    createdAt: now,
+    updatedAt: now,
+    etag: davEtag('mount-root', 0, now),
   }
 }
 
@@ -35,10 +46,13 @@ export function matterEntry(workspace: WebDavWorkspace, matter: Matter): DavEntr
   const collection = matter.dirtype !== DirType.FILE
   return {
     href: collection ? `${matterHref(workspace, matter)}/` : matterHref(workspace, matter),
+    displayName: matter.name,
     collection,
     contentType: collection ? 'httpd/unix-directory' : matter.type,
     contentLength: matter.size ?? 0,
+    createdAt: matter.createdAt,
     updatedAt: matter.updatedAt,
+    etag: davEtag(matter.id, matter.size ?? 0, matter.updatedAt),
   }
 }
 
@@ -51,14 +65,23 @@ function response(entry: DavEntry): string {
     <D:href>${escapeXml(entry.href)}</D:href>
     <D:propstat>
       <D:prop>
+        <D:displayname>${escapeXml(entry.displayName)}</D:displayname>
+        <D:creationdate>${entry.createdAt.toISOString()}</D:creationdate>
+        <D:getetag>${escapeXml(entry.etag)}</D:getetag>
         <D:resourcetype>${entry.collection ? '<D:collection/>' : ''}</D:resourcetype>
         <D:getcontentlength>${entry.contentLength}</D:getcontentlength>
         <D:getcontenttype>${escapeXml(entry.contentType)}</D:getcontenttype>
         <D:getlastmodified>${entry.updatedAt.toUTCString()}</D:getlastmodified>
+        <D:supportedlock/>
+        <D:lockdiscovery/>
       </D:prop>
       <D:status>HTTP/1.1 200 OK</D:status>
     </D:propstat>
   </D:response>`
+}
+
+export function davEtag(id: string, size: number, updatedAt: Date): string {
+  return `"${id}-${size}-${updatedAt.getTime()}"`
 }
 
 function escapeXml(value: string): string {


### PR DESCRIPTION
## Summary
- serve WebDAV file GETs directly from storage with coherent HEAD/GET validators and range support
- expand PROPFIND DAV properties for common clients
- honor ETag preconditions and WebDAV Overwrite semantics for PUT/MOVE/COPY
- reject collection COPY explicitly instead of shallow-copying folders

## Verification
- npx vitest run server/routes/webdav.integration.test.ts
- npm run typecheck
- npm run lint