### PR TITLE
ci(e2e): run core checks before cloud store flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,20 +57,22 @@ jobs:
       - run: pnpm lint
       - run: pnpm typecheck
       - run: pnpm openapi:downloader:check
-      - run: pnpm exec vitest run --project unit --coverage
+      - run: pnpm exec vitest run --project unit --coverage --coverage.reportsDirectory=coverage/unit
       - uses: codecov/codecov-action@v5
         if: always()
         with:
-          files: coverage/coverage-final.json
+          files: coverage/unit/coverage-final.json
           flags: unit
+          disable_search: true
           fail_ci_if_error: false
           handle_no_reports_found: true
-      - run: pnpm exec vitest run --project integration --coverage
+      - run: pnpm exec vitest run --project integration --coverage --coverage.reportsDirectory=coverage/integration
       - uses: codecov/codecov-action@v5
         if: always()
         with:
-          files: coverage/coverage-final.json
+          files: coverage/integration/coverage-final.json
           flags: integration
+          disable_search: true
           fail_ci_if_error: false
           handle_no_reports_found: true
       - run: mkdir -p dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,17 +92,19 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Run E2E
+        run: |
+          E2E_BASE_URL=http://localhost:5173 \
+          E2E_LOCAL_BASE_URL=http://localhost:5173 \
+          BETTER_AUTH_URL=http://localhost:5173 \
+          TRUSTED_ORIGINS=http://localhost:5173 \
+          pnpm e2e --project=desktop --grep-invert "Cloud store|Archive jobs|Site announcements"
       - name: Install cloudflared
-        if: env.E2E_CLOUD_BUSINESS_EMAIL_NODE != '' && env.E2E_CLOUD_BUSINESS_PASSWORD_NODE != ''
         run: |
           curl -L --fail --output cloudflared https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64
           chmod +x cloudflared
       - name: Run cloud E2E
-        if: env.E2E_CLOUD_BUSINESS_EMAIL_NODE != '' && env.E2E_CLOUD_BUSINESS_PASSWORD_NODE != ''
         run: CLOUDFLARED_BIN=./cloudflared pnpm e2e:cloud -- --runtime node
-      - name: Skip cloud E2E
-        if: env.E2E_CLOUD_BUSINESS_EMAIL_NODE == '' || env.E2E_CLOUD_BUSINESS_PASSWORD_NODE == ''
-        run: echo "Skipping Node cloud E2E because Business credentials are not configured."
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
@@ -115,6 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check
     env:
+      BETTER_AUTH_SECRET: ci-test-secret-that-is-at-least-32-chars
       E2E_CLOUD_BUSINESS_EMAIL_CF: ${{ secrets.E2E_CLOUD_BUSINESS_EMAIL_CF }}
       E2E_CLOUD_BUSINESS_PASSWORD_CF: ${{ secrets.E2E_CLOUD_BUSINESS_PASSWORD_CF }}
     steps:
@@ -125,17 +128,23 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Prepare local D1
+        run: pnpm exec wrangler d1 migrations apply DB --local
+      - name: Run E2E
+        run: |
+          E2E_RUNTIME=cf \
+          E2E_APP_PORT=6174 \
+          E2E_BASE_URL=http://localhost:6174 \
+          E2E_LOCAL_BASE_URL=http://localhost:6174 \
+          BETTER_AUTH_URL=http://localhost:6174 \
+          TRUSTED_ORIGINS=http://localhost:6174 \
+          pnpm e2e --project=desktop --grep-invert "Cloud store|Archive jobs|Site announcements"
       - name: Install cloudflared
-        if: env.E2E_CLOUD_BUSINESS_EMAIL_CF != '' && env.E2E_CLOUD_BUSINESS_PASSWORD_CF != ''
         run: |
           curl -L --fail --output cloudflared https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64
           chmod +x cloudflared
       - name: Run cloud E2E
-        if: env.E2E_CLOUD_BUSINESS_EMAIL_CF != '' && env.E2E_CLOUD_BUSINESS_PASSWORD_CF != ''
         run: CLOUDFLARED_BIN=./cloudflared pnpm e2e:cloud:cf
-      - name: Skip cloud E2E
-        if: env.E2E_CLOUD_BUSINESS_EMAIL_CF == '' || env.E2E_CLOUD_BUSINESS_PASSWORD_CF == ''
-        run: echo "Skipping CF cloud E2E because Business credentials are not configured."
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,15 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Prepare local D1
         run: pnpm exec wrangler d1 migrations apply DB --local
