### PR TITLE
fix+refactor: audit bugs (license cache, timing-safe token) + architecture cleanup

### DIFF
--- a/server/lib/constant-time.test.ts
+++ b/server/lib/constant-time.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { constantTimeEqual } from './constant-time'
+
+describe('constantTimeEqual', () => {
+  it('returns true for identical strings', () => {
+    expect(constantTimeEqual('Bearer abc123', 'Bearer abc123')).toBe(true)
+    expect(constantTimeEqual('', '')).toBe(true)
+  })
+
+  it('returns false for differing strings of equal length', () => {
+    expect(constantTimeEqual('Bearer abc123', 'Bearer abc124')).toBe(false)
+  })
+
+  it('returns false for differing lengths', () => {
+    expect(constantTimeEqual('short', 'longer-token')).toBe(false)
+    expect(constantTimeEqual('abc', '')).toBe(false)
+  })
+})

--- a/server/lib/constant-time.ts
+++ b/server/lib/constant-time.ts
@@ -1,0 +1,13 @@
+/**
+ * Length-aware constant-time string comparison. Avoids leaking how many
+ * leading characters match via response timing — use for comparing secrets
+ * (tokens, signatures) supplied by a caller.
+ */
+export function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  let result = 0
+  for (let i = 0; i < a.length; i += 1) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return result === 0
+}

--- a/server/lib/http-errors.test.ts
+++ b/server/lib/http-errors.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { NameConflictError } from '../services/matter-name-conflict'
+import { StorageQuotaExceededError } from '../services/storage-usage'
+import { WebDavPathError } from '../services/webdav-path'
+import { mapDomainError } from './http-errors'
+
+describe('mapDomainError', () => {
+  it('maps StorageQuotaExceededError to 422', () => {
+    const m = mapDomainError(new StorageQuotaExceededError())
+    expect(m).toEqual({ status: 422, message: 'Quota exceeded', json: { error: 'Quota exceeded' } })
+  })
+
+  it('maps NameConflictError to 409 with conflict metadata', () => {
+    const m = mapDomainError(new NameConflictError('doc.txt', 'id-1'))
+    expect(m?.status).toBe(409)
+    expect(m?.json).toMatchObject({ code: 'NAME_CONFLICT', conflictingName: 'doc.txt', conflictingId: 'id-1' })
+  })
+
+  it('maps WebDavPathError to its own status', () => {
+    const m = mapDomainError(new WebDavPathError('Bad path', 409))
+    expect(m).toEqual({ status: 409, message: 'Bad path', json: { error: 'Bad path' } })
+  })
+
+  it('returns null for unrecognized errors', () => {
+    expect(mapDomainError(new Error('boom'))).toBeNull()
+    expect(mapDomainError(null)).toBeNull()
+  })
+})

--- a/server/lib/http-errors.ts
+++ b/server/lib/http-errors.ts
@@ -1,0 +1,40 @@
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
+import { NameConflictError } from '../services/matter-name-conflict'
+import { StorageQuotaExceededError } from '../services/storage-usage'
+import { WebDavPathError } from '../services/webdav-path'
+
+export interface DomainErrorMapping {
+  status: ContentfulStatusCode
+  /** Plain message for text responses (e.g. WebDAV). */
+  message: string
+  /** Structured body for JSON responses. */
+  json: Record<string, unknown>
+}
+
+/**
+ * Maps a known domain error to its HTTP status and response bodies, or null
+ * when the error is not one we translate (caller should rethrow). Centralizes
+ * the quota→422 / name-conflict→409 / webdav-path mappings that routes
+ * otherwise hand-roll.
+ */
+export function mapDomainError(error: unknown): DomainErrorMapping | null {
+  if (error instanceof StorageQuotaExceededError) {
+    return { status: 422, message: 'Quota exceeded', json: { error: 'Quota exceeded' } }
+  }
+  if (error instanceof NameConflictError) {
+    return {
+      status: 409,
+      message: error.message,
+      json: {
+        error: error.message,
+        code: 'NAME_CONFLICT',
+        conflictingName: error.conflictingName,
+        conflictingId: error.conflictingId,
+      },
+    }
+  }
+  if (error instanceof WebDavPathError) {
+    return { status: error.status as ContentfulStatusCode, message: error.message, json: { error: error.message } }
+  }
+  return null
+}

--- a/server/lib/mime-utils.test.ts
+++ b/server/lib/mime-utils.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { mimeToExt } from './mime-utils'
+
+describe('mimeToExt', () => {
+  it('maps known image MIME types to extensions', () => {
+    expect(mimeToExt('image/png')).toBe('png')
+    expect(mimeToExt('image/jpeg')).toBe('jpg')
+    expect(mimeToExt('image/gif')).toBe('gif')
+    expect(mimeToExt('image/webp')).toBe('webp')
+    expect(mimeToExt('image/svg+xml')).toBe('svg')
+    expect(mimeToExt('image/x-icon')).toBe('ico')
+    expect(mimeToExt('image/vnd.microsoft.icon')).toBe('ico')
+  })
+
+  it('falls back to bin for unknown types', () => {
+    expect(mimeToExt('application/octet-stream')).toBe('bin')
+    expect(mimeToExt('')).toBe('bin')
+  })
+})

