### PR TITLE
feat(admin): add diagonal license-edition corner ribbon to admin layout

### DIFF
--- a/src/components/billing/LicenseRibbon.test.tsx
+++ b/src/components/billing/LicenseRibbon.test.tsx
@@ -1,0 +1,183 @@
+// Tests for src/components/billing/LicenseRibbon.tsx
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { LicenseRibbon } from './LicenseRibbon'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: Record<string, string>) => {
+      if (values) return `${key}:${Object.values(values).join(':')}`
+      return key
+    },
+  }),
+}))
+
+const useEntitlementMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/hooks/useEntitlement', () => ({
+  useEntitlement: useEntitlementMock,
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEntitlement(overrides: {
+  bound?: boolean
+  edition?: string | null
+  cloudDashboardUrl?: string | null
+  isLoading?: boolean
+}) {
+  return {
+    bound: false,
+    edition: null,
+    cloudDashboardUrl: null,
+    active: false,
+    hasFeature: vi.fn().mockReturnValue(false),
+    isLoading: false,
+    isError: false,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+afterEach(cleanup)
+
+beforeEach(() => {
+  useEntitlementMock.mockReset()
+})
+
+describe('LicenseRibbon — loading state', () => {
+  it('renders nothing while the entitlement query is loading', () => {
+    useEntitlementMock.mockReturnValue(makeEntitlement({ isLoading: true }))
+
+    const { container } = render(<LicenseRibbon />)
+
+    expect(container.firstChild).toBeNull()
+  })
+})
+
+describe('LicenseRibbon — Community edition (unbound)', () => {
+  beforeEach(() => {
+    useEntitlementMock.mockReturnValue(makeEntitlement({ bound: false }))
+  })
+
+  it('renders the ribbon container with license-ribbon slot', () => {
+    const { container } = render(<LicenseRibbon />)
+
+    expect(container.querySelector('[data-slot="license-ribbon"]')).toBeTruthy()
+  })
+
+  it('displays the Community label key', () => {
+    const { getByText } = render(<LicenseRibbon />)
+
+    expect(getByText('admin.licenseRibbon.community')).toBeTruthy()
+  })
+
+  it('links to the GitHub repo', () => {
+    const { getByRole } = render(<LicenseRibbon />)
+
+    expect(getByRole('link').getAttribute('href')).toBe('https://github.com/saltbo/zpan')
+  })
+
+  it('opens link in a new tab with rel="noopener noreferrer"', () => {
+    const { getByRole } = render(<LicenseRibbon />)
+    const link = getByRole('link')
+
+    expect(link.getAttribute('target')).toBe('_blank')
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+
+  it('has an accessible aria-label', () => {
+    const { getByRole } = render(<LicenseRibbon />)
+    const link = getByRole('link')
+
+    expect(link.getAttribute('aria-label')).toBeTruthy()
+  })
+
+  it('applies gray color (#64748B)', () => {
+    const { getByRole } = render(<LicenseRibbon />)
+    const link = getByRole('link') as HTMLElement
+
+    expect(link.style.backgroundColor).toBe('rgb(100, 116, 139)')
+  })
+})
+
+describe('LicenseRibbon — Pro edition', () => {
+  beforeEach(() => {
+    useEntitlementMock.mockReturnValue(makeEntitlement({ bound: true, edition: 'pro' }))
+  })
+
+  it('displays the Pro label key', () => {
+    const { getByText } = render(<LicenseRibbon />)
+
+    expect(getByText('admin.licenseRibbon.pro')).toBeTruthy()
+  })
+
+  it('links to the GitHub repo', () => {
+    const { getByRole } = render(<LicenseRibbon />)
+
+    expect(getByRole('link').getAttribute('href')).toBe('https://github.com/saltbo/zpan')
+  })
+
+  it('applies brand blue color (#1A73E8)', () => {
+    const { getByRole } = render(<LicenseRibbon />)
+    const link = getByRole('link') as HTMLElement
+
+    expect(link.style.backgroundColor).toBe('rgb(26, 115, 232)')
+  })
+})
+
+describe('LicenseRibbon — Business edition', () => {
+  it('displays the Business label key', () => {
+    useEntitlementMock.mockReturnValue(makeEntitlement({ bound: true, edition: 'business' }))
+
+    const { getByText } = render(<LicenseRibbon />)
+
+    expect(getByText('admin.licenseRibbon.business')).toBeTruthy()
+  })
+
+  it('links to cloud_dashboard_url when provided', () => {
+    useEntitlementMock.mockReturnValue(
+      makeEntitlement({ bound: true, edition: 'business', cloudDashboardUrl: 'https://cloud.example.com/dash' }),
+    )
+
+    const { getByRole } = render(<LicenseRibbon />)
+
+    expect(getByRole('link').getAttribute('href')).toBe('https://cloud.example.com/dash')
+  })
+
+  it('falls back to the default cloud dashboard URL when cloud_dashboard_url is absent', () => {
+    useEntitlementMock.mockReturnValue(makeEntitlement({ bound: true, edition: 'business', cloudDashboardUrl: null }))
+
+    const { getByRole } = render(<LicenseRibbon />)
+
+    expect(getByRole('link').getAttribute('href')).toBe('https://cloud.zpan.space/dashboard')
+  })
+
+  it('applies gold color (#F59E0B)', () => {
+    useEntitlementMock.mockReturnValue(makeEntitlement({ bound: true, edition: 'business' }))
+
+    const { getByRole } = render(<LicenseRibbon />)
+    const link = getByRole('link') as HTMLElement
+
+    expect(link.style.backgroundColor).toBe('rgb(245, 158, 11)')
+  })
+})
+
+describe('LicenseRibbon — bound but unknown edition falls back to Pro', () => {
+  it('uses Pro styles when edition is not "business"', () => {
+    useEntitlementMock.mockReturnValue(makeEntitlement({ bound: true, edition: null }))
+
+    const { getByText } = render(<LicenseRibbon />)
+
+    expect(getByText('admin.licenseRibbon.pro')).toBeTruthy()
+  })
+})

--- a/src/components/billing/LicenseRibbon.test.tsx
+++ b/src/components/billing/LicenseRibbon.test.tsx
@@ -95,11 +95,13 @@ describe('LicenseRibbon — Community edition (unbound)', () => {
     expect(link.getAttribute('rel')).toBe('noopener noreferrer')
   })
 
-  it('has an accessible aria-label', () => {
+  it('has an accessible aria-label naming the edition', () => {
     const { getByRole } = render(<LicenseRibbon />)
     const link = getByRole('link')
 
-    expect(link.getAttribute('aria-label')).toBeTruthy()
+    // t('admin.licenseRibbon.ariaLabel', { edition: 'admin.licenseRibbon.community' })
+    // → 'admin.licenseRibbon.ariaLabel:admin.licenseRibbon.community'
+    expect(link.getAttribute('aria-label')).toBe('admin.licenseRibbon.ariaLabel:admin.licenseRibbon.community')
   })
 
   it('applies gray color (#64748B)', () => {

--- a/src/components/billing/LicenseRibbon.tsx
+++ b/src/components/billing/LicenseRibbon.tsx
@@ -1,0 +1,49 @@
+import { useTranslation } from 'react-i18next'
+import { useEntitlement } from '@/hooks/useEntitlement'
+
+const GITHUB_URL = 'https://github.com/saltbo/zpan'
+const CLOUD_DASHBOARD_FALLBACK = 'https://cloud.zpan.space/dashboard'
+
+function editionKey(bound: boolean, edition: string | null): 'community' | 'pro' | 'business' {
+  if (!bound) return 'community'
+  return edition === 'business' ? 'business' : 'pro'
+}
+
+const RIBBON_STYLES: Record<'community' | 'pro' | 'business', string> = {
+  community: '#64748B',
+  pro: '#1A73E8',
+  business: '#F59E0B',
+}
+
+export function LicenseRibbon() {
+  const { t } = useTranslation()
+  const { bound, edition, cloudDashboardUrl, isLoading } = useEntitlement()
+
+  if (isLoading) return null
+
+  const key = editionKey(bound, edition)
+  const label = t(`admin.licenseRibbon.${key}`)
+  const color = RIBBON_STYLES[key]
+
+  let href: string
+  if (key === 'business') {
+    href = cloudDashboardUrl ?? CLOUD_DASHBOARD_FALLBACK
+  } else {
+    href = GITHUB_URL
+  }
+
+  return (
+    <div data-slot="license-ribbon" className="pointer-events-none fixed right-0 top-0 z-50 h-20 w-20 overflow-hidden">
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={t('admin.licenseRibbon.ariaLabel', { edition: label })}
+        className="pointer-events-auto absolute -right-6 top-3 w-24 rotate-45 py-1 text-center text-xs font-semibold text-white shadow-sm"
+        style={{ backgroundColor: color }}
+      >
+        {label}
+      </a>
+    </div>
+  )
+}

--- a/src/components/billing/LicenseRibbon.tsx
+++ b/src/components/billing/LicenseRibbon.tsx
@@ -1,10 +1,11 @@
+import type { LicenseEdition } from '@shared/types'
 import { useTranslation } from 'react-i18next'
 import { useEntitlement } from '@/hooks/useEntitlement'
 
 const GITHUB_URL = 'https://github.com/saltbo/zpan'
 const CLOUD_DASHBOARD_FALLBACK = 'https://cloud.zpan.space/dashboard'
 
-function editionKey(bound: boolean, edition: string | null): 'community' | 'pro' | 'business' {
+function editionKey(bound: boolean, edition: LicenseEdition | null): 'community' | 'pro' | 'business' {
   if (!bound) return 'community'
   return edition === 'business' ? 'business' : 'pro'
 }
@@ -33,7 +34,7 @@ export function LicenseRibbon() {
   }
 
   return (
-    <div data-slot="license-ribbon" className="pointer-events-none fixed right-0 top-0 z-50 h-20 w-20 overflow-hidden">
+    <div data-slot="license-ribbon" className="pointer-events-none fixed right-0 top-0 z-50 h-24 w-24 overflow-hidden">
       <a
         href={href}
         target="_blank"

--- a/src/hooks/useEntitlement.ts
+++ b/src/hooks/useEntitlement.ts
@@ -20,6 +20,7 @@ export function useEntitlement() {
     bound: data?.bound ?? false,
     active: data?.active ?? false,
     edition: data?.edition ?? null,
+    cloudDashboardUrl: data?.cloud_dashboard_url ?? null,
     hasFeature,
     isLoading,
     isError,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1321,6 +1321,12 @@
   "settings.billing.bound.pro.disconnectSuccess": "Pro license removed",
   "settings.billing.bound.business.disconnectSuccess": "Business license removed",
   "settings.billing.bound.disconnectError": "Failed to remove license",
+
+  "admin.licenseRibbon.community": "Community",
+  "admin.licenseRibbon.pro": "Pro",
+  "admin.licenseRibbon.business": "Business",
+  "admin.licenseRibbon.ariaLabel": "{{edition}} edition",
+
   "admin.cloudStore.title": "Storage Plans",
   "admin.cloudStore.subtitle": "Manage purchasable storage plans and gift cards for personal and team workspaces.",
   "admin.cloudStore.enabled": "Enabled",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1321,6 +1321,12 @@
   "settings.billing.bound.pro.disconnectSuccess": "已移除 Pro 授权",
   "settings.billing.bound.business.disconnectSuccess": "已移除 Business 授权",
   "settings.billing.bound.disconnectError": "移除授权失败",
+
+  "admin.licenseRibbon.community": "社区版",
+  "admin.licenseRibbon.pro": "专业版",
+  "admin.licenseRibbon.business": "商业版",
+  "admin.licenseRibbon.ariaLabel": "{{edition}}",
+
   "admin.cloudStore.title": "存储套餐",
   "admin.cloudStore.subtitle": "管理个人空间和团队工作空间可购买的存储套餐及礼品卡。",
   "admin.cloudStore.enabled": "启用",

--- a/src/routes/_authenticated/admin/route.tsx
+++ b/src/routes/_authenticated/admin/route.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 import { AdminSidebar } from '@/components/admin/admin-sidebar'
+import { LicenseRibbon } from '@/components/billing/LicenseRibbon'
 import { Separator } from '@/components/ui/separator'
 import { SidebarInset, SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar'
 
@@ -28,6 +29,7 @@ function AdminLayout() {
           <Outlet />
         </main>
       </SidebarInset>
+      <LicenseRibbon />
     </SidebarProvider>
   )
 }

--- a/src/routes/_authenticated/teams/index.test.tsx
+++ b/src/routes/_authenticated/teams/index.test.tsx
@@ -259,6 +259,7 @@ function makeEntitlement(hasTeamsUnlimited: boolean) {
     bound: true,
     active: hasTeamsUnlimited,
     edition: hasTeamsUnlimited ? 'pro' : null,
+    cloudDashboardUrl: null,
     hasFeature: (name: string) => hasTeamsUnlimited && name === 'teams_unlimited',
     isLoading: false,
     isError: false,


### PR DESCRIPTION
## Summary

- Adds `LicenseRibbon` component (`src/components/billing/LicenseRibbon.tsx`) — a fixed diagonal corner ribbon in the top-right of every admin page
- Renders at the `AdminLayout` level (`src/routes/_authenticated/admin/route.tsx`) so it appears on all admin pages
- Three editions with distinct styles: Community (gray #64748B → GitHub), Pro (blue #1A73E8 → GitHub), Business (gold #F59E0B → `cloud_dashboard_url` or fallback)
- Exposes `cloudDashboardUrl` from `useEntitlement` (was in `BindingState` but previously dropped)
- Adds `admin.licenseRibbon.*` i18n keys in both `en.json` and `zh.json`
- 15 co-located tests covering all editions, loading state, link targets, colors, and accessibility

## Test plan

- [ ] `pnpm typecheck` passes (no errors)
- [ ] `pnpm test` passes — 93 test files, 2484 tests (including 15 new `LicenseRibbon` tests)
- [ ] i18n parity test passes (en/zh key count matches)
- [ ] Community gray ribbon visible top-right on any `/admin/*` page
- [ ] Pro blue ribbon links to `https://github.com/saltbo/zpan`
- [ ] Business gold ribbon links to `cloud_dashboard_url` or `https://cloud.zpan.space/dashboard`
- [ ] Ribbon renders nothing while the licensing query is loading (no flash)
- [ ] Link has `target="_blank"`, `rel="noopener noreferrer"`, and `aria-label`

🤖 Generated with [Claude Code](https://claude.com/claude-code)