+      - name: Prepare CF E2E env
+        run: |
+          cat > .dev.vars <<'EOF'
+          BETTER_AUTH_SECRET=ci-test-secret-that-is-at-least-32-chars
+          BETTER_AUTH_URL=http://localhost:6174
+          TRUSTED_ORIGINS=http://localhost:6174
+          ZPAN_CLOUD_URL=https://zpan-cloud-staging.saltbo.workers.dev
+          VITE_ZPAN_CLOUD_URL=https://zpan-cloud-staging.saltbo.workers.dev
+          EOF
       - name: Run E2E
         run: |
           E2E_RUNTIME=cf \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,17 +94,28 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Run E2E
         run: |
-          E2E_BASE_URL=http://localhost:5173 \
-          E2E_LOCAL_BASE_URL=http://localhost:5173 \
-          BETTER_AUTH_URL=http://localhost:5173 \
-          TRUSTED_ORIGINS=http://localhost:5173 \
+          E2E_APP_PORT=5185 \
+          E2E_BASE_URL=http://localhost:5185 \
+          E2E_LOCAL_BASE_URL=http://localhost:5185 \
+          E2E_S3_MOCK=1 \
+          E2E_STORAGE_ENDPOINT=http://127.0.0.1:9191 \
+          E2E_STORAGE_BUCKET=e2e-test \
+          E2E_STORAGE_REGION=auto \
+          E2E_STORAGE_ACCESS_KEY=e2e-access-key \
+          E2E_STORAGE_SECRET_KEY=e2e-secret-key \
+          BETTER_AUTH_URL=http://localhost:5185 \
+          TRUSTED_ORIGINS=http://localhost:5185 \
           pnpm e2e --project=desktop --grep-invert "Cloud store|Archive jobs|Site announcements"
       - name: Install cloudflared
         run: |
           curl -L --fail --output cloudflared https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64
           chmod +x cloudflared
       - name: Run cloud E2E
-        run: CLOUDFLARED_BIN=./cloudflared pnpm e2e:cloud -- --runtime node
+        run: |
+          ZPAN_CLOUD_URL=https://zpan-cloud-staging.saltbo.workers.dev \
+          VITE_ZPAN_CLOUD_URL=https://zpan-cloud-staging.saltbo.workers.dev \
+          CLOUDFLARED_BIN=./cloudflared \
+          pnpm e2e:cloud -- --runtime node
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
@@ -134,26 +145,41 @@ jobs:
         run: |
           cat > .dev.vars <<'EOF'
           BETTER_AUTH_SECRET=ci-test-secret-that-is-at-least-32-chars
-          BETTER_AUTH_URL=http://localhost:6174
-          TRUSTED_ORIGINS=http://localhost:6174
+          BETTER_AUTH_URL=http://localhost:5185
+          TRUSTED_ORIGINS=http://localhost:5185
           ZPAN_CLOUD_URL=https://zpan-cloud-staging.saltbo.workers.dev
           VITE_ZPAN_CLOUD_URL=https://zpan-cloud-staging.saltbo.workers.dev
+          E2E_STORAGE_ENDPOINT=http://127.0.0.1:9191
+          E2E_STORAGE_BUCKET=e2e-test
+          E2E_STORAGE_REGION=auto
+          E2E_STORAGE_ACCESS_KEY=e2e-access-key
+          E2E_STORAGE_SECRET_KEY=e2e-secret-key
           EOF
       - name: Run E2E
         run: |
           E2E_RUNTIME=cf \
-          E2E_APP_PORT=6174 \
-          E2E_BASE_URL=http://localhost:6174 \
-          E2E_LOCAL_BASE_URL=http://localhost:6174 \
-          BETTER_AUTH_URL=http://localhost:6174 \
-          TRUSTED_ORIGINS=http://localhost:6174 \
+          E2E_APP_PORT=5185 \
+          E2E_BASE_URL=http://localhost:5185 \
+          E2E_LOCAL_BASE_URL=http://localhost:5185 \
+          E2E_S3_MOCK=1 \
+          E2E_STORAGE_ENDPOINT=http://127.0.0.1:9191 \
+          E2E_STORAGE_BUCKET=e2e-test \
+          E2E_STORAGE_REGION=auto \
+          E2E_STORAGE_ACCESS_KEY=e2e-access-key \
+          E2E_STORAGE_SECRET_KEY=e2e-secret-key \
+          BETTER_AUTH_URL=http://localhost:5185 \
+          TRUSTED_ORIGINS=http://localhost:5185 \
           pnpm e2e --project=desktop --grep-invert "Cloud store|Archive jobs|Site announcements"
       - name: Install cloudflared
         run: |
           curl -L --fail --output cloudflared https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64
           chmod +x cloudflared
       - name: Run cloud E2E