--- a/server/lib/mime-utils.ts
+++ b/server/lib/mime-utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Canonical image MIME → file-extension map. Endpoints keep their own
+ * allow-lists (which subset of these they accept); this is only the lookup
+ * for naming the stored object, so it is the superset of every allow-list.
+ */
+const MIME_TO_EXT: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/svg+xml': 'svg',
+  'image/x-icon': 'ico',
+  'image/vnd.microsoft.icon': 'ico',
+}
+
+/** File extension for an image MIME type, or 'bin' when unknown. */
+export function mimeToExt(mime: string): string {
+  return MIME_TO_EXT[mime] ?? 'bin'
+}

--- a/server/licensing/entitlement.test.ts
+++ b/server/licensing/entitlement.test.ts
@@ -2,7 +2,7 @@
 import Database from 'better-sqlite3'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
 import { generateKeys, sign } from 'paseto-ts/v4'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as authSchema from '../db/auth-schema'
 import * as appSchema from '../db/schema'
 import { invalidateEntitlementCache, loadEntitlement } from './entitlement'
@@ -159,6 +159,24 @@ describe('loadEntitlement', () => {
       features: effectiveFeatures('business'),
       licenseId: 'lic-business',
     })
+  })
+
+  it('stops serving a cached entitlement once the certificate expires mid-window', async () => {
+    vi.useFakeTimers()
+    try {
+      const db = makeDb()
+      await seedBinding(db, signAssertion({ expiresAt: nowSec() + 30 }))
+
+      const first = await loadEntitlement(db)
+      expect(first?.edition).toBe('pro')
+
+      // Advance past the cert's 30s expiry but within the 60s cache TTL.
+      vi.advanceTimersByTime(40_000)
+      const second = await loadEntitlement(db)
+      expect(second).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('returns null for an expired PASETO assertion', async () => {

--- a/server/licensing/entitlement.ts
+++ b/server/licensing/entitlement.ts
@@ -20,7 +20,14 @@ let cachedAt = 0
 export async function loadEntitlement(db: Database): Promise<EntitlementSummary | null> {
   const now = Date.now()
   if (cachedAt > 0 && now - cachedAt < CACHE_TTL_MS) {
-    return cachedSummary
+    // The 60s TTL must not outlive the certificate itself: a cert that expires
+    // mid-window would otherwise keep granting features until the cache lapses.
+    if (!cachedSummary) return null
+    const nowSeconds = Math.floor(now / 1000)
+    if (nowSeconds < cachedSummary.certificateExpiresAt && nowSeconds < cachedSummary.licenseValidUntil) {
+      return cachedSummary
+    }
+    // Cached cert has since expired — fall through to re-verify (yields null).
   }
 
   const state = await loadLicenseState(db)

--- a/server/routes/ihost.ts
+++ b/server/routes/ihost.ts
@@ -9,6 +9,7 @@ import {
   patchIhostImageSchema,
 } from '../../shared/schemas'
 import { imageHostings } from '../db/schema'
+import { mapDomainError } from '../lib/http-errors'
 import { requireAuth, requireTeamRole } from '../middleware/auth'
 import { requirePermission } from '../middleware/authz'
 import type { Env } from '../middleware/platform'
@@ -25,7 +26,7 @@ import {
 } from '../services/image-hosting'
 import { S3Service } from '../services/s3'
 import { getStorage, type Storage as S3Storage, selectStorage } from '../services/storage'
-import { StorageQuotaExceededError, withStorageUsageReservation } from '../services/storage-usage'
+import { withStorageUsageReservation } from '../services/storage-usage'
 import { PRESIGN_TTL_SECS } from './share-utils'
 
 const s3 = new S3Service()
@@ -208,7 +209,8 @@ const app = new Hono<Env>()
         201,
       )
     } catch (err) {
-      if (err instanceof StorageQuotaExceededError) return c.json({ error: 'Quota exceeded' }, 422)
+      const mapped = mapDomainError(err)
+      if (mapped) return c.json(mapped.json, mapped.status)
       throw err
     }
   })

--- a/server/routes/internal.ts
+++ b/server/routes/internal.ts
@@ -1,5 +1,6 @@
 import { release as osRelease } from 'node:os'
 import { Hono } from 'hono'
+import { constantTimeEqual } from '../lib/constant-time'
 import type { Env } from '../middleware/platform'
 import { getDeployPlatform } from '../runtime-platform'
 import { INSTANCE_TELEMETRY_CRON, reportInstanceTelemetry } from '../services/instance-telemetry'
@@ -18,7 +19,7 @@ internal.post('/instance-telemetry/report', async (c) => {
   if (!token) return c.json({ error: 'Not found' }, 404)
 
   const auth = c.req.header('authorization') ?? ''
-  if (auth !== `Bearer ${token}`) return c.json({ error: 'Unauthorized' }, 401)
+  if (!constantTimeEqual(auth, `Bearer ${token}`)) return c.json({ error: 'Unauthorized' }, 401)
 
   const runtime = platform.getBinding('DB')
     ? {

--- a/server/routes/objects.ts
+++ b/server/routes/objects.ts
@@ -13,6 +13,7 @@ import {
   presignObjectUploadPartsSchema,
   transferMatterSchema,
 } from '../../shared/schemas'
+import { mapDomainError } from '../lib/http-errors'
 import { requireTeamRole } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
 import { recordActivity } from '../services/activity'
@@ -30,7 +31,6 @@ import {
   trashMatter,
   updateMatter,
 } from '../services/matter'
-import { NameConflictError } from '../services/matter-name-conflict'
 import {
   createObjectUploadSession,
   ObjectUploadSessionError,
@@ -43,19 +43,10 @@ import { purgeRecursively } from '../services/purge'
 import { S3Service } from '../services/s3'
 import { computeSourceBytes, copyMatterToOrg, isQuotaSufficient } from '../services/save-to-drive'
 import { getStorage, type Storage as S3Storage, selectStorage } from '../services/storage'
-import { StorageQuotaExceededError, withStorageUsageReservation } from '../services/storage-usage'
+import { withStorageUsageReservation } from '../services/storage-usage'
 import { consumeAndReportDownloadTraffic } from './traffic-metering-utils'
 
 const s3 = new S3Service()
-
-function conflictBody(err: NameConflictError) {
-  return {
-    error: err.message,
-    code: 'NAME_CONFLICT' as const,
-    conflictingName: err.conflictingName,
-    conflictingId: err.conflictingId,
-  }
-}
 
 function normalizeMatterPath(path: string): string {
   return path
@@ -188,7 +179,8 @@ const app = new Hono<Env>()
       const uploadUrl = await s3.presignUpload(storage, objectKey, type, name)
       return c.json({ ...matter, uploadUrl, contentDisposition }, 201)
     } catch (e) {
-      if (e instanceof NameConflictError) return c.json(conflictBody(e), 409)
+      const mapped = mapDomainError(e)
+      if (mapped) return c.json(mapped.json, mapped.status)
       throw e
     }
   })
@@ -330,7 +322,8 @@ const app = new Hono<Env>()
           if (!matter) return c.json({ error: 'Not found' }, 404)
           return c.json(matter)
         } catch (e) {
-          if (e instanceof NameConflictError) return c.json(conflictBody(e), 409)
+          const mapped = mapDomainError(e)
+          if (mapped) return c.json(mapped.json, mapped.status)
           return c.json({ error: (e as Error).message }, 400)
         }
       }
@@ -344,7 +337,8 @@ const app = new Hono<Env>()
           if (!matter) return c.json({ error: 'Not found or not in draft status' }, 404)
           return c.json(matter)
         } catch (e) {
-          if (e instanceof NameConflictError) return c.json(conflictBody(e), 409)
+          const mapped = mapDomainError(e)
+          if (mapped) return c.json(mapped.json, mapped.status)
           throw e
         }
       }
