### PR TITLE
fix(telemetry): use built-in product reporting endpoint

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -10,7 +10,3 @@ TRUSTED_ORIGINS=http://localhost:5185
 
 # Local ZPan Cloud URL.
 ZPAN_CLOUD_URL=http://localhost:5186
-
-# Optional instance telemetry reporting.
-ZPAN_POSTHOG_HOST=https://e.zpan.space
-ZPAN_POSTHOG_PROJECT_TOKEN=

--- a/server/entry-node.ts
+++ b/server/entry-node.ts
@@ -77,14 +77,11 @@ setInterval(() => {
       await reportInstanceTelemetry({
         db: platform.db,
         config: {
-          posthogHost: process.env.ZPAN_POSTHOG_HOST,
-          posthogProjectToken: process.env.ZPAN_POSTHOG_PROJECT_TOKEN,
           configuredInstanceId: process.env.ZPAN_INSTANCE_ID,
         },
         cron: INSTANCE_TELEMETRY_CRON,
         runtime: {
           target: 'node/docker',
-          hostname: configuredTelemetryHostname(),
           osPlatform: process.platform,
           osArch: process.arch,
           osRelease: osRelease(),
@@ -96,9 +93,3 @@ setInterval(() => {
     }
   })()
 }, INSTANCE_TELEMETRY_INTERVAL_MS)
-
-function configuredTelemetryHostname(): string | undefined {
-  const instanceUrl = configuredPublicOrigin()
-  if (instanceUrl) return new URL(instanceUrl).hostname
-  return process.env.HOSTNAME
-}

--- a/server/scheduled-worker.test.ts
+++ b/server/scheduled-worker.test.ts
@@ -65,8 +65,6 @@ describe('handleScheduled', () => {
         BETTER_AUTH_URL: 'https://zpan.example',
         ZPAN_CLOUD_URL: 'https://cloud.example',
         ZPAN_INSTANCE_ID: 'configured-instance',
-        ZPAN_POSTHOG_HOST: 'https://e.zpan.space',
-        ZPAN_POSTHOG_PROJECT_TOKEN: 'ph-token',
       },
     )
 
@@ -74,14 +72,11 @@ describe('handleScheduled', () => {
     expect(reportInstanceTelemetry).toHaveBeenCalledWith({
       db: 'db',
       config: {
-        posthogHost: 'https://e.zpan.space',
-        posthogProjectToken: 'ph-token',
         configuredInstanceId: 'configured-instance',
       },
       cron: '0 */12 * * *',
       runtime: {
         target: 'cloudflare-worker',
-        hostname: 'zpan.example',
       },
     })
     expect(runLicensingRefresh).not.toHaveBeenCalled()

--- a/server/services/instance-telemetry.test.ts
+++ b/server/services/instance-telemetry.test.ts
@@ -18,7 +18,7 @@ describe('instance telemetry', () => {
     vi.mocked(getOrCreateInstanceId).mockReset()
   })
 
-  it('does not call the telemetry gateway when product token is disabled', async () => {
+  it('does not call the telemetry endpoint when product token is disabled', async () => {
     const fetchFn = vi.fn()
 
     const result = await reportInstanceTelemetry({
@@ -60,7 +60,6 @@ describe('instance telemetry', () => {
     expect(fetchFn).toHaveBeenCalledWith(INSTANCE_TELEMETRY_ENDPOINT, {
       method: 'POST',
       headers: {
-        authorization: `Bearer ${INSTANCE_TELEMETRY_PRODUCT_TOKEN}`,
         'content-type': 'application/json',
       },
       body: expect.any(String),
@@ -68,10 +67,10 @@ describe('instance telemetry', () => {
 
     const body = JSON.parse(fetchFn.mock.calls[0][1].body)
     expect(body).toMatchObject({
-      schema_version: 1,
+      api_key: INSTANCE_TELEMETRY_PRODUCT_TOKEN,
       event: INSTANCE_TELEMETRY_EVENT,
-      anonymous_id: 'inst-1',
-      sent_at: '2026-06-08T12:00:00.000Z',
+      distinct_id: 'inst-1',
+      timestamp: '2026-06-08T12:00:00.000Z',
       properties: {
         instance_id: 'inst-1',
         app_version: '0.0.1',

--- a/server/services/instance-telemetry.test.ts
+++ b/server/services/instance-telemetry.test.ts
@@ -1,7 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getOrCreateInstanceId } from '../licensing/instance-id'
 import type { Database } from '../platform/interface'
-import { INSTANCE_TELEMETRY_CRON, INSTANCE_TELEMETRY_EVENT, reportInstanceTelemetry } from './instance-telemetry'
+import {
+  INSTANCE_TELEMETRY_CRON,
+  INSTANCE_TELEMETRY_ENDPOINT,
+  INSTANCE_TELEMETRY_EVENT,
+  INSTANCE_TELEMETRY_PRODUCT_TOKEN,
+  reportInstanceTelemetry,
+} from './instance-telemetry'
 
 vi.mock('../licensing/instance-id', () => ({
   getOrCreateInstanceId: vi.fn(),
@@ -12,12 +18,12 @@ describe('instance telemetry', () => {
     vi.mocked(getOrCreateInstanceId).mockReset()
   })
 
-  it('does not call PostHog when config is disabled', async () => {
+  it('does not call the telemetry gateway when product token is disabled', async () => {
     const fetchFn = vi.fn()
 
     const result = await reportInstanceTelemetry({
       db: {} as Database,
-      config: { posthogHost: 'https://e.zpan.space' },
+      config: { productToken: '' },
       cron: INSTANCE_TELEMETRY_CRON,
       runtime: { target: 'cloudflare-worker' },
       fetchFn,
@@ -28,21 +34,18 @@ describe('instance telemetry', () => {
     expect(getOrCreateInstanceId).not.toHaveBeenCalled()
   })
 
-  it('captures the expected PostHog event when config is enabled', async () => {
+  it('captures the expected telemetry event with built-in endpoint and product token', async () => {
     vi.mocked(getOrCreateInstanceId).mockResolvedValue('inst-1')
     const fetchFn = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }))
 
     const result = await reportInstanceTelemetry({
       db: {} as Database,
       config: {
-        posthogHost: 'https://e.zpan.space/',
-        posthogProjectToken: 'ph-token',
         configuredInstanceId: 'configured-inst',
       },
       cron: INSTANCE_TELEMETRY_CRON,
       runtime: {
         target: 'node/docker',
-        hostname: 'zpan.example',
         osPlatform: 'linux',
         osArch: 'arm64',
         osRelease: '6.8.0',
@@ -54,23 +57,25 @@ describe('instance telemetry', () => {
     expect(result).toEqual({ reported: true })
     expect(getOrCreateInstanceId).toHaveBeenCalledWith({}, 'configured-inst')
     expect(fetchFn).toHaveBeenCalledTimes(1)
-    expect(fetchFn).toHaveBeenCalledWith('https://e.zpan.space/capture/', {
+    expect(fetchFn).toHaveBeenCalledWith(INSTANCE_TELEMETRY_ENDPOINT, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: {
+        authorization: `Bearer ${INSTANCE_TELEMETRY_PRODUCT_TOKEN}`,
+        'content-type': 'application/json',
+      },
       body: expect.any(String),
     })
 
     const body = JSON.parse(fetchFn.mock.calls[0][1].body)
     expect(body).toMatchObject({
-      api_key: 'ph-token',
+      schema_version: 1,
       event: INSTANCE_TELEMETRY_EVENT,
-      distinct_id: 'inst-1',
-      timestamp: '2026-06-08T12:00:00.000Z',
+      anonymous_id: 'inst-1',
+      sent_at: '2026-06-08T12:00:00.000Z',
       properties: {
         instance_id: 'inst-1',
         app_version: '0.0.1',
         runtime_target: 'node/docker',
-        hostname: 'zpan.example',
         os_platform: 'linux',
         os_arch: 'arm64',
         os_release: '6.8.0',

--- a/server/services/instance-telemetry.ts
+++ b/server/services/instance-telemetry.ts
@@ -3,18 +3,19 @@ import { getOrCreateInstanceId } from '../licensing/instance-id'
 import type { Database } from '../platform/interface'
 
 export const INSTANCE_TELEMETRY_CRON = '0 */12 * * *'
-export const INSTANCE_TELEMETRY_EVENT = 'zpan instance reported'
+export const INSTANCE_TELEMETRY_EVENT = 'heartbeat'
 export const INSTANCE_TELEMETRY_INTERVAL = '12h'
+export const INSTANCE_TELEMETRY_ENDPOINT = 'https://e.zpan.space/v1/events'
+export const INSTANCE_TELEMETRY_PRODUCT_TOKEN = 'pub_4709cd351f9bf91df7a4926d8ec835f423b0b2539a1d6f53'
 
 export interface InstanceTelemetryConfig {
-  posthogHost?: string
-  posthogProjectToken?: string
+  endpoint?: string
+  productToken?: string
   configuredInstanceId?: string
 }
 
 export interface InstanceTelemetryRuntime {
   target: 'cloudflare-worker' | 'node/docker'
-  hostname?: string
   osPlatform?: string
   osArch?: string
   osRelease?: string
@@ -34,46 +35,47 @@ export interface InstanceTelemetryResult {
   reason?: 'disabled'
 }
 
-interface PostHogCapturePayload {
-  api_key: string
+interface TelemetryCapturePayload {
+  schema_version: 1
   event: string
-  distinct_id: string
+  anonymous_id: string
   properties: Record<string, string>
-  timestamp: string
+  sent_at: string
 }
 
 export async function reportInstanceTelemetry(params: InstanceTelemetryParams): Promise<InstanceTelemetryResult> {
-  const posthogHost = params.config.posthogHost?.trim()
-  const posthogProjectToken = params.config.posthogProjectToken?.trim()
-  if (!posthogHost || !posthogProjectToken) return { reported: false, reason: 'disabled' }
+  const endpoint = (params.config.endpoint ?? INSTANCE_TELEMETRY_ENDPOINT).trim()
+  const productToken = (params.config.productToken ?? INSTANCE_TELEMETRY_PRODUCT_TOKEN).trim()
+  if (!endpoint || !productToken) return { reported: false, reason: 'disabled' }
 
   const instanceId = await getOrCreateInstanceId(params.db, params.config.configuredInstanceId)
   const timestamp = (params.now ?? new Date()).toISOString()
-  const payload = buildPostHogCapturePayload({
+  const payload = buildTelemetryPayload({
     instanceId,
-    posthogProjectToken,
     cron: params.cron,
     runtime: params.runtime,
     timestamp,
   })
 
-  const res = await (params.fetchFn ?? fetch)(posthogCaptureUrl(posthogHost), {
+  const res = await (params.fetchFn ?? fetch)(endpoint, {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: {
+      authorization: `Bearer ${productToken}`,
+      'content-type': 'application/json',
+    },
     body: JSON.stringify(payload),
   })
 
-  if (!res.ok) throw new Error(`posthog_capture_failed_${res.status}`)
+  if (!res.ok) throw new Error(`instance_telemetry_failed_${res.status}`)
   return { reported: true }
 }
 
-function buildPostHogCapturePayload(params: {
+function buildTelemetryPayload(params: {
   instanceId: string
-  posthogProjectToken: string
   cron: string
   runtime: InstanceTelemetryRuntime
   timestamp: string
-}): PostHogCapturePayload {
+}): TelemetryCapturePayload {
   const properties: Record<string, string> = {
     instance_id: params.instanceId,
     app_version: packageJson.version,
@@ -83,24 +85,19 @@ function buildPostHogCapturePayload(params: {
     reported_at: params.timestamp,
   }
 
-  addOptionalProperty(properties, 'hostname', params.runtime.hostname)
   addOptionalProperty(properties, 'os_platform', params.runtime.osPlatform)
   addOptionalProperty(properties, 'os_arch', params.runtime.osArch)
   addOptionalProperty(properties, 'os_release', params.runtime.osRelease)
 
   return {
-    api_key: params.posthogProjectToken,
+    schema_version: 1,
     event: INSTANCE_TELEMETRY_EVENT,
-    distinct_id: params.instanceId,
+    anonymous_id: params.instanceId,
     properties,
-    timestamp: params.timestamp,
+    sent_at: params.timestamp,
   }
 }
 
 function addOptionalProperty(properties: Record<string, string>, key: string, value: string | undefined): void {
   if (value) properties[key] = value
-}
-
-function posthogCaptureUrl(host: string): string {
-  return `${host.replace(/\/+$/, '')}/capture/`
 }

--- a/server/services/instance-telemetry.ts
+++ b/server/services/instance-telemetry.ts
@@ -5,7 +5,7 @@ import type { Database } from '../platform/interface'
 export const INSTANCE_TELEMETRY_CRON = '0 */12 * * *'
 export const INSTANCE_TELEMETRY_EVENT = 'heartbeat'
 export const INSTANCE_TELEMETRY_INTERVAL = '12h'
-export const INSTANCE_TELEMETRY_ENDPOINT = 'https://e.zpan.space/v1/events'
+export const INSTANCE_TELEMETRY_ENDPOINT = 'https://e.zpan.space/capture/'
 export const INSTANCE_TELEMETRY_PRODUCT_TOKEN = 'pub_4709cd351f9bf91df7a4926d8ec835f423b0b2539a1d6f53'
 
 export interface InstanceTelemetryConfig {
@@ -36,11 +36,11 @@ export interface InstanceTelemetryResult {
 }
 
 interface TelemetryCapturePayload {
-  schema_version: 1
+  api_key: string
   event: string
-  anonymous_id: string
+  distinct_id: string
   properties: Record<string, string>
-  sent_at: string
+  timestamp: string
 }
 
 export async function reportInstanceTelemetry(params: InstanceTelemetryParams): Promise<InstanceTelemetryResult> {
@@ -55,12 +55,12 @@ export async function reportInstanceTelemetry(params: InstanceTelemetryParams): 
     cron: params.cron,
     runtime: params.runtime,
     timestamp,
+    productToken,
   })
 
   const res = await (params.fetchFn ?? fetch)(endpoint, {
     method: 'POST',
     headers: {
-      authorization: `Bearer ${productToken}`,
       'content-type': 'application/json',
     },
     body: JSON.stringify(payload),
@@ -75,6 +75,7 @@ function buildTelemetryPayload(params: {
   cron: string
   runtime: InstanceTelemetryRuntime
   timestamp: string
+  productToken: string
 }): TelemetryCapturePayload {
   const properties: Record<string, string> = {
     instance_id: params.instanceId,
@@ -90,11 +91,11 @@ function buildTelemetryPayload(params: {
   addOptionalProperty(properties, 'os_release', params.runtime.osRelease)
 
   return {
-    schema_version: 1,
+    api_key: params.productToken,
     event: INSTANCE_TELEMETRY_EVENT,
-    anonymous_id: params.instanceId,
+    distinct_id: params.instanceId,
     properties,
-    sent_at: params.timestamp,
+    timestamp: params.timestamp,
   }
 }
 

--- a/workers/scheduled.ts
+++ b/workers/scheduled.ts
@@ -11,12 +11,8 @@ import { ZPAN_CLOUD_URL_DEFAULT } from '../shared/constants'
 // The full Env is defined in bootstrap.ts; this avoids circular imports.
 export interface ScheduledEnv {
   DB: D1Database
-  BETTER_AUTH_URL?: string
-  ZPAN_PUBLIC_ORIGIN?: string
   ZPAN_CLOUD_URL?: string
   ZPAN_INSTANCE_ID?: string
-  ZPAN_POSTHOG_HOST?: string
-  ZPAN_POSTHOG_PROJECT_TOKEN?: string
   [key: string]: unknown
 }
 
@@ -36,28 +32,15 @@ export async function handleScheduled(event: ScheduledTrigger, env: ScheduledEnv
     await reportInstanceTelemetry({
       db: platform.db,
       config: {
-        posthogHost: env.ZPAN_POSTHOG_HOST,
-        posthogProjectToken: env.ZPAN_POSTHOG_PROJECT_TOKEN,
         configuredInstanceId: env.ZPAN_INSTANCE_ID,
       },
       cron: event.cron,
       runtime: {
         target: 'cloudflare-worker',
-        hostname: configuredHostname(env),
       },
     })
     return
   }
 
   await runLicensingRefresh(platform.db, cloudBaseUrl)
-}
-
-function configuredHostname(env: ScheduledEnv): string | undefined {
-  const value = env.ZPAN_PUBLIC_ORIGIN ?? env.BETTER_AUTH_URL
-  if (!value) return undefined
-  try {
-    return new URL(value).hostname
-  } catch {
-    return undefined
-  }
 }


### PR DESCRIPTION
## Summary
- switch instance telemetry from user-provided PostHog env vars to the built-in reporting endpoint and product token
- send reports through the configured PostHog/ProxyHog capture endpoint at `https://e.zpan.space/capture/`
- remove telemetry env vars from `.dev.vars.example`
- stop sending hostname/domain-like data in anonymous telemetry

## Verification
- `curl https://e.zpan.space/capture/ ...` returned HTTP 200 `{"status":"Ok"}`
- `pnpm exec vitest run --project unit server/services/instance-telemetry.test.ts server/scheduled-worker.test.ts`
- `pnpm typecheck`
- `pnpm lint`

## Note
`https://e.zpan.space/v1/events` returns 404 because this domain is currently configured as a PostHog/ProxyHog capture endpoint, not the telemetry-gateway `/v1/events` service.