### PR TITLE
fix(admin): register default quota input with valueAsNumber

### DIFF
--- a/src/routes/_authenticated/admin/settings/index.test.tsx
+++ b/src/routes/_authenticated/admin/settings/index.test.tsx
@@ -159,6 +159,22 @@ describe('SettingsPage', () => {
     expect(toast.success).toHaveBeenCalledWith('admin.settings.saved')
   })
 
+  it('saves a newly typed quota value as bytes', async () => {
+    const view = renderSettingsPage()
+
+    const quotaInput = await view.findByLabelText('admin.settings.defaultOrgQuota')
+    await waitFor(() => expect(quotaInput).toHaveProperty('value', '1'))
+    fireEvent.change(quotaInput, { target: { value: '5' } })
+
+    const storageSection = view.getByText('admin.settings.storageSection').closest('[data-slot="card"]')
+    if (!storageSection) throw new Error('storage section not found')
+    fireEvent.click(within(storageSection as HTMLElement).getByRole('button', { name: 'common.save' }))
+
+    await waitFor(() => expect(setSystemOption).toHaveBeenCalledWith('default_org_quota', '5368709120', false))
+    expect(toast.success).toHaveBeenCalledWith('admin.settings.saved')
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
   it('saves captcha settings from the authentication protection section', async () => {
     const view = renderSettingsPage()
 

--- a/src/routes/_authenticated/admin/settings/index.tsx
+++ b/src/routes/_authenticated/admin/settings/index.tsx
@@ -431,7 +431,7 @@ export function SettingsPage() {
         <StorageSettingsSection
           quotaUnit={quotaUnit}
           quotaError={form.formState.errors.quotaValue?.message}
-          quotaInputProps={form.register('quotaValue')}
+          quotaInputProps={form.register('quotaValue', { valueAsNumber: true })}
           pending={storageMutation.isPending}
           onQuotaUnitChange={(unit) => form.setValue('quotaUnit', unit)}
           onSave={() => storageMutation.mutate()}


### PR DESCRIPTION
## Problem

Saving the default org quota in admin settings failed with **"Quota must be a positive number"** for any value the admin typed, while leaving the default untouched saved fine.

## Root cause

The quota field was registered with `form.register('quotaValue')` — **without `valueAsNumber`** — so a typed value is stored as a *string*. The save handler reads `form.getValues()` directly (bypassing the zod `coerce`) and runs:

```ts
if (!Number.isFinite(values.quotaValue) || values.quotaValue <= 0)
```

`Number.isFinite("100")` is `false` (it doesn't coerce strings), so every typed positive number was rejected. The default-untouched case worked only because `form.reset()` seeds the value as a number.

## Fix

Register the number input with `{ valueAsNumber: true }` so it stores a number. Empty input becomes `NaN`, still correctly rejected.

## Test

Added a regression test that types a *different* value (5), exercising `onChange`. The existing quota test reused the default display value (`1`), so React's `onChange` never fired and the bug slipped through. Verified the new test fails on the old code and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)