-        run: CLOUDFLARED_BIN=./cloudflared pnpm e2e:cloud:cf
+        run: |
+          ZPAN_CLOUD_URL=https://zpan-cloud-staging.saltbo.workers.dev \
+          VITE_ZPAN_CLOUD_URL=https://zpan-cloud-staging.saltbo.workers.dev \
+          CLOUDFLARED_BIN=./cloudflared \
+          pnpm e2e:cloud:cf
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/e2e/cloud-store.spec.ts
+++ b/e2e/cloud-store.spec.ts
@@ -276,7 +276,7 @@ async function expectCloudOk(response: APIResponse, message: string) {
 }
 
 async function unbindCurrentCloudBinding() {
-  const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:5173'
+  const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:5185'
   const headers = { Origin: new URL(baseURL).origin }
   const request = await playwrightRequest.newContext({ baseURL })
   try {

--- a/e2e/cloud-store.spec.ts
+++ b/e2e/cloud-store.spec.ts
@@ -461,7 +461,6 @@ async function browserJson<T>(page: Page, method: 'GET' | 'POST', url: string, d
         await page.waitForTimeout(stripeRateLimitRetryDelays[attempt] ?? 0)
         continue
       }
-      skipOnLiveCloudInfrastructureError(error)
 
       if (isTransientBrowserJsonError(error) && attempt < retryDelays.length) {
         await page.waitForTimeout(retryDelays[attempt] ?? 0)
@@ -492,22 +491,7 @@ async function cloudJson<T>(
 async function expectResponseStatus(response: ResponseLike, status: number) {
   if (response.status() === status) return
   const text = await response.text()
-  skipOnLiveCloudInfrastructureText(text)
   expect(response.status(), `expected ${status}, got ${response.status()}: ${text}`).toBe(status)
-}
-
-function skipOnLiveCloudInfrastructureError(error: unknown) {
-  if (!(error instanceof Error)) return
-  skipOnLiveCloudInfrastructureText(error.message)
-}
-
-function skipOnLiveCloudInfrastructureText(text: string) {
-  if (text.includes('request_rate_limit_exceeded')) {
-    test.skip(true, 'Cloud staging Stripe API is rate limited; retry the live Cloud E2E after the limit window resets.')
-  }
-  if (text.includes('trycloudflare.com | 502: Bad gateway')) {
-    test.skip(true, 'Cloudflare quick tunnel returned 502 for the live Node Cloud E2E; retry the job.')
-  }
 }
 
 function isPlaywrightSkipError(error: unknown) {

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -8,7 +8,7 @@ import Database from 'better-sqlite3'
 import { hashPassword } from '../server/lib/password'
 import { ADMIN_EMAIL, ADMIN_PASSWORD } from './helpers'
 
-const localBaseUrl = process.env.E2E_LOCAL_BASE_URL ?? 'http://localhost:5173'
+const localBaseUrl = process.env.E2E_LOCAL_BASE_URL ?? 'http://localhost:5185'
 const defaultOrgQuota = process.env.E2E_DEFAULT_ORG_QUOTA ?? String(1024 * 1024 * 1024)
 
 const storageConfig = {

--- a/e2e/image-host.spec.ts
+++ b/e2e/image-host.spec.ts
@@ -8,12 +8,24 @@
  * fake storage endpoint. All other API calls go through the real server.
  */
 
-import { expect, test } from '@playwright/test'
+import { type APIResponse, expect, test } from '@playwright/test'
 import { expandSignUpForm } from './helpers'
 
 const EMAIL = () => `ihost-${Date.now()}@example.com`
 const USERNAME = () => `ihost${Date.now()}`
 const PASSWORD = 'password123456'
+
+async function expectApiOk(response: APIResponse, label: string) {
+  if (response.ok()) return
+  const body = await response.text().catch(() => '')
+  expect(response.ok(), `${label} failed with ${response.status()}: ${body}`).toBe(true)
+}
+
+async function openImageRowActions(page: import('@playwright/test').Page, fileName: string) {
+  const row = page.getByRole('row', { name: new RegExp(fileName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')) })
+  await expect(row).toBeVisible({ timeout: 10000 })
+  await row.getByRole('button').last().click()
+}
 
 async function signUpAndGoToImageHost(page: import('@playwright/test').Page) {
   await page.goto('/sign-up')
@@ -104,13 +116,11 @@ test.describe('Image Host gallery golden path @all', () => {
     })
 
     // Wait for the presign + confirm API calls to complete
-    await page
-      .waitForResponse((r) => r.url().includes('/api/ihost/images') && r.request().method() === 'POST', {
-        timeout: 10000,
-      })
-      .catch(() => {
-        // Upload step may not succeed in all CI environments — that's OK
-      })
+    const uploadResp = await page.waitForResponse(
+      (r) => r.url().includes('/api/ihost/images') && r.request().method() === 'POST',
+      { timeout: 10000 },
+    )
+    await expectApiOk(uploadResp, 'Image upload')
 
     // Grid view should be the default
     // Switch to table view
@@ -139,10 +149,7 @@ test.describe('Image Host gallery golden path @all', () => {
       headers: { 'Content-Type': 'application/json' },
       data: { path: 'e2e-copy-test.png', mime: 'image/png', size: 100 },
     })
-    if (!presignResp.ok()) {
-      test.skip(true, 'Could not seed image via API — skipping copy URL test')
-      return
-    }
+    await expectApiOk(presignResp, 'Seed image presign')
     const { id: draftId } = await presignResp.json()
 
     // Confirm the draft (simulate successful S3 upload)
@@ -150,42 +157,18 @@ test.describe('Image Host gallery golden path @all', () => {
       headers: { 'Content-Type': 'application/json' },
       data: { action: 'confirm' },
     })
-    if (!confirmResp.ok()) {
-      test.skip(true, 'Could not confirm draft — skipping copy URL test')
-      return
-    }
+    await expectApiOk(confirmResp, 'Confirm seeded image')
 
     // Reload to see the seeded image
     await page.reload()
     await page.waitForLoadState('networkidle')
 
-    // Hover over the first image card to reveal actions
-    const firstCard = page.locator('[data-testid="file-card"], [role="article"]').first()
-    if (await firstCard.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await firstCard.hover()
+    await openImageRowActions(page, 'e2e-copy-test.png')
+    await page.getByRole('menuitem', { name: /copy url/i }).hover()
+    await page.getByRole('menuitem', { name: /markdown/i }).click()
 
-      // Open the copy URL menu
-      const copyUrlBtn = page
-        .getByRole('button', { name: /copy url|copy link/i })
-        .or(page.getByText(/copy url/i))
-        .first()
-      if (await copyUrlBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
-        await copyUrlBtn.click()
-
-        // Click Markdown option
-        const markdownBtn = page
-          .getByRole('menuitem', { name: /markdown/i })
-          .or(page.getByText('Markdown'))
-          .first()
-        if (await markdownBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
-          await markdownBtn.click()
-
-          // Verify clipboard contains Markdown image syntax
-          const clipText = await page.evaluate(() => navigator.clipboard.readText())
-          expect(clipText).toMatch(/!\[\]\(/)
-        }
-      }
-    }
+    const clipText = await page.evaluate(() => navigator.clipboard.readText())
+    expect(clipText).toMatch(/!\[\]\(/)
   })
 
   test('delete with Undo → cancel → item restored', async ({ page }) => {
@@ -196,42 +179,24 @@ test.describe('Image Host gallery golden path @all', () => {
       headers: { 'Content-Type': 'application/json' },
       data: { path: 'e2e-delete-undo.png', mime: 'image/png', size: 100 },
     })
-    if (!presignResp.ok()) {
-      test.skip(true, 'Could not seed image — skipping delete/undo test')
-      return
-    }
+    await expectApiOk(presignResp, 'Seed image presign')
     const { id: draftId } = await presignResp.json()
     const confirmResp = await page.request.patch(`/api/ihost/images/${draftId}`, {
       headers: { 'Content-Type': 'application/json' },
       data: { action: 'confirm' },
     })
-    if (!confirmResp.ok()) {
-      test.skip(true, 'Could not confirm draft — skipping delete/undo test')
-      return
-    }
+    await expectApiOk(confirmResp, 'Confirm seeded image')
 
     await page.reload()
     await page.waitForLoadState('networkidle')
 
-    // Select and delete the item
-    const firstCard = page.locator('[data-testid="file-card"], [role="article"]').first()
-    if (!(await firstCard.isVisible({ timeout: 5000 }).catch(() => false))) {
-      test.skip(true, 'No image card visible — skipping delete/undo test')
-      return
-    }
-
-    // Right-click to get context menu with delete option
-    await firstCard.click({ button: 'right' })
+    await openImageRowActions(page, 'e2e-delete-undo.png')
     const deleteMenuItem = page.getByRole('menuitem', { name: /delete/i }).first()
-    if (await deleteMenuItem.isVisible({ timeout: 3000 }).catch(() => false)) {
-      await deleteMenuItem.click()
-    } else {
-      test.skip(true, 'No delete menu item found — skipping')
-      return
-    }
+    await expect(deleteMenuItem).toBeVisible({ timeout: 3000 })
+    await deleteMenuItem.click()
 
     // Undo toast should appear
-    const undoBtn = page.getByRole('button', { name: /undo/i })
+    const undoBtn = page.getByRole('button', { name: 'Undo', exact: true })
     await expect(undoBtn).toBeVisible({ timeout: 5000 })
 
     // Click Undo to cancel the deletion
@@ -249,36 +214,20 @@ test.describe('Image Host gallery golden path @all', () => {
       headers: { 'Content-Type': 'application/json' },
       data: { path: 'e2e-delete-perm.png', mime: 'image/png', size: 100 },
     })
-    if (!presignResp.ok()) {
-      test.skip(true, 'Could not seed image — skipping permanent delete test')
-      return
-    }
+    await expectApiOk(presignResp, 'Seed image presign')
     const { id: draftId } = await presignResp.json()
     const confirmResp = await page.request.patch(`/api/ihost/images/${draftId}`, {
       headers: { 'Content-Type': 'application/json' },
       data: { action: 'confirm' },
     })
-    if (!confirmResp.ok()) {
-      test.skip(true, 'Could not confirm draft — skipping permanent delete test')
-      return
-    }
+    await expectApiOk(confirmResp, 'Confirm seeded image')
 
     await page.reload()
     await page.waitForLoadState('networkidle')
 
-    const firstCard = page.locator('[data-testid="file-card"], [role="article"]').first()
-    if (!(await firstCard.isVisible({ timeout: 5000 }).catch(() => false))) {
-      test.skip(true, 'No image card visible — skipping permanent delete test')
-      return
-    }
-
-    // Delete the item
-    await firstCard.click({ button: 'right' })
+    await openImageRowActions(page, 'e2e-delete-perm.png')
     const deleteMenuItem = page.getByRole('menuitem', { name: /delete/i }).first()
-    if (!(await deleteMenuItem.isVisible({ timeout: 3000 }).catch(() => false))) {
-      test.skip(true, 'No delete menu item — skipping')
-      return
-    }
+    await expect(deleteMenuItem).toBeVisible({ timeout: 3000 })
     await deleteMenuItem.click()
 
     // Undo toast appears — wait for the 5s timer, then the DELETE API call fires

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from '@playwright/test'
 const isCF = process.env.E2E_RUNTIME === 'cf'
 const envFile = process.env.CI ? '' : '--env-file=.dev.vars'
 const chromeHostResolverRules = process.env.E2E_CHROME_HOST_RESOLVER_RULES
-const appPort = Number(process.env.E2E_APP_PORT ?? 5173)
+const appPort = Number(process.env.E2E_APP_PORT ?? 5185)
 const apiPort = Number(process.env.E2E_API_PORT ?? 8222)
 const s3MockPort = Number(process.env.E2E_S3_MOCK_PORT ?? 9191)
 const nodeCommand = JSON.stringify(process.execPath)
@@ -50,7 +50,7 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? 'github' : 'list',
   use: {
-    baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:5173',
+    baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:5185',
     headless: true,
     channel: process.env.CI ? 'chrome' : undefined,
     launchOptions: chromeHostResolverRules

--- a/scripts/run-cloud-e2e.mjs
+++ b/scripts/run-cloud-e2e.mjs
@@ -11,7 +11,7 @@ const spec = valueAfter('--spec') ?? 'cloud-store.spec.ts'
 const local = args.includes('--local')
 const withS3Mock = args.includes('--with-s3-mock')
 const cloudflared = process.env.CLOUDFLARED_BIN ?? 'cloudflared'
-const appPort = Number(process.env.E2E_APP_PORT ?? (runtime === 'cf' ? 6174 : 6173))
+const appPort = Number(process.env.E2E_APP_PORT ?? 5185)
 const apiPort = Number(process.env.E2E_API_PORT ?? 9222)
 const s3MockPort = Number(process.env.E2E_S3_MOCK_PORT ?? 9191)
 const localBaseUrl = `http://localhost:${appPort}`
@@ -21,8 +21,8 @@ const publicDns = new Resolver()
 publicDns.setServers(['1.1.1.1', '1.0.0.1'])
 
 const cloudEnv = {
-  ZPAN_CLOUD_URL: process.env.ZPAN_CLOUD_URL ?? 'https://zpan-cloud-staging.saltbo.workers.dev',
-  VITE_ZPAN_CLOUD_URL: process.env.VITE_ZPAN_CLOUD_URL ?? 'https://zpan-cloud-staging.saltbo.workers.dev',
+  ZPAN_CLOUD_URL: process.env.ZPAN_CLOUD_URL ?? 'http://localhost:5186',
+  VITE_ZPAN_CLOUD_URL: process.env.VITE_ZPAN_CLOUD_URL ?? 'http://localhost:5186',
 }
 
 const tunnel = local ? null : await startTunnel(localBaseUrl)

--- a/scripts/run-cloud-e2e.mjs
+++ b/scripts/run-cloud-e2e.mjs
@@ -24,6 +24,7 @@ const cloudEnv = {
   ZPAN_CLOUD_URL: process.env.ZPAN_CLOUD_URL ?? 'http://localhost:5186',
   VITE_ZPAN_CLOUD_URL: process.env.VITE_ZPAN_CLOUD_URL ?? 'http://localhost:5186',
 }
+const credentialsEnv = runtimeCloudCredentials(runtime)
 
 const tunnel = local ? null : await startTunnel(localBaseUrl)
 const tunnelHost = tunnel ? new URL(tunnel.url).hostname : ''
@@ -43,7 +44,7 @@ const e2eEnv = {
   ...cloudEnv,
   ...tunnelEnv,
   ...s3MockEnv(),
-  ...runtimeCloudCredentials(runtime),
+  ...credentialsEnv,
   ...(runtime === 'cf' ? { E2E_RUNTIME: 'cf' } : {}),
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,9 @@ export default defineConfig(({ mode }) => ({
       ? undefined
       : {
           zpan: {
+            optimizeDeps: {
+              exclude: ['@aws-sdk/client-s3', '@aws-sdk/s3-request-presigner'],
+            },
             resolve: {
               conditions: ['browser', 'workerd', 'worker', 'module', 'development|production'],
               mainFields: ['browser', 'module', 'jsnext:main', 'jsnext'],


### PR DESCRIPTION
## Summary
- run the regular desktop E2E suite before the live Cloud store E2E flow in both Node and CF jobs
- remove cloud E2E infrastructure skips so rate limits/tunnel errors fail after retries instead of turning green
- fail CI when required Cloud E2E credentials are missing instead of skipping the job

## Verification
- `pnpm e2e --project=desktop --grep-invert "Cloud store|Archive jobs|Site announcements" --list`
- `CI=1 BETTER_AUTH_SECRET=ci-test-secret-that-is-at-least-32-chars E2E_APP_PORT=6173 E2E_API_PORT=9222 E2E_BASE_URL=http://localhost:6173 E2E_LOCAL_BASE_URL=http://localhost:6173 BETTER_AUTH_URL=http://localhost:6173 TRUSTED_ORIGINS=http://localhost:6173 pnpm e2e e2e/auth.spec.ts --project=desktop`
- `CI=1 BETTER_AUTH_SECRET=ci-test-secret-that-is-at-least-32-chars E2E_APP_PORT=6173 E2E_API_PORT=9222 E2E_BASE_URL=http://localhost:6173 E2E_LOCAL_BASE_URL=http://localhost:6173 BETTER_AUTH_URL=http://localhost:6173 TRUSTED_ORIGINS=http://localhost:6173 pnpm e2e --project=desktop --grep-invert "Cloud store|Archive jobs|Site announcements"`