### PR TITLE
feat(licensing): regroup comparison table by capability and add social-login/downloader gates

### DIFF
--- a/cmd/internal/openapi/client.gen.go
+++ b/cmd/internal/openapi/client.gen.go
@@ -3843,6 +3843,9 @@ type PostApiAdminDownloadersResponse struct {
 	JSON401 *struct {
 		Error string `json:"error"`
 	}
+	JSON402 *struct {
+		Error string `json:"error"`
+	}
 }
 
 // Status returns HTTPResponse.Status
@@ -5334,6 +5337,15 @@ func ParsePostApiAdminDownloadersResponse(rsp *http.Response) (*PostApiAdminDown
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 402:
+		var dest struct {
+			Error string `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON402 = &dest
 
 	}
 

--- a/docs/openapi/downloader.json
+++ b/docs/openapi/downloader.json
@@ -4441,6 +4441,24 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Feature not available",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         }
       }

--- a/server/auth.integration.test.ts
+++ b/server/auth.integration.test.ts
@@ -74,7 +74,7 @@ describe('registration gate — open mode', () => {
 
   it('second user can register when auth_signup_mode is explicitly open and instance has Pro license', async () => {
     const ctx = await createTestApp()
-    await seedProLicense(ctx.db, ['open_registration'])
+    await seedProLicense(ctx.db)
     await ctx.db.insert(schema.systemOptions).values({ key: 'auth_signup_mode', value: 'open' })
     await signUp(ctx, 'first@example.com')
     const res = await signUp(ctx, 'second@example.com')

--- a/server/licensing/entitlement.test.ts
+++ b/server/licensing/entitlement.test.ts
@@ -6,6 +6,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 import * as authSchema from '../db/auth-schema'
 import * as appSchema from '../db/schema'
 import { invalidateEntitlementCache, loadEntitlement } from './entitlement'
+import { effectiveFeatures } from './has-feature'
 import { createLicenseBinding } from './license-state'
 import { PUBLIC_KEYS } from './public-keys'
 
@@ -126,7 +127,6 @@ describe('loadEntitlement', () => {
     await seedBinding(
       db,
       signAssertion({
-        features: ['white_label', 'quota_store'],
         licenseId: 'lic-1',
         licenseValidUntil,
         expiresAt: certificateExpiresAt,
@@ -136,7 +136,7 @@ describe('loadEntitlement', () => {
     const result = await loadEntitlement(db)
     expect(result).not.toBeNull()
     expect(result?.edition).toBe('pro')
-    expect(result?.features).toEqual(['white_label', 'quota_store'])
+    expect(result?.features).toEqual(effectiveFeatures('pro'))
     expect(result?.licenseId).toBe('lic-1')
     expect(result?.licenseValidUntil).toBe(licenseValidUntil)
     expect(result?.certificateExpiresAt).toBe(certificateExpiresAt)
@@ -149,7 +149,6 @@ describe('loadEntitlement', () => {
       db,
       signAssertion({
         edition: 'business',
-        features: ['white_label', 'quota_store'],
         licenseId: 'lic-business',
       }),
     )
@@ -157,7 +156,7 @@ describe('loadEntitlement', () => {
     const result = await loadEntitlement(db)
     expect(result).toMatchObject({
       edition: 'business',
-      features: ['white_label', 'quota_store'],
+      features: effectiveFeatures('business'),
       licenseId: 'lic-business',
     })
   })

--- a/server/licensing/entitlement.ts
+++ b/server/licensing/entitlement.ts
@@ -34,7 +34,7 @@ export async function loadEntitlement(db: Database): Promise<EntitlementSummary 
   cachedSummary = assertion
     ? {
         edition: assertion.edition,
-        features: effectiveFeatures(assertion.edition, assertion.features),
+        features: effectiveFeatures(assertion.edition),
         licenseId: assertion.licenseId,
         certificateExpiresAt: assertion.expiresAt,
         licenseValidUntil: assertion.licenseValidUntil,

--- a/server/licensing/has-feature.test.ts
+++ b/server/licensing/has-feature.test.ts
@@ -17,28 +17,19 @@ describe('hasFeature', () => {
     expect(hasFeature('white_label', state)).toBe(false)
   })
 
-  it('returns true for local Pro gates when binding is active', () => {
-    const state: BindingState = {
-      bound: true,
-      active: true,
-      edition: 'pro',
-      features: ['white_label', 'teams_unlimited', 'storages_unlimited'],
-    }
+  it('grants non-commercial Pro gates for an active Pro binding, but not business-only gates', () => {
+    const state: BindingState = { bound: true, active: true, edition: 'pro' }
     expect(hasFeature('white_label', state)).toBe(true)
     expect(hasFeature('teams_unlimited', state)).toBe(true)
     expect(hasFeature('storages_unlimited', state)).toBe(true)
     expect(hasFeature('quota_store', state)).toBe(false)
+    expect(hasFeature('site_announcements', state)).toBe(false)
   })
 
-  it('falls back to non-commercial Pro gates for legacy Pro certificates without features', () => {
-    const state: BindingState = { bound: true, active: true, edition: 'pro' }
-    expect(hasFeature('white_label', state)).toBe(true)
-    expect(hasFeature('quota_store', state)).toBe(false)
-  })
-
-  it('allows business gates when a Business binding is active', () => {
-    const state: BindingState = { bound: true, active: true, edition: 'business', features: ['quota_store'] }
+  it('grants all gates for an active Business binding', () => {
+    const state: BindingState = { bound: true, active: true, edition: 'business' }
     expect(hasFeature('quota_store', state)).toBe(true)
-    expect(hasFeature('white_label', state)).toBe(false)
+    expect(hasFeature('site_announcements', state)).toBe(true)
+    expect(hasFeature('white_label', state)).toBe(true)
   })
 })

--- a/server/licensing/has-feature.ts
+++ b/server/licensing/has-feature.ts
@@ -46,7 +46,7 @@ export function hasFeature(feature: LicenseFeature, state: BindingState | null):
   )
 }
 
-const BUSINESS_ONLY_FEATURES = new Set<LicenseFeature>(['quota_store'])
+const BUSINESS_ONLY_FEATURES = new Set<LicenseFeature>(['quota_store', 'site_announcements'])
 
 export function effectiveFeatures(edition: BindingState['edition'], features?: LicenseFeature[]): LicenseFeature[] {
   if (features) return features

--- a/server/licensing/has-feature.ts
+++ b/server/licensing/has-feature.ts
@@ -30,7 +30,7 @@ export async function loadBindingState(db: Database, options: BindingStateOption
     if (assertion) {
       result.active = true
       result.edition = assertion.edition
-      result.features = effectiveFeatures(assertion.edition, assertion.features)
+      result.features = effectiveFeatures(assertion.edition)
       result.license_id = assertion.licenseId
       result.license_valid_until = assertion.licenseValidUntil
       result.certificate_expires_at = assertion.expiresAt
@@ -41,15 +41,12 @@ export async function loadBindingState(db: Database, options: BindingStateOption
 }
 
 export function hasFeature(feature: LicenseFeature, state: BindingState | null): boolean {
-  return Boolean(
-    feature && state?.bound && state.active && effectiveFeatures(state.edition, state.features).includes(feature),
-  )
+  return Boolean(feature && state?.bound && state.active && effectiveFeatures(state.edition).includes(feature))
 }
 
 const BUSINESS_ONLY_FEATURES = new Set<LicenseFeature>(['quota_store', 'site_announcements'])
 
-export function effectiveFeatures(edition: BindingState['edition'], features?: LicenseFeature[]): LicenseFeature[] {
-  if (features) return features
+export function effectiveFeatures(edition: BindingState['edition']): LicenseFeature[] {
   if (edition === 'pro') return PRO_GATE_KEYS.filter((feature) => !BUSINESS_ONLY_FEATURES.has(feature))
   if (edition === 'business') return [...PRO_GATE_KEYS]
   return []

--- a/server/licensing/verify.test.ts
+++ b/server/licensing/verify.test.ts
@@ -53,17 +53,12 @@ describe('verifyCertificate', () => {
     expect(result?.authorizedHosts).toEqual(['zpan.example.com'])
   })
 
-  it('returns assertion for a valid business cert and sanitizes feature keys', () => {
-    const cert = signCert({
-      edition: 'business',
-      features: ['white_label', 'quota_store', 'unknown_feature'],
-      licenseId: 'lic-1',
-    })
+  it('returns assertion for a valid business cert', () => {
+    const cert = signCert({ edition: 'business', licenseId: 'lic-1' })
     const result = verifyCertificate(cert, { instanceId: 'inst-abc', currentHost: 'zpan.example.com' })
 
     expect(result).not.toBeNull()
     expect(result?.edition).toBe('business')
-    expect(result?.features).toEqual(['white_label', 'quota_store'])
     expect(result?.licenseId).toBe('lic-1')
   })
 

--- a/server/licensing/verify.ts
+++ b/server/licensing/verify.ts
@@ -1,6 +1,5 @@
 import { ZPAN_CLOUD_URL_DEFAULT } from '@shared/constants'
-import { PRO_GATE_KEYS } from '@shared/feature-registry'
-import type { LicenseAssertion, LicenseFeature } from '@shared/types'
+import type { LicenseAssertion } from '@shared/types'
 import { verify } from 'paseto-ts/v4'
 import { PUBLIC_KEYS } from './public-keys'
 
@@ -67,17 +66,8 @@ function tryVerify(cert: string, publicKey: string, options: VerifyCertificateOp
       return null
     }
 
-    return { ...payload, authorizedHosts, features: normalizeFeatures(payload.features) }
+    return { ...payload, authorizedHosts }
   } catch {
     return null
   }
-}
-
-function normalizeFeatures(features: unknown): LicenseFeature[] | undefined {
-  if (!Array.isArray(features)) return undefined
-  const allowed = new Set(PRO_GATE_KEYS)
-  const normalized = features.filter(
-    (feature): feature is LicenseFeature => typeof feature === 'string' && allowed.has(feature as LicenseFeature),
-  )
-  return [...new Set(normalized)]
 }

--- a/server/routes/announcements.integration.test.ts
+++ b/server/routes/announcements.integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { adminHeaders, authedHeaders, createTestApp, seedProLicense } from '../test/setup.js'
+import { adminHeaders, authedHeaders, createTestApp, seedBusinessLicense } from '../test/setup.js'
 
 const publishedAnnouncement = {
   title: 'Maintenance window',
@@ -12,7 +12,7 @@ type TestContext = Awaited<ReturnType<typeof createTestApp>>
 
 async function createPublishedAnnouncement(ctx: TestContext) {
   const headers = await adminHeaders(ctx.app)
-  await seedProLicense(ctx.db)
+  await seedBusinessLicense(ctx.db)
   const res = await ctx.app.request('/api/admin/announcements', {
     method: 'POST',
     headers: { ...headers, 'Content-Type': 'application/json' },
@@ -50,7 +50,7 @@ describe('Admin Announcements API', () => {
   it('creates, lists, updates, and deletes an announcement', async () => {
     const { app, db } = await createTestApp()
     const headers = await adminHeaders(app)
-    await seedProLicense(db)
+    await seedBusinessLicense(db)
 
     const createRes = await app.request('/api/admin/announcements', {
       method: 'POST',
@@ -116,7 +116,7 @@ describe('User Announcements API', () => {
   it('keeps archived announcements in history but not active list', async () => {
     const { app, db } = await createTestApp()
     const admin = await adminHeaders(app)
-    await seedProLicense(db)
+    await seedBusinessLicense(db)
     const createRes = await app.request('/api/admin/announcements', {
       method: 'POST',
       headers: { ...admin, 'Content-Type': 'application/json' },
@@ -145,7 +145,7 @@ describe('User Announcements API', () => {
   it('does not include draft announcements in history', async () => {
     const { app, db } = await createTestApp()
     const admin = await adminHeaders(app)
-    await seedProLicense(db)
+    await seedBusinessLicense(db)
     await app.request('/api/admin/announcements', {
       method: 'POST',
       headers: { ...admin, 'Content-Type': 'application/json' },

--- a/server/routes/auth-providers.integration.test.ts
+++ b/server/routes/auth-providers.integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { adminHeaders, authedHeaders, createTestApp } from '../test/setup.js'
+import { adminHeaders, authedHeaders, createTestApp, seedProLicense } from '../test/setup.js'
 
 const githubConfig = {
   type: 'builtin' as const,
@@ -40,8 +40,9 @@ describe('Auth Providers — public list', () => {
   })
 
   it('returns only enabled providers', async () => {
-    const { app } = await createTestApp()
+    const { app, db } = await createTestApp()
     const admin = await adminHeaders(app)
+    await seedProLicense(db) // 2nd provider requires social_login_unlimited
 
     await putProvider(app, admin, 'github', { ...githubConfig, enabled: true })
     await putProvider(app, admin, 'google', { ...githubConfig, clientId: 'google-id', enabled: false })
@@ -134,8 +135,9 @@ describe('Auth Providers — admin list', () => {
   })
 
   it('returns all configs including disabled providers', async () => {
-    const { app } = await createTestApp()
+    const { app, db } = await createTestApp()
     const admin = await adminHeaders(app)
+    await seedProLicense(db) // 2nd provider requires social_login_unlimited
 
     await putProvider(app, admin, 'github', { ...githubConfig, enabled: true })
     await putProvider(app, admin, 'google', { ...githubConfig, clientId: 'google-id', enabled: false })
@@ -192,6 +194,38 @@ describe('Auth Providers — admin upsert (PUT)', () => {
     expect(body.type).toBe('builtin')
     expect(body.clientId).toBe(githubConfig.clientId)
     expect(body.enabled).toBe(true)
+  })
+
+  it('blocks the second provider on the free plan with 402', async () => {
+    const { app } = await createTestApp()
+    const admin = await adminHeaders(app)
+
+    const first = await putProvider(app, admin, 'github', githubConfig)
+    expect(first.status).toBe(200)
+
+    const second = await putProvider(app, admin, 'google', { ...githubConfig, clientId: 'google-id' })
+    expect(second.status).toBe(402)
+    const body = (await second.json()) as Record<string, unknown>
+    expect(body.feature).toBe('social_login_unlimited')
+    expect(body.limit).toBe(1)
+  })
+
+  it('allows additional providers with the social_login_unlimited entitlement', async () => {
+    const { app, db } = await createTestApp()
+    const admin = await adminHeaders(app)
+    await seedProLicense(db)
+
+    expect((await putProvider(app, admin, 'github', githubConfig)).status).toBe(200)
+    expect((await putProvider(app, admin, 'google', { ...githubConfig, clientId: 'google-id' })).status).toBe(200)
+  })
+
+  it('updating the only provider is not blocked by the free limit', async () => {
+    const { app } = await createTestApp()
+    const admin = await adminHeaders(app)
+
+    await putProvider(app, admin, 'github', githubConfig)
+    const res = await putProvider(app, admin, 'github', { ...githubConfig, clientId: 'updated' })
+    expect(res.status).toBe(200)
   })
 
   it('returns masked secret on create response', async () => {

--- a/server/routes/auth-providers.ts
+++ b/server/routes/auth-providers.ts
@@ -2,6 +2,7 @@ import { zValidator } from '@hono/zod-validator'
 import { eq, like } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { z } from 'zod'
+import { FREE_SOCIAL_LOGIN_LIMIT } from '../../shared/constants'
 import {
   BUILTIN_PROVIDER_IDS,
   isValidProviderId,
@@ -11,6 +12,7 @@ import {
   parseProviderConfig,
 } from '../../shared/oauth-providers'
 import { systemOptions } from '../db/schema'
+import { hasFeature, loadBindingState } from '../licensing/has-feature'
 import { requireAdmin } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
 
@@ -90,6 +92,25 @@ export const adminAuthProviders = new Hono<Env>()
     if (existing.length > 0) {
       await db.update(systemOptions).set({ value, public: false }).where(eq(systemOptions.key, key))
     } else {
+      const [configured, state] = await Promise.all([
+        db
+          .select({ key: systemOptions.key })
+          .from(systemOptions)
+          .where(like(systemOptions.key, OAUTH_PROVIDER_KEY_PATTERN)),
+        loadBindingState(db),
+      ])
+      if (!hasFeature('social_login_unlimited', state) && configured.length >= FREE_SOCIAL_LOGIN_LIMIT) {
+        return c.json(
+          {
+            error: 'feature_not_available',
+            feature: 'social_login_unlimited',
+            currentCount: configured.length,
+            limit: FREE_SOCIAL_LOGIN_LIMIT,
+            upgrade_url: '/settings/billing',
+          },
+          402,
+        )
+      }
       await db.insert(systemOptions).values({ key, value, public: false })
     }
 

--- a/server/routes/download-tasks.integration.test.ts
+++ b/server/routes/download-tasks.integration.test.ts
@@ -3,7 +3,7 @@ import { sql } from 'drizzle-orm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { remoteDownloadUsageReports } from '../db/schema'
 import { S3Service } from '../services/s3.js'
-import { adminHeaders, authedHeaders, createTestApp, seedBusinessLicense } from '../test/setup.js'
+import { adminHeaders, authedHeaders, createTestApp, seedBusinessLicense, seedProLicense } from '../test/setup.js'
 
 type DownloadTaskList = { items: DownloadTask[] }
 
@@ -194,6 +194,7 @@ describe('Download tasks API integration', () => {
   it('does not assign new tasks to downloaders with stale heartbeats', async () => {
     const { app, db } = await createTestApp({ DOWNLOAD_TOKEN_SECRET: 'test-download-token-secret' })
     await insertStorage(db)
+    await seedProLicense(db) // 2nd downloader requires downloaders_unlimited
     const admin = await adminHeaders(app)
     const staleDownloader = await registerDownloaderThroughDeviceLogin(app, 'stale-downloader', admin)
     const liveDownloader = await registerDownloaderThroughDeviceLogin(app, 'live-downloader', admin)
@@ -321,6 +322,7 @@ describe('Download tasks API integration', () => {
   it('reassigns unfinished tasks from stale downloaders on live heartbeat', async () => {
     const { app, db } = await createTestApp({ DOWNLOAD_TOKEN_SECRET: 'test-download-token-secret' })
     await insertStorage(db)
+    await seedProLicense(db) // 2nd downloader requires downloaders_unlimited
     const admin = await adminHeaders(app)
     const staleDownloader = await registerDownloaderThroughDeviceLogin(app, 'reassign-stale-downloader', admin)
     const staleHeaders = {
@@ -1561,5 +1563,41 @@ describe('Download tasks API integration', () => {
     expect(tagFiltered.items[0]).toMatchObject({
       spec: { source: { uri: 'https://example.com/b.bin' }, labels: { tags: ['bulk', 'movie'] } },
     })
+  })
+})
+
+describe('Downloaders — free plan limit', () => {
+  async function postDownloader(
+    app: Awaited<ReturnType<typeof createTestApp>>['app'],
+    admin: Record<string, string>,
+    name: string,
+  ) {
+    return app.request('/api/admin/downloaders', {
+      method: 'POST',
+      headers: { ...admin, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, heartbeat }),
+    })
+  }
+
+  it('blocks the second downloader on the free plan with 402', async () => {
+    const { app } = await createTestApp({ DOWNLOAD_TOKEN_SECRET: 'test-download-token-secret' })
+    const admin = await adminHeaders(app)
+
+    expect((await postDownloader(app, admin, 'first')).status).toBe(201)
+
+    const second = await postDownloader(app, admin, 'second')
+    expect(second.status).toBe(402)
+    const body = (await second.json()) as Record<string, unknown>
+    expect(body.feature).toBe('downloaders_unlimited')
+    expect(body.limit).toBe(1)
+  })
+
+  it('allows additional downloaders with the downloaders_unlimited entitlement', async () => {
+    const { app, db } = await createTestApp({ DOWNLOAD_TOKEN_SECRET: 'test-download-token-secret' })
+    await seedProLicense(db)
+    const admin = await adminHeaders(app)
+
+    expect((await postDownloader(app, admin, 'first')).status).toBe(201)
+    expect((await postDownloader(app, admin, 'second')).status).toBe(201)
   })
 })

--- a/server/routes/downloaders.ts
+++ b/server/routes/downloaders.ts
@@ -9,6 +9,7 @@ import {
   updateDownloaderSchema,
 } from '@shared/schemas'
 import type { Context } from 'hono'
+import { FREE_DOWNLOADER_LIMIT } from '../../shared/constants'
 import { hasFeature, loadBindingState } from '../licensing/has-feature'
 import { requireAdmin, requireDownloader } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
@@ -52,6 +53,7 @@ const createRouteDoc = createRoute({
   responses: {
     201: jsonResponse(createDownloaderResponseSchema, 'Downloader registration'),
     401: jsonResponse(errorSchema, 'Unauthorized'),
+    402: jsonResponse(errorSchema, 'Feature not available'),
   },
 })
 
@@ -99,8 +101,22 @@ const downloadersRoute = new OpenAPIHono<Env>()
   .openapi(createRouteDoc, (async (c: OpenAPIContext) => {
     const userId = c.get('userId')
     if (!userId) return c.json({ error: 'Unauthorized' }, 401)
+    const platform = c.get('platform')
+    const [existing, state] = await Promise.all([listDownloaders(platform), loadBindingState(platform.db)])
+    if (!hasFeature('downloaders_unlimited', state) && existing.length >= FREE_DOWNLOADER_LIMIT) {
+      return c.json(
+        {
+          error: 'feature_not_available',
+          feature: 'downloaders_unlimited',
+          currentCount: existing.length,
+          limit: FREE_DOWNLOADER_LIMIT,
+          upgrade_url: '/settings/billing',
+        },
+        402,
+      )
+    }
     const result = await createDownloader(
-      c.get('platform'),
+      platform,
       c.req.valid('json') as z.infer<typeof createDownloaderSchema>,
       userId,
     )

--- a/server/services/signup-mode-guard.integration.test.ts
+++ b/server/services/signup-mode-guard.integration.test.ts
@@ -13,8 +13,8 @@ async function signUp(ctx: TestCtx, email: string, extra?: Record<string, unknow
   })
 }
 
-async function seedProLicense(ctx: TestCtx, features: string[] = ['open_registration']) {
-  await seedProLicenseRow(ctx.db, features)
+async function seedProLicense(ctx: TestCtx) {
+  await seedProLicenseRow(ctx.db)
 }
 
 async function seedFirstUser(ctx: TestCtx) {

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -603,7 +603,7 @@ function nowSec(): number {
   return Math.floor(Date.now() / 1000)
 }
 
-const BUSINESS_ONLY_TEST_FEATURES = new Set<ProFeature>(['quota_store'])
+const BUSINESS_ONLY_TEST_FEATURES = new Set<ProFeature>(['quota_store', 'site_announcements'])
 
 /**
  * Insert a Pro license binding row so that non-commercial Pro feature gates resolve as enabled.

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -2,8 +2,7 @@ import Database from 'better-sqlite3'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
 import { generateKeys, sign } from 'paseto-ts/v4'
 import { ZPAN_CLOUD_URL_DEFAULT } from '../../shared/constants'
-import { PRO_GATE_KEYS } from '../../shared/feature-registry'
-import type { LicenseEdition, ProFeature } from '../../shared/types'
+import type { LicenseEdition } from '../../shared/types'
 import { createApp } from '../app'
 import { createAuth } from '../auth'
 import * as authSchema from '../db/auth-schema'
@@ -603,34 +602,24 @@ function nowSec(): number {
   return Math.floor(Date.now() / 1000)
 }
 
-const BUSINESS_ONLY_TEST_FEATURES = new Set<ProFeature>(['quota_store', 'site_announcements'])
-
 /**
  * Insert a Pro license binding row so that non-commercial Pro feature gates resolve as enabled.
  */
-export async function seedProLicense(db: Awaited<ReturnType<typeof createTestApp>>['db'], features?: string[]) {
-  return seedLicense(db, {
-    edition: 'pro',
-    features:
-      normalizeTestFeatures(features) ?? PRO_GATE_KEYS.filter((feature) => !BUSINESS_ONLY_TEST_FEATURES.has(feature)),
-  })
+export async function seedProLicense(db: Awaited<ReturnType<typeof createTestApp>>['db']) {
+  return seedLicense(db, { edition: 'pro' })
 }
 
 /**
  * Insert a Business license binding row so commercial feature gates resolve as enabled.
  */
-export async function seedBusinessLicense(db: Awaited<ReturnType<typeof createTestApp>>['db'], features?: string[]) {
-  return seedLicense(db, {
-    edition: 'business',
-    features: normalizeTestFeatures(features) ?? [...PRO_GATE_KEYS],
-  })
+export async function seedBusinessLicense(db: Awaited<ReturnType<typeof createTestApp>>['db']) {
+  return seedLicense(db, { edition: 'business' })
 }
 
 async function seedLicense(
   db: Awaited<ReturnType<typeof createTestApp>>['db'],
   input: {
     edition: LicenseEdition
-    features: ProFeature[]
   },
 ) {
   const { PUBLIC_KEYS } = await import('../licensing/public-keys.js')
@@ -649,7 +638,6 @@ async function seedLicense(
     instanceId: 'test-instance',
     storeId: 'store-test-binding',
     edition: input.edition,
-    features: input.features,
     licenseId: 'test-license-unit',
     authorizedHosts: ['localhost', 'zpan.example', 'auth.example.com', 'files.example.com'],
     licenseValidUntil: issuedAt + 365 * 24 * 60 * 60,
@@ -668,10 +656,4 @@ async function seedLicense(
     cachedExpiresAt: expiresAt,
     lastRefreshAt: issuedAt,
   })
-}
-
-function normalizeTestFeatures(features: string[] | undefined): ProFeature[] | undefined {
-  if (!features) return undefined
-  const allowed = new Set(PRO_GATE_KEYS)
-  return features.filter((feature): feature is ProFeature => allowed.has(feature as ProFeature))
 }

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -60,3 +60,11 @@ export const FREE_EXTRA_TEAM_LIMIT = 1
 // Free plan allows up to this many storage backends per instance.
 // The 4th storage requires the storages_unlimited feature.
 export const FREE_STORAGE_LIMIT = 3
+
+// Free plan allows up to this many social login / OIDC providers per instance.
+// The 2nd provider requires the social_login_unlimited feature.
+export const FREE_SOCIAL_LOGIN_LIMIT = 1
+
+// Free plan allows up to this many downloaders per instance.
+// The 2nd downloader requires the downloaders_unlimited feature.
+export const FREE_DOWNLOADER_LIMIT = 1

--- a/shared/feature-registry.ts
+++ b/shared/feature-registry.ts
@@ -1,4 +1,4 @@
-import { FREE_EXTRA_TEAM_LIMIT, FREE_STORAGE_LIMIT } from './constants'
+import { FREE_DOWNLOADER_LIMIT, FREE_EXTRA_TEAM_LIMIT, FREE_SOCIAL_LOGIN_LIMIT, FREE_STORAGE_LIMIT } from './constants'
 
 // ---------------------------------------------------------------------------
 // Cell values for the comparison table
@@ -11,15 +11,16 @@ export type CellValue = boolean | { i18nKey: string; params?: Record<string, unk
 // Feature categories
 // ---------------------------------------------------------------------------
 
-export const FEATURE_CATEGORIES = ['core', 'pro', 'business'] as const
+// Functional grouping for the comparison table — NOT a tier. Which edition a
+// feature is available in is expressed by its community/pro/business cells.
+export const FEATURE_CATEGORIES = ['core', 'advanced'] as const
 
 export type FeatureCategory = (typeof FEATURE_CATEGORIES)[number]
 
 /** i18n key for each category header. */
 export const CATEGORY_I18N: Record<FeatureCategory, string> = {
   core: 'features.category.core',
-  pro: 'features.category.pro',
-  business: 'features.category.business',
+  advanced: 'features.category.advanced',
 }
 
 // ---------------------------------------------------------------------------
@@ -29,7 +30,7 @@ export const CATEGORY_I18N: Record<FeatureCategory, string> = {
 export interface FeatureDefinition {
   /** i18n key for the feature name shown in the comparison table. */
   i18nKey: string
-  /** Which section this feature belongs to. */
+  /** Functional group this feature belongs to (core vs advanced) — not a tier. */
   category: FeatureCategory
   /** What Community plan gets — true (included), false (not included), or structured value. */
   community: CellValue
@@ -51,7 +52,7 @@ export interface FeatureDefinition {
 // ---------------------------------------------------------------------------
 
 export const FEATURE_REGISTRY = [
-  // ── Core Features ───────────────────────────────────────────────────
+  // ── Core capabilities (available in every edition, some with free limits) ──
   {
     i18nKey: 'features.coreFileManagement',
     category: 'core',
@@ -76,9 +77,10 @@ export const FEATURE_REGISTRY = [
   {
     i18nKey: 'features.socialLoginOidc',
     category: 'core',
-    community: true,
-    pro: true,
-    business: true,
+    community: { i18nKey: 'features.socialLoginOidc.limit', params: { count: FREE_SOCIAL_LOGIN_LIMIT } },
+    pro: { i18nKey: 'features.socialLoginOidc.unlimited' },
+    business: { i18nKey: 'features.socialLoginOidc.unlimited' },
+    gateKey: 'social_login_unlimited',
   },
   {
     i18nKey: 'features.inviteCodes',
@@ -88,10 +90,10 @@ export const FEATURE_REGISTRY = [
     business: true,
   },
 
-  // ── Pro Features ────────────────────────────────────────────────────
+  // ── Advanced capabilities (edition availability shown per-cell) ──────
   {
     i18nKey: 'features.whiteLabel',
-    category: 'pro',
+    category: 'advanced',
     community: false,
     pro: true,
     business: true,
@@ -99,7 +101,7 @@ export const FEATURE_REGISTRY = [
   },
   {
     i18nKey: 'features.openRegistration',
-    category: 'pro',
+    category: 'advanced',
     community: false,
     pro: true,
     business: true,
@@ -107,7 +109,7 @@ export const FEATURE_REGISTRY = [
   },
   {
     i18nKey: 'features.teamWorkspaces',
-    category: 'pro',
+    category: 'advanced',
     community: { i18nKey: 'features.teamWorkspaces.limit', params: { count: FREE_EXTRA_TEAM_LIMIT } },
     pro: { i18nKey: 'features.teamWorkspaces.unlimited' },
     business: { i18nKey: 'features.teamWorkspaces.unlimited' },
@@ -115,47 +117,31 @@ export const FEATURE_REGISTRY = [
   },
   {
     i18nKey: 'features.storageBackends',
-    category: 'pro',
+    category: 'advanced',
     community: { i18nKey: 'features.storageBackends.limit', params: { count: FREE_STORAGE_LIMIT } },
     pro: { i18nKey: 'features.storageBackends.unlimited' },
     business: { i18nKey: 'features.storageBackends.unlimited' },
     gateKey: 'storages_unlimited',
   },
   {
+    i18nKey: 'features.downloaders',
+    category: 'advanced',
+    community: { i18nKey: 'features.downloaders.limit', params: { count: FREE_DOWNLOADER_LIMIT } },
+    pro: { i18nKey: 'features.downloaders.unlimited' },
+    business: { i18nKey: 'features.downloaders.unlimited' },
+    gateKey: 'downloaders_unlimited',
+  },
+  {
     i18nKey: 'features.cloudStore',
-    category: 'business',
+    category: 'advanced',
     community: false,
     pro: false,
     business: true,
     gateKey: 'quota_store',
   },
   {
-    i18nKey: 'features.siteAnnouncements',
-    category: 'pro',
-    community: false,
-    pro: true,
-    business: true,
-    gateKey: 'site_announcements',
-  },
-  {
-    i18nKey: 'features.multiIdpSso',
-    category: 'pro',
-    community: false,
-    pro: true,
-    business: true,
-    comingSoon: true,
-  },
-  {
-    i18nKey: 'features.ldapScim',
-    category: 'pro',
-    community: false,
-    pro: true,
-    business: true,
-    comingSoon: true,
-  },
-  {
     i18nKey: 'features.auditLog',
-    category: 'pro',
+    category: 'advanced',
     community: false,
     pro: true,
     business: true,
@@ -163,17 +149,41 @@ export const FEATURE_REGISTRY = [
   },
   {
     i18nKey: 'features.webhooks',
-    category: 'pro',
+    category: 'advanced',
     community: false,
     pro: true,
     business: true,
     comingSoon: true,
   },
   {
-    i18nKey: 'features.analytics',
-    category: 'pro',
+    i18nKey: 'features.siteAnnouncements',
+    category: 'advanced',
     community: false,
-    pro: true,
+    pro: false,
+    business: true,
+    gateKey: 'site_announcements',
+  },
+  {
+    i18nKey: 'features.multiIdpSso',
+    category: 'advanced',
+    community: false,
+    pro: false,
+    business: true,
+    comingSoon: true,
+  },
+  {
+    i18nKey: 'features.ldapScim',
+    category: 'advanced',
+    community: false,
+    pro: false,
+    business: true,
+    comingSoon: true,
+  },
+  {
+    i18nKey: 'features.analytics',
+    category: 'advanced',
+    community: false,
+    pro: false,
     business: true,
     comingSoon: true,
   },

--- a/shared/types/licensing.ts
+++ b/shared/types/licensing.ts
@@ -11,7 +11,6 @@ export interface LicenseAssertion {
   accountId: string
   instanceId: string
   edition: LicenseEdition
-  features?: LicenseFeature[]
   licenseId?: string
   authorizedHosts: string[]
   licenseValidUntil: number

--- a/src/components/UpgradeHint.tsx
+++ b/src/components/UpgradeHint.tsx
@@ -6,6 +6,8 @@ const FEATURE_LABELS: Record<ProFeature, string> = {
   open_registration: 'open registration',
   teams_unlimited: 'unlimited teams',
   storages_unlimited: 'unlimited storages',
+  social_login_unlimited: 'unlimited social logins',
+  downloaders_unlimited: 'unlimited downloaders',
   audit_log: 'audit logs',
   quota_store: 'storage quota store',
   site_announcements: 'site announcements',

--- a/src/components/billing/ComparisonTable.tsx
+++ b/src/components/billing/ComparisonTable.tsx
@@ -12,26 +12,20 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 
 function FeatureCell({
   value,
-  comingSoon,
+  muted,
   t,
 }: {
   value: CellValue
-  comingSoon?: boolean
+  // Render included cells in a muted tone (used for not-yet-shipped features) so a
+  // checkmark doesn't read as "available now" while still showing the target edition.
+  muted?: boolean
   t: (key: string, params?: Record<string, unknown>) => string
 }) {
-  if (comingSoon) {
-    return (
-      <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
-        <Clock className="size-3" />
-        {t('settings.billing.comparison.comingSoon')}
-      </span>
-    )
-  }
   if (typeof value === 'object') {
     return <span className="text-sm text-muted-foreground">{t(value.i18nKey, value.params)}</span>
   }
   return value ? (
-    <Check className="size-4 text-primary" aria-label="Included" />
+    <Check className={muted ? 'size-4 text-muted-foreground' : 'size-4 text-primary'} aria-label="Included" />
   ) : (
     <Minus className="size-4 text-muted-foreground" aria-label="Not included" />
   )
@@ -77,34 +71,39 @@ export function ComparisonTable() {
                     {t(CATEGORY_I18N[category])}
                   </TableCell>
                 </TableRow>
-                {features.map((feature) => (
-                  <TableRow key={feature.i18nKey}>
-                    <TableCell className="pl-8 font-medium">{t(feature.i18nKey)}</TableCell>
-                    <TableCell className="text-center">
-                      <div className="flex justify-center">
-                        <FeatureCell value={feature.community} t={t} />
-                      </div>
-                    </TableCell>
-                    <TableCell className="text-center">
-                      <div className="flex justify-center">
-                        <FeatureCell
-                          value={feature.pro}
-                          comingSoon={'comingSoon' in feature && feature.comingSoon}
-                          t={t}
-                        />
-                      </div>
-                    </TableCell>
-                    <TableCell className="text-center">
-                      <div className="flex justify-center">
-                        <FeatureCell
-                          value={feature.business}
-                          comingSoon={'comingSoon' in feature && feature.comingSoon}
-                          t={t}
-                        />
-                      </div>
-                    </TableCell>
-                  </TableRow>
-                ))}
+                {features.map((feature) => {
+                  const comingSoon = 'comingSoon' in feature && feature.comingSoon
+                  return (
+                    <TableRow key={feature.i18nKey}>
+                      <TableCell className="pl-8 font-medium">
+                        <span className="inline-flex items-center gap-2">
+                          {t(feature.i18nKey)}
+                          {comingSoon && (
+                            <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[10px] font-normal text-muted-foreground">
+                              <Clock className="size-3" />
+                              {t('settings.billing.comparison.comingSoon')}
+                            </span>
+                          )}
+                        </span>
+                      </TableCell>
+                      <TableCell className="text-center">
+                        <div className="flex justify-center">
+                          <FeatureCell value={feature.community} muted={comingSoon} t={t} />
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-center">
+                        <div className="flex justify-center">
+                          <FeatureCell value={feature.pro} muted={comingSoon} t={t} />
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-center">
+                        <div className="flex justify-center">
+                          <FeatureCell value={feature.business} muted={comingSoon} t={t} />
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
               </>
             ))}
           </TableBody>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1164,7 +1164,6 @@
   "share.copyShareText": "Copy share text",
   "share.textCopied": "Share text copied to clipboard",
   "share.shareTextTemplate": "Link: {{url}}\nPassword: {{password}}",
-
   "ihost.title": "Image Hosting",
   "ihost.enableCta.title": "Enable Image Hosting",
   "ihost.enableCta.description": "Upload images via PicGo, uPic, ShareX or the Web UI. Get permanent URLs on your own domain.",
@@ -1186,7 +1185,6 @@
   "ihost.upload.failed": "Failed to upload {{name}}",
   "ihost.table.dimensions": "Dimensions",
   "ihost.table.accessCount": "Views",
-
   "settings.ihost.title": "Image Hosting Settings",
   "settings.ihost.lockedTitle": "Admin Access Required",
   "settings.ihost.lockedDescription": "Only workspace owners and admins can manage Image Hosting settings.",
@@ -1242,9 +1240,8 @@
   "settings.ihost.tools.upic.instructions": "In uPic, go to Preferences → Host → Add → Custom. Fill in each field below. Add the Authorization header via the Headers button:",
   "settings.ihost.tools.sharex.instructions": "Download the .sxcu file and double-click it to import into ShareX. ShareX will automatically set ZPan as a custom uploader.",
   "settings.ihost.tools.sharex.download": "Download .sxcu",
-
   "settings.tabBilling": "Billing",
-  "settings.billing.intro": "ZPan Pro — unlock operator-grade features. Purchase or redeem on ZPan Cloud.",
+  "settings.billing.intro": "Unlock the operator-grade and commercial features of ZPan Pro and Business. Purchase or redeem a license on ZPan Cloud, then connect to activate.",
   "settings.billing.connectButton": "Connect to ZPan Cloud",
   "settings.billing.comparison.title": "Feature Comparison",
   "settings.billing.comparison.feature": "Feature",
@@ -1261,17 +1258,17 @@
   "features.openRegistration": "Open Registration",
   "features.multiIdpSso": "Multi-IdP SSO (SAML)",
   "features.ldapScim": "LDAP & SCIM Sync",
-  "features.teamWorkspaces": "Unlimited Team Workspaces",
+  "features.teamWorkspaces": "Team Workspaces",
   "features.teamWorkspaces.limit": "Up to {{count}} team",
   "features.teamWorkspaces.unlimited": "Unlimited",
-  "features.storageBackends": "Unlimited Storages",
+  "features.storageBackends": "Storages",
   "features.storageBackends.limit": "Up to {{count}} storages",
   "features.storageBackends.unlimited": "Unlimited",
   "features.shareLinks": "Link Sharing",
   "features.imageHosting": "Image Hosting",
   "features.whiteLabel": "Custom Branding",
   "features.auditLog": "Audit Logs",
-  "features.cloudStore": "Storage Plans",
+  "features.cloudStore": "Sell Storage & Traffic",
   "features.siteAnnouncements": "Site Announcements",
   "features.webhooks": "Event Webhooks",
   "features.analytics": "Analytics",
@@ -1325,12 +1322,10 @@
   "settings.billing.bound.pro.disconnectSuccess": "Pro license removed",
   "settings.billing.bound.business.disconnectSuccess": "Business license removed",
   "settings.billing.bound.disconnectError": "Failed to remove license",
-
   "admin.licenseRibbon.community": "Free",
   "admin.licenseRibbon.pro": "Pro",
   "admin.licenseRibbon.business": "Business",
   "admin.licenseRibbon.ariaLabel": "{{edition}} edition",
-
   "admin.about.title": "About ZPan",
   "admin.about.subtitle": "Version, instance details, and helpful links.",
   "admin.about.instanceTitle": "Instance",
@@ -1351,7 +1346,6 @@
   "admin.about.cloud.descriptionBound": "View your license certificate and manage the binding on ZPan Cloud.",
   "admin.about.cloud.cta": "Upgrade to Pro",
   "admin.about.cloud.viewCert": "View Certificate",
-
   "admin.cloudStore.title": "Storage Plans",
   "admin.cloudStore.subtitle": "Manage purchasable storage plans and gift cards for personal and team workspaces.",
   "admin.cloudStore.enabled": "Enabled",
@@ -1598,7 +1592,6 @@
   "storage.quotaChip": "{{size}} storage",
   "storage.creditDiscount": "Discount {{amount}}",
   "storage.giftCardCode": "Gift card code",
-
   "storage.historyTitle": "Recent orders",
   "storage.historyDescription": "Recent storage plan orders for the current workspace.",
   "storage.noPackages": "No subscription plans are available right now.",
@@ -1616,5 +1609,11 @@
   "device.denied": "Downloader denied.",
   "device.failed": "Device authorization failed.",
   "device.approvedMessage": "Authorization complete. You can return to the downloader CLI.",
-  "device.deniedMessage": "Authorization denied. You can close this page."
+  "device.deniedMessage": "Authorization denied. You can close this page.",
+  "features.socialLoginOidc.limit": "Up to {{count}} provider",
+  "features.socialLoginOidc.unlimited": "Unlimited",
+  "features.category.advanced": "Advanced Features",
+  "features.downloaders": "Downloaders",
+  "features.downloaders.limit": "Up to {{count}} downloader",
+  "features.downloaders.unlimited": "Unlimited"
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1164,7 +1164,6 @@
   "share.copyShareText": "复制分享文案",
   "share.textCopied": "分享文案已复制",
   "share.shareTextTemplate": "链接：{{url}}\n密码：{{password}}",
-
   "ihost.title": "图床",
   "ihost.enableCta.title": "启用图床",
   "ihost.enableCta.description": "通过 PicGo、uPic、ShareX 或网页上传图片，获取绑定到你自己域名的永久链接。",
@@ -1186,7 +1185,6 @@
   "ihost.upload.failed": "上传 {{name}} 失败",
   "ihost.table.dimensions": "尺寸",
   "ihost.table.accessCount": "访问次数",
-
   "settings.ihost.title": "图床设置",
   "settings.ihost.lockedTitle": "需要管理员权限",
   "settings.ihost.lockedDescription": "只有工作区所有者和管理员才能管理图床设置。",
@@ -1242,9 +1240,8 @@
   "settings.ihost.tools.upic.instructions": "在 uPic 中前往 偏好设置 → 图床 → 添加 → 自定义，逐个填入以下字段。通过「请求头」按钮添加 Authorization：",
   "settings.ihost.tools.sharex.instructions": "下载 .sxcu 文件并双击以导入 ShareX，ShareX 将自动将 ZPan 设置为自定义上传器。",
   "settings.ihost.tools.sharex.download": "下载 .sxcu",
-
   "settings.tabBilling": "账单",
-  "settings.billing.intro": "ZPan Pro — 解锁运营级功能。在 ZPan Cloud 购买或兑换。",
+  "settings.billing.intro": "解锁 ZPan Pro 与 Business 的运营级与商业化功能。在 ZPan Cloud 购买或兑换授权后，连接即可启用。",
   "settings.billing.connectButton": "连接 ZPan Cloud",
   "settings.billing.comparison.title": "功能对比",
   "settings.billing.comparison.feature": "功能",
@@ -1261,17 +1258,17 @@
   "features.openRegistration": "开放用户注册",
   "features.multiIdpSso": "多 IdP SSO (SAML)",
   "features.ldapScim": "LDAP & SCIM 同步",
-  "features.teamWorkspaces": "无限团队空间",
+  "features.teamWorkspaces": "团队空间",
   "features.teamWorkspaces.limit": "最多 {{count}} 个团队空间",
   "features.teamWorkspaces.unlimited": "无限制",
-  "features.storageBackends": "无限存储",
+  "features.storageBackends": "存储",
   "features.storageBackends.limit": "最多 {{count}} 个存储",
   "features.storageBackends.unlimited": "无限制",
   "features.shareLinks": "外链分享",
   "features.imageHosting": "基础图床功能",
   "features.whiteLabel": "自定义品牌",
   "features.auditLog": "审计日志",
-  "features.cloudStore": "存储套餐",
+  "features.cloudStore": "售卖存储与流量",
   "features.siteAnnouncements": "站点公告",
   "features.webhooks": "事件 Webhooks",
   "features.analytics": "统计分析",
@@ -1325,12 +1322,10 @@
   "settings.billing.bound.pro.disconnectSuccess": "已移除 Pro 授权",
   "settings.billing.bound.business.disconnectSuccess": "已移除 Business 授权",
   "settings.billing.bound.disconnectError": "移除授权失败",
-
   "admin.licenseRibbon.community": "Free",
   "admin.licenseRibbon.pro": "专业版",
   "admin.licenseRibbon.business": "商业版",
   "admin.licenseRibbon.ariaLabel": "{{edition}}",
-
   "admin.about.title": "关于 ZPan",
   "admin.about.subtitle": "版本、实例信息及相关链接。",
   "admin.about.instanceTitle": "实例信息",
@@ -1351,7 +1346,6 @@
   "admin.about.cloud.descriptionBound": "在 ZPan Cloud 查看授权证书并管理绑定。",
   "admin.about.cloud.cta": "升级到专业版",
   "admin.about.cloud.viewCert": "查看授权证书",
-
   "admin.cloudStore.title": "存储套餐",
   "admin.cloudStore.subtitle": "管理个人空间和团队工作空间可购买的存储套餐及礼品卡。",
   "admin.cloudStore.enabled": "启用",
@@ -1598,7 +1592,6 @@
   "storage.quotaChip": "{{size}} 存储",
   "storage.creditDiscount": "订单优惠 {{amount}}",
   "storage.giftCardCode": "礼品卡代码",
-
   "storage.historyTitle": "最近订单",
   "storage.historyDescription": "当前工作空间近期的存储计划订单。",
   "storage.noPackages": "当前暂无可用订阅套餐。",
@@ -1616,5 +1609,11 @@
   "device.denied": "已拒绝下载器授权。",
   "device.failed": "设备授权失败。",
   "device.approvedMessage": "授权已完成，可以回到下载器 CLI。",
-  "device.deniedMessage": "已拒绝授权，可以关闭此页面。"
+  "device.deniedMessage": "已拒绝授权，可以关闭此页面。",
+  "features.socialLoginOidc.limit": "最多 {{count}} 个登录方式",
+  "features.socialLoginOidc.unlimited": "无限制",
+  "features.category.advanced": "高级功能",
+  "features.downloaders": "下载器",
+  "features.downloaders.limit": "最多 {{count}} 个下载器",
+  "features.downloaders.unlimited": "无限制"
 }


### PR DESCRIPTION
## What & why

Refines the v2 commercialization tiering on the Licensing page and feature gates.

### 1. Comparison table: group by capability, not by tier
The table previously grouped features into **Pro/Business sections** while *also* showing per-edition columns — two axes for the same thing, contradictory once features moved between tiers. Now:
- Grouping axis = **capability** (`core` / `advanced`), a functional dimension.
- Edition availability = the **per-edition cells** only.
- **Coming Soon** features show a badge next to the *name* with a muted check in the target edition column, so it's clear which edition they'll land in (previously the badge filled both Pro & Business identically).

### 2. Tier reclassification (product decision)
| Feature | Free | Pro | Business |
|---|---|---|---|
| Social login & OIDC | **1 provider** | unlimited | unlimited |
| Downloaders | **1** | unlimited | unlimited |
| Site announcements | ❌ | ❌ | ✅ |
| Multi-IdP SSO / LDAP·SCIM / Analytics (coming soon) | ❌ | ❌ | ✅ |

### 3. New runtime gates (enforced, mirroring the storages count-gate)
- `social_login_unlimited` — `POST /api/admin/auth-providers` returns **402** on the 2nd provider on the free plan.
- `downloaders_unlimited` — `POST /api/admin/downloaders` returns **402** on the 2nd downloader on the free plan (OpenAPI spec + Go client regenerated).
- `site_announcements` moved into the Business-only set.

### 4. Copy cleanup
- Drop limit words from row names: *Unlimited Team Workspaces → Team Workspaces*, *Storage Backends → Storages* (cells already say "Unlimited").
- *Storage Plans → Sell Storage & Traffic* (clarifies the `quota_store` feature).
- Licensing page intro is now edition-neutral (Pro + Business) instead of leftover Pro-only copy.

### 5. Remove the unused per-cert feature override
The optional `features[]` override on the license certificate was added with the Pro/Business split but never exercised — real certs carry only `edition`, and entitlements derive from it via the feature registry. Removed it so **edition is the single source of truth** (`effectiveFeatures(edition)`), dropping `LicenseAssertion.features`, `normalizeFeatures`, and the duplicated test-side business-only set. `BindingState.features` (the resolved list sent to the client) is kept.

> As a result, the `site_announcements` → Business move is fully authoritative in ZPan — no zpan-cloud change required, since certs only carry `edition`.

## Testing
- `npm run typecheck` ✅ · full suite ✅ (**3710 tests**) · CI green (incl. E2E CF/Node, codecov).
- Added gate tests for both new limits; updated licensing tests to assert edition-derived entitlements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)