### PR TITLE
Add explicit return type annotation to cn function

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
-export function cn(...inputs: ClassValue[]) {
+export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs))
 }


### PR DESCRIPTION
## Background
The `cn` function in `src/lib/utils.ts` lacked an explicit return type annotation. Although TypeScript can infer the type, adding an explicit annotation improves code readability and maintainability, which aligns with TypeScript best practices for type safety and documentation.

## Changes
- Added explicit return type `: string` to the `cn` function definition in `src/lib/utils.ts`.

## Verification
- Run the TypeScript compiler (`tsc`) to ensure no compilation errors.
- Verify existing tests pass to confirm no functional changes, as this is a type-only update that preserves behavior.