@@ -374,7 +368,8 @@ const app = new Hono<Env>()
           if (!matter) return c.json({ error: 'Not found' }, 404)
           return c.json(matter)
         } catch (e) {
-          if (e instanceof NameConflictError) return c.json(conflictBody(e), 409)
+          const mapped = mapDomainError(e)
+          if (mapped) return c.json(mapped.json, mapped.status)
           throw e
         }
       }
@@ -439,8 +434,8 @@ const app = new Hono<Env>()
       )
       return c.json(copy, 201)
     } catch (e) {
-      if (e instanceof StorageQuotaExceededError) return c.json({ error: 'Quota exceeded' }, 422)
-      if (e instanceof NameConflictError) return c.json(conflictBody(e), 409)
+      const mapped = mapDomainError(e)
+      if (mapped) return c.json(mapped.json, mapped.status)
       throw e
     }
   })

--- a/server/routes/webdav.ts
+++ b/server/routes/webdav.ts
@@ -5,19 +5,15 @@ import { ApiKeyTemplate } from '../../shared/api-key-templates'
 import { DirType, ObjectStatus } from '../../shared/constants'
 import { user } from '../db/auth-schema'
 import { matters } from '../db/schema'
+import { mapDomainError } from '../lib/http-errors'
 import type { Env } from '../middleware/platform'
 import { ApiKeyRateLimitError, verifyApiKeyForPermission } from '../services/api-keys'
 import { refundTraffic } from '../services/effective-quota'
 import { copyMatter, createMatter, trashMatter, updateMatter } from '../services/matter'
-import { NameConflictError } from '../services/matter-name-conflict'
 import { buildObjectKey, fileExt } from '../services/path-template'
 import { S3Service } from '../services/s3'
 import { getStorage, type Storage as S3Storage, selectStorage } from '../services/storage'
-import {
-  reconcileStorageUsage,
-  StorageQuotaExceededError,
-  withStorageUsageReservation,
-} from '../services/storage-usage'
+import { reconcileStorageUsage, withStorageUsageReservation } from '../services/storage-usage'
 import {
   ensureFolder,
   joinMatterPath,
@@ -150,8 +146,8 @@ function normalizeDavMountPath(pathname: string): string {
 }
 
 function davError(c: DavContext, error: unknown): Response {
-  if (error instanceof WebDavPathError) return new Response(error.message, { status: error.status })
-  if (error instanceof NameConflictError) return c.text(error.message, 409)
+  const mapped = mapDomainError(error)
+  if (mapped) return c.text(mapped.message, mapped.status)
   throw error
 }
 
@@ -919,7 +915,8 @@ async function putFile(c: DavContext, auth: DavAuth): Promise<Response> {
         },
       )
     } catch (e) {
-      if (e instanceof StorageQuotaExceededError) return c.text('Quota exceeded', 422)
+      const mapped = mapDomainError(e)
+      if (mapped) return c.text(mapped.message, mapped.status)
       throw e
     }
   } catch (e) {
@@ -1131,7 +1128,8 @@ async function copyMatterRoute(c: DavContext, auth: DavAuth): Promise<Response> 
         },
       )
     } catch (e) {
-      if (e instanceof StorageQuotaExceededError) return c.text('Quota exceeded', 422)
+      const mapped = mapDomainError(e)
+      if (mapped) return c.text(mapped.message, mapped.status)
       throw e
     }
   } catch (e) {
@@ -1234,7 +1232,8 @@ async function copyCollection(
       await deleteWebDavState(db, targetWorkspace.id, targetRoot)
     }
     if (targetRows.length > 0) await restoreActiveMatterRows(db, targetRows)
-    if (e instanceof StorageQuotaExceededError) return c.text('Quota exceeded', 422)
+    const mapped = mapDomainError(e)
+    if (mapped) return c.text(mapped.message, mapped.status)
     throw e
   }
 }

--- a/server/services/branding.ts
+++ b/server/services/branding.ts
@@ -1,6 +1,7 @@
 import { eq, inArray } from 'drizzle-orm'
 import { type BrandingThemeConfig, type BrandingThemeMode, isBrandingThemePresetId } from '../../shared/types'
 import { systemOptions } from '../db/schema'
+import { mimeToExt } from '../lib/mime-utils'
 import type { Database, Platform } from '../platform/interface'
 import { S3Service } from './s3'
 import { type Storage as S3Storage, selectStorage } from './storage'
@@ -10,15 +11,6 @@ const s3 = new S3Service()
 const LOGO_MIMES = ['image/png', 'image/jpeg', 'image/webp', 'image/svg+xml'] as const
 const FAVICON_MIMES = ['image/png', 'image/x-icon', 'image/vnd.microsoft.icon', 'image/svg+xml'] as const
 export const MAX_BRANDING_FILE_SIZE = 2 * 1024 * 1024 // 2 MiB
-
-const MIME_TO_EXT: Record<string, string> = {
-  'image/png': 'png',
-  'image/jpeg': 'jpg',
-  'image/webp': 'webp',
-  'image/svg+xml': 'svg',
-  'image/x-icon': 'ico',
-  'image/vnd.microsoft.icon': 'ico',
-}
 
 export const BRANDING_KEYS = {
   logo: 'branding_logo_url',
@@ -88,7 +80,7 @@ export async function uploadBrandingImage(
     return { ok: false, status: 503, error: 'No public storage configured' }
   }
 
-  const ext = MIME_TO_EXT[file.type] ?? 'bin'
+  const ext = mimeToExt(file.type)
   const key = `_system/branding/${field}.${ext}`
   const bytes = new Uint8Array(await file.arrayBuffer())
   await s3.putObject(storage, key, bytes, file.type)

--- a/server/services/download-tokens.ts
+++ b/server/services/download-tokens.ts
@@ -1,6 +1,7 @@
 import { eq } from 'drizzle-orm'
 import { z } from 'zod'
 import { downloaders, downloadTasks } from '../db/schema'
+import { constantTimeEqual } from '../lib/constant-time'
 import type { Database, Platform } from '../platform/interface'
 
 const TOKEN_VERSION = 1
@@ -151,13 +152,4 @@ function base64UrlDecode(value: string): string {
     .replace(/_/g, '/')
     .padEnd(Math.ceil(value.length / 4) * 4, '=')
   return atob(padded)
-}
-
-function constantTimeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) return false
-  let result = 0
-  for (let i = 0; i < a.length; i += 1) {
-    result |= a.charCodeAt(i) ^ b.charCodeAt(i)
-  }
-  return result === 0
 }

--- a/server/services/effective-quota.ts
+++ b/server/services/effective-quota.ts
@@ -37,50 +37,10 @@ export function currentTrafficPeriod(now = new Date()): string {
 }
 
 export async function getEffectiveQuota(db: Database, orgId: string, now = new Date()): Promise<EffectiveQuota> {
-  const period = currentTrafficPeriod(now)
-
-  const quotaRows = await db
-    .select({
-      id: orgQuotas.id,
-      baseQuota: orgQuotas.quota,
-      used: orgQuotas.used,
-      trafficQuota: orgQuotas.trafficQuota,
-      trafficUsed: orgQuotas.trafficUsed,
-      trafficPeriod: orgQuotas.trafficPeriod,
-    })
-    .from(orgQuotas)
-    .where(eq(orgQuotas.orgId, orgId))
-    .limit(1)
-  const quotaRow = quotaRows[0]
-
-  const storagePlan = await activePlanEntitlement(db, orgId, 'storage', now)
-  const entitlementQuota = await activeExtraEntitlementBytes(db, orgId, 'storage', now)
-  const storageExtraNames = await activeExtraEntitlementNames(db, orgId, 'storage', now)
-  const entitlementTrafficQuota = await activeExtraEntitlementBytes(db, orgId, 'traffic', now)
-  const trafficExtraNames = await activeExtraEntitlementNames(db, orgId, 'traffic', now)
-  const trafficUsed = quotaRow && quotaRow.trafficPeriod === period ? quotaRow.trafficUsed : 0
-  const trafficPeriod = quotaRow?.trafficPeriod === period ? quotaRow.trafficPeriod : period
-  const trafficPlan = await activePlanEntitlement(db, orgId, 'traffic', now)
-  const currentPlan = buildCurrentPlan(storagePlan, trafficPlan)
-  const baseQuota = storagePlan?.bytes ?? 0
-  const baseTrafficQuota = trafficPlan?.bytes ?? 0
-  return {
-    orgId,
-    baseQuota,
-    entitlementQuota,
-    quota: baseQuota + entitlementQuota,
-    used: quotaRow?.used ?? 0,
-    baseTrafficQuota,
-    entitlementTrafficQuota,
-    trafficQuota: baseTrafficQuota + entitlementTrafficQuota,
-    trafficUsed,
-    trafficPeriod,
-    storagePlanName: storagePlan?.name ?? null,
-    storageExtraNames,
-    trafficPlanName: trafficPlan?.name ?? null,
-    trafficExtraNames,
-    currentPlan,
-  }
+  // Delegate to the batch path's single in-memory aggregation. It always
+  // returns an entry for every requested orgId (zero-filled when absent).
+  const byOrg = await getEffectiveQuotasByOrg(db, [orgId], now)
+  return byOrg.get(orgId) as EffectiveQuota
 }
 
 // Batch variant of getEffectiveQuota for list views. Resolves every org with two
@@ -424,44 +384,8 @@ function toPlanEntitlement(row: {
   }
 }
 
-async function activeExtraEntitlementBytes(
-  db: Database,
-  orgId: string,
-  resourceType: 'storage' | 'traffic',
-  now: Date,
-): Promise<number> {
-  const rows = await db
-    .select({ bytes: sql<number>`COALESCE(SUM(${orgQuotaEntitlements.bytes}), 0)` })
-    .from(orgQuotaEntitlements)
-    .where(activeExtraEntitlementWhere(orgId, resourceType, now))
-
-  return rows[0]?.bytes ?? 0
-}
-
-async function activeExtraEntitlementNames(
-  db: Database,
-  orgId: string,
-  resourceType: 'storage' | 'traffic',
-  now: Date,
-): Promise<string[]> {
-  const rows = await db
-    .select({ metadata: orgQuotaEntitlements.metadata })
-    .from(orgQuotaEntitlements)
-    .where(activeExtraEntitlementWhere(orgId, resourceType, now))
-
-  const names = rows.flatMap((row) => {
-    const name = entitlementName(row.metadata)
-    return name ? [name] : []
-  })
-  return Array.from(new Set(names))
-}
-
 function activePlanEntitlementWhere(orgId: string, resourceType: 'storage' | 'traffic', now: Date) {
   return activeEntitlementWhere(orgId, resourceType, now, sql`${orgQuotaEntitlements.entitlementType} = 'plan'`)
-}
-
-function activeExtraEntitlementWhere(orgId: string, resourceType: 'storage' | 'traffic', now: Date) {
-  return activeEntitlementWhere(orgId, resourceType, now, sql`${orgQuotaEntitlements.entitlementType} != 'plan'`)
 }
 
 function activeEntitlementWhere(

--- a/server/services/image-hosting.ts
+++ b/server/services/image-hosting.ts
@@ -3,6 +3,7 @@ import { nanoid } from 'nanoid'
 import type { AllowedImageMime } from '../../shared/schemas'
 import type { ImageHosting } from '../../shared/types'
 import { imageHostingConfigs, imageHostings } from '../db/schema'
+import { mimeToExt } from '../lib/mime-utils'
 import type { Database } from '../platform/interface'
 import { reconcileStorageUsage, StorageQuotaExceededError, withStorageUsageReservation } from './storage-usage'
 
@@ -69,17 +70,6 @@ const PATH_PATTERN = /^[a-zA-Z0-9._/-]+$/
 const MAX_DEPTH = 5
 const MAX_PATH_LENGTH = 256
 const MAX_COLLISION_RETRIES = 5
-
-const MIME_TO_EXT: Record<AllowedImageMime, string> = {
-  'image/png': 'png',
-  'image/jpeg': 'jpg',
-  'image/gif': 'gif',
-  'image/webp': 'webp',
-}
-
-export function mimeToExt(mime: string): string {
-  return MIME_TO_EXT[mime as AllowedImageMime] ?? 'bin'
-}
 
 export type PathValidationError = { error: 'invalid path'; detail: string }
 

--- a/server/services/image-upload.ts
+++ b/server/services/image-upload.ts
@@ -1,3 +1,4 @@
+import { mimeToExt } from '../lib/mime-utils'
 import type { Platform } from '../platform/interface'
 import { S3Service } from './s3'
 import { type Storage as S3Storage, selectStorage } from './storage'
@@ -8,18 +9,12 @@ export const IMAGE_MIMES = ['image/png', 'image/jpeg', 'image/webp'] as const
 export type ImageMime = (typeof IMAGE_MIMES)[number]
 export const MAX_IMAGE_SIZE = 2 * 1024 * 1024 // 2 MiB
 
-const MIME_TO_EXT: Record<ImageMime, string> = {
-  'image/png': 'png',
-  'image/jpeg': 'jpg',
-  'image/webp': 'webp',
-}
-
 export function isImageMime(v: unknown): v is ImageMime {
   return typeof v === 'string' && (IMAGE_MIMES as readonly string[]).includes(v)
 }
 
 export function imageKey(prefix: string, id: string, mime: ImageMime): string {
-  return `${prefix}/${id}.${MIME_TO_EXT[mime]}`
+  return `${prefix}/${id}.${mimeToExt(mime)}`
 }
 
 export type ImageUploadResult = { ok: true; url: string } | { ok: false; status: 400 | 413 | 503; error: string }

--- a/src/components/music/music-player-button.tsx
+++ b/src/components/music/music-player-button.tsx
@@ -8,8 +8,9 @@ import { mimeFromExt } from '@/components/preview/media-preview'
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { getObject } from '@/lib/api'
+import { formatSize } from '@/lib/format'
 import { cn } from '@/lib/utils'
-import { formatTrackSize, toPreviewFile } from './music-player-model'
+import { toPreviewFile } from './music-player-model'
 import { type MusicTrack, useMusicPlayer } from './music-player-provider'
 
 function TrackCover({ track, large }: { track: MusicTrack; large?: boolean }) {
@@ -61,7 +62,7 @@ function TrackButton({
       <span className="min-w-0 flex-1">
         <span className="block truncate font-medium">{track.name}</span>
         <span className="block truncate text-xs text-muted-foreground">
-          {[track.artist, track.album, formatTrackSize(track.size)].filter(Boolean).join(' · ')}
+          {[track.artist, track.album, formatSize(track.size)].filter(Boolean).join(' · ')}
         </span>
       </span>
     </button>

--- a/src/components/music/music-player-model.test.ts
+++ b/src/components/music/music-player-model.test.ts
@@ -1,7 +1,7 @@
 import { DirType, ObjectStatus } from '@shared/constants'
 import type { StorageObject } from '@shared/types'
 import { describe, expect, it } from 'vitest'
-import { formatTrackSize, isMusicPreviewFile, toPreviewFile } from './music-player-model'
+import { isMusicPreviewFile, toPreviewFile } from './music-player-model'
 
 function makeObject(overrides: Partial<StorageObject & { downloadUrl?: string }> = {}): StorageObject & {
   downloadUrl?: string
@@ -26,13 +26,6 @@ function makeObject(overrides: Partial<StorageObject & { downloadUrl?: string }>
 }
 
 describe('music player model', () => {
-  it('formats track size for playlist rows', () => {
-    expect(formatTrackSize(0)).toBe('0 B')
-    expect(formatTrackSize(512)).toBe('512 B')
-    expect(formatTrackSize(1536)).toBe('1.5 KB')
-    expect(formatTrackSize(2 * 1024 * 1024)).toBe('2.0 MB')
-  })
-
   it('detects audio preview files by extension or MIME type', () => {
     expect(isMusicPreviewFile({ id: '1', name: 'song.mp3', type: '', size: 1, downloadUrl: 'u' })).toBe(true)
     expect(isMusicPreviewFile({ id: '2', name: 'song.bin', type: 'audio/flac', size: 1, downloadUrl: 'u' })).toBe(true)

--- a/src/components/music/music-player-model.ts
+++ b/src/components/music/music-player-model.ts
@@ -2,14 +2,6 @@ import type { StorageObject } from '@shared/types'
 import { getPreviewType } from '@/lib/file-types'
 import type { MusicTrack } from './music-player-provider'
 
-export function formatTrackSize(bytes: number): string {
-  if (bytes === 0) return '0 B'
-  const units = ['B', 'KB', 'MB', 'GB']
-  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1)
-  const value = bytes / 1024 ** i
-  return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`
-}
-
 export function isMusicPreviewFile(file: MusicTrack): boolean {
   return getPreviewType(file.name, file.type) === 'audio'
 }

--- a/src/components/preview/file-preview-dialog.tsx
+++ b/src/components/preview/file-preview-dialog.tsx
@@ -7,6 +7,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sh
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { getPreviewType, type PreviewType } from '@/lib/file-types'
+import { formatSize } from '@/lib/format'
 import { cn } from '@/lib/utils'
 import { FilePreviewContent, PreviewDownloadButton, type PreviewFile } from './file-preview-content'
 import { ImagePreview } from './image-preview'
@@ -22,14 +23,6 @@ interface PreviewPanelProps {
   previewType: PreviewType
   open: boolean
   onOpenChange: (open: boolean) => void
-}
-
-function formatFileSize(bytes: number): string {
-  if (bytes === 0) return '0 B'
-  const units = ['B', 'KB', 'MB', 'GB']
-  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1)
-  const value = bytes / 1024 ** i
-  return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`
 }
 
 function dialogClass(previewType: PreviewType, fullscreen: boolean): string {
@@ -74,7 +67,7 @@ function PreviewHeader({
     <div className="flex items-center justify-between border-b px-4 py-3">
       <div className="min-w-0 flex-1">
         <p className={cn('truncate font-medium', compact ? 'text-sm' : 'text-base')}>{file.name}</p>
-        <p className="text-xs text-muted-foreground">{formatFileSize(file.size)}</p>
+        <p className="text-xs text-muted-foreground">{formatSize(file.size)}</p>
       </div>
       <div className="flex shrink-0 items-center gap-1 pl-2">
         <PreviewDownloadButton url={file.downloadUrl} filename={file.name} compact={compact} />

--- a/src/components/store/checkout-confirm-dialog.tsx
+++ b/src/components/store/checkout-confirm-dialog.tsx
@@ -15,6 +15,7 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { ApiError, createDiscountQuote } from '@/lib/api'
+import { formatCurrency } from '@/lib/format'
 
 export type CheckoutSelection = {
   packageId: string
@@ -89,7 +90,7 @@ export function CheckoutConfirmDialog({
                 <>
                   <Row
                     label={t('storage.discountLabel')}
-                    value={`-${formatMoney(quote.discount, selection.currency, language)}`}
+                    value={`-${formatCurrency(quote.discount, selection.currency, language)}`}
                     accent
                   />
                   <Row
@@ -159,17 +160,13 @@ function Row({ label, value, accent, strong }: { label: string; value: string; a
   )
 }
 
-function formatMoney(amount: number, currency: string, language: string) {
-  return new Intl.NumberFormat(language, { style: 'currency', currency: currency.toUpperCase() }).format(amount / 100)
-}
-
 function periodPrice(
   amount: number,
   selection: CheckoutSelection,
   language: string,
   t: ReturnType<typeof useTranslation>['t'],
 ) {
-  const label = formatMoney(amount, selection.currency, language)
+  const label = formatCurrency(amount, selection.currency, language)
   if (selection.interval === 'month') return t('storage.priceMonthly', { amount: label })
   if (selection.interval === 'year') return t('storage.priceYearly', { amount: label })
   return label

--- a/src/components/store/credits-panel.tsx
+++ b/src/components/store/credits-panel.tsx
@@ -13,6 +13,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { cloudProductIncludedCredits } from '@/lib/cloud-product'
+import { formatCurrency } from '@/lib/format'
 import { StorageActions } from './storage-dialogs'
 
 export function CreditBalanceButton({
@@ -96,7 +97,7 @@ function CreditProducts({
                 </div>
               </div>
               <div className="shrink-0 text-sm font-semibold tabular-nums">
-                {formatMoney(price.amount, price.currency, language)}
+                {formatCurrency(price.amount, price.currency, language)}
               </div>
             </div>
             <Button className="mt-3 h-8 w-full" disabled={disabled} onClick={() => onCheckout(product.id, price.id)}>
@@ -182,10 +183,6 @@ function CreditEmptyState({ label }: { label: string }) {
 
 function formatCredits(amount: number) {
   return new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(amount)
-}
-
-function formatMoney(amount: number, currency: string, language: string) {
-  return new Intl.NumberFormat(language, { style: 'currency', currency: currency.toUpperCase() }).format(amount / 100)
 }
 
 function oneTimeUsdPrice(pricesProduct: CloudProduct) {

--- a/src/components/store/order-history.tsx
+++ b/src/components/store/order-history.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/components/ui/dialog'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cloudOrderItemStorageBytes, cloudOrderItemTrafficBytes } from '@/lib/cloud-order'
-import { formatSize } from '@/lib/format'
+import { formatCurrency, formatSize } from '@/lib/format'
 
 export function StorageOrderHistoryDialog({
   orders,
@@ -131,12 +131,12 @@ function OrderRow({
       <div className="flex items-center gap-3 self-center">
         <div className="text-right">
           <div className="text-sm font-medium tabular-nums">
-            {formatMoney(order.totalAmount, order.currency, i18n.resolvedLanguage ?? 'en')}
+            {formatCurrency(order.totalAmount, order.currency, i18n.resolvedLanguage ?? 'en')}
           </div>
           {order.discountAmount > 0 && (
             <div className="text-xs text-muted-foreground">
               {t('storage.creditDiscount', {
-                amount: formatMoney(order.discountAmount, order.currency, i18n.resolvedLanguage ?? 'en'),
+                amount: formatCurrency(order.discountAmount, order.currency, i18n.resolvedLanguage ?? 'en'),
               })}
             </div>
           )}
@@ -202,10 +202,6 @@ function OrderIconButton({
       <TooltipContent>{label}</TooltipContent>
     </Tooltip>
   )
-}
-
-function formatMoney(amount: number, currency: string, language: string) {
-  return new Intl.NumberFormat(language, { style: 'currency', currency: currency.toUpperCase() }).format(amount / 100)
 }
 
 function isActionableOrder(order: CloudOrder) {

--- a/src/components/store/storage-packages.tsx
+++ b/src/components/store/storage-packages.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { cloudProductIncludedCredits, cloudProductStorageBytes } from '@/lib/cloud-product'
-import { formatSize } from '@/lib/format'
+import { formatCurrency, formatSize } from '@/lib/format'
 
 export function StoragePackages({
   packages,
@@ -242,16 +242,12 @@ function selectPlanPrices(prices: CloudProduct['prices']) {
   }
 }
 
-function formatMoney(amount: number, currency: string, language: string) {
-  return new Intl.NumberFormat(language, { style: 'currency', currency: currency.toUpperCase() }).format(amount / 100)
-}
-
 function formatPlanPrice(
   price: CloudProduct['prices'][number],
   language: string,
   t: ReturnType<typeof useTranslation>['t'],
 ) {
-  const amount = formatMoney(price.amount, price.currency, language)
+  const amount = formatCurrency(price.amount, price.currency, language)
   if (price.recurring?.interval === 'month' && price.recurring.intervalCount === 1)
     return t('storage.priceMonthly', { amount })
   if (price.recurring?.interval === 'year' && price.recurring.intervalCount === 1)

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it } from 'vitest'
-import { formatDate, formatSize } from './format'
+import { formatCurrency, formatDate, formatSize } from './format'
+
+describe('formatCurrency', () => {
+  it('formats minor-unit cents as locale currency', () => {
+    expect(formatCurrency(1299, 'usd', 'en-US')).toBe('$12.99')
+    expect(formatCurrency(0, 'usd', 'en-US')).toBe('$0.00')
+  })
+
+  it('uppercases the currency code', () => {
+    expect(formatCurrency(500, 'eur', 'en-US')).toBe('€5.00')
+  })
+})
 
 describe('formatSize', () => {
   it('returns "0 B" for 0 bytes', () => {

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -29,3 +29,10 @@ export function formatSize(bytes: number): string {
 export function formatMoney(amount: number, currency: string): string {
   return `${(amount / 100).toFixed(2)} ${currency.toUpperCase()}`
 }
+
+/** Locale-aware currency from a minor-unit (cents) amount, e.g. 1299 → "$12.99". */
+export function formatCurrency(amountCents: number, currency: string, locale?: string): string {
+  return new Intl.NumberFormat(locale, { style: 'currency', currency: currency.toUpperCase() }).format(
+    amountCents / 100,
+  )
+}

--- a/src/routes/_authenticated/users/index.tsx
+++ b/src/routes/_authenticated/users/index.tsx
@@ -9,7 +9,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { listUsers, type UserWithOrg, updateUserStatus } from '@/lib/api'
-import { formatSize, getInitials } from '@/lib/format'
+import { formatDate, formatSize, getInitials } from '@/lib/format'
 
 export const Route = createFileRoute('/_authenticated/users/')({
   component: UsersPage,
@@ -227,9 +227,4 @@ function UserTableRow({
 function formatQuota(used: number, total: number): string {
   if (total <= 0) return `${formatSize(used)} / --`
   return `${formatSize(used)} / ${formatSize(total)}`
-}
-
-function formatDate(timestamp: number): string {
-  const d = new Date(timestamp)
-  return Number.isNaN(d.getTime()) ? '—' : d.toLocaleDateString()
 }


### PR DESCRIPTION
Second pass on the audit backlog: the remaining correctness/security bugs plus the higher-value architecture cleanup. Each commit is self-contained with tests; both typecheck configs are clean and the touched suites pass.

## Bugs
- **fix(security): constant-time compare for internal API token** — the internal telemetry endpoint compared the Bearer token with `!==` (timing side-channel). Reuse a shared `constantTimeEqual` (extracted from download-tokens.ts).
- **fix(licensing): drop cached entitlement once the certificate expires** — `loadEntitlement` cached the verified summary for 60s by wall-clock age only, so a cert expiring mid-window kept granting Pro/Business features. Cache hits now also check `certificateExpiresAt`/`licenseValidUntil`.

## Architecture cleanup
- **refactor(server): central domain-error → HTTP mapper** — `mapDomainError` replaces the hand-rolled quota→422 / name-conflict→409 / webdav-path `instanceof` ladders across objects.ts (6×), webdav.ts (4×), ihost.ts, and the duplicated `conflictBody`.
- **refactor(server): dedupe MIME→ext into lib/mime-utils** — three services each had a `MIME_TO_EXT` map; consolidated into one shared lookup (endpoints keep their allow-lists).
- **refactor(ui): dedupe currency/size formatters** — `formatCurrency` replaces 4 identical store `formatMoney` copies; `formatSize`/`formatDate` replace the `formatFileSize`/`formatTrackSize`/verbatim-`formatDate` reimplementations.
- **refactor(quota): route getEffectiveQuota through the batch aggregation** — the single-org path now reuses the batch in-memory aggregation (2 queries vs ~8) and the now-unused per-resource SQL helpers are deleted (−75 lines).

## Deliberately not done (engineering judgment)
- **replace-on-upload quota double-reserve** — the only correct fix (net-neutral replace) requires purging the replaced file instead of trashing it (losing undo) plus a coordinated frontend conflict-prompt change. That's a product decision, not a mechanical bug fix, so it's flagged for a separate call rather than shipped silently.
- **pagination helper (D5)** — `(page-1)*pageSize` is a trivial expression; a helper across 13 slightly-different call sites would add indirection without reducing real complexity.
- **generic ConfirmDialog (D10)** — the existing confirm dialogs are specialized (e.g. checkout carries order details); a forced generic primitive risks over-abstraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)