### PR TITLE
fix(upload): overwrite-on-replace (no trash, net-neutral quota, no double prompt)

### DIFF
--- a/server/routes/objects-quota.integration.test.ts
+++ b/server/routes/objects-quota.integration.test.ts
@@ -606,4 +606,44 @@ describe('PATCH /api/objects/:id (action: confirm) — quota enforcement via con
     const body = (await res.json()) as Record<string, unknown>
     expect(body.status).toBe('active')
   })
+
+  it('replaces a same-size file at full quota — net-neutral, incumbent purged', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    // Quota exactly full: the 100-byte incumbent fills the 100-byte quota.
+    await insertFile(db, orgId, { id: 'incumbent', name: 'doc.txt', size: 100 })
+    await setOrgQuota(db, orgId, 100, 100)
+
+    // Create the replacement draft (incumbent stays active — overwrite deferred).
+    const createRes = await app.request('/api/objects', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'doc.txt',
+        type: 'text/plain',
+        size: 100,
+        parent: '',
+        dirtype: 0,
+        onConflict: 'replace',
+      }),
+    })
+    expect(createRes.status).toBe(201)
+    const draft = (await createRes.json()) as { id: string }
+
+    // Confirm with replace. Before the fix this 422'd (headroom for both copies).
+    const confirmRes = await app.request(`/api/objects/${draft.id}`, {
+      method: 'PATCH',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'confirm', onConflict: 'replace' }),
+    })
+    expect(confirmRes.status).toBe(200)
+
+    // Incumbent purged (overwritten, not trashed) and usage unchanged.
+    const incumbent = await db.all(sql`SELECT id FROM matters WHERE id = 'incumbent'`)
+    expect(incumbent).toHaveLength(0)
+    const quotaRows = await db.all<{ used: number }>(sql`SELECT used FROM org_quotas WHERE org_id = ${orgId}`)
+    expect(quotaRows[0].used).toBe(100)
+  })
 })

--- a/server/routes/objects.ts
+++ b/server/routes/objects.ts
@@ -332,6 +332,7 @@ const app = new Hono<Env>()
           const { matter, quotaExceeded } = await confirmUpload(db, c.req.param('id'), orgId, {
             onConflict: body.onConflict,
             userId,
+            purgeReplaced: (incumbent) => purgeRecursively(db, orgId, [incumbent]).then(() => undefined),
           })
           if (quotaExceeded) return c.json({ error: 'Quota exceeded' }, 422)
           if (!matter) return c.json({ error: 'Not found or not in draft status' }, 404)

--- a/server/services/matter-conflict.integration.test.ts
+++ b/server/services/matter-conflict.integration.test.ts
@@ -8,7 +8,7 @@ import { nanoid } from 'nanoid'
 import { describe, expect, it } from 'vitest'
 import { ObjectStatus } from '../../shared/constants'
 import { createTestApp } from '../test/setup.js'
-import { confirmUpload, copyMatter, createMatter, restoreMatter, updateMatter } from './matter.js'
+import { cancelDraftMatter, confirmUpload, copyMatter, createMatter, restoreMatter, updateMatter } from './matter.js'
 import { NameConflictError } from './matter-name-conflict.js'
 
 type TestDb = Awaited<ReturnType<typeof createTestApp>>['db']
@@ -147,7 +147,7 @@ describe('createMatter — name conflict', () => {
     expect(matter.name).toBe('photo (1).jpg')
   })
 
-  it('replaces existing file with onConflict: replace (existing becomes trashed)', async () => {
+  it('defers the overwrite for a draft replace — incumbent stays active until confirm', async () => {
     const { db } = await createTestApp()
     await insertStorage(db)
     const orgId = nanoid()
@@ -163,9 +163,37 @@ describe('createMatter — name conflict', () => {
       onConflict: 'replace',
     })
 
+    // The incumbent is left untouched: a failed/abandoned upload must not
+    // destroy it. confirmUpload performs the actual overwrite.
     expect(matter.name).toBe('data.csv')
     const rows = await db.all<{ status: string }>(sql`SELECT status FROM matters WHERE id = ${existingId}`)
-    expect(rows[0].status).toBe(ObjectStatus.TRASHED)
+    expect(rows[0].status).toBe(ObjectStatus.ACTIVE)
+  })
+
+  it('keeps the incumbent intact when a deferred-replace upload is cancelled', async () => {
+    const { db } = await createTestApp()
+    await insertStorage(db)
+    const orgId = nanoid()
+    const existingId = await makeFile(db, orgId, 'data.csv')
+
+    const draft = await createMatter(db, {
+      orgId,
+      name: 'data.csv',
+      type: 'text/csv',
+      object: 'some/data.csv',
+      storageId: STORAGE_ID,
+      status: 'draft',
+      onConflict: 'replace',
+    })
+
+    // Upload aborted before confirm: cancelling the draft must leave the
+    // existing file fully intact (it was never trashed).
+    await cancelDraftMatter(db, draft.id, orgId)
+
+    const rows = await db.all<{ status: string }>(sql`SELECT status FROM matters WHERE id = ${existingId}`)
+    expect(rows[0].status).toBe(ObjectStatus.ACTIVE)
+    const draftRows = await db.all(sql`SELECT id FROM matters WHERE id = ${draft.id}`)
+    expect(draftRows).toHaveLength(0)
   })
 })
 

--- a/server/services/matter.ts
+++ b/server/services/matter.ts
@@ -11,7 +11,7 @@ import {
   commitConflictPlan,
   planConflictResolution,
 } from './matter-name-conflict'
-import { StorageQuotaExceededError, withStorageUsageReservation } from './storage-usage'
+import { reconcileStorageUsage, StorageQuotaExceededError, withStorageUsageReservation } from './storage-usage'
 
 export type Matter = typeof matters.$inferSelect
 
@@ -37,12 +37,21 @@ export async function createMatter(db: Database, input: CreateMatterInput): Prom
 
   // Resolve name collisions against existing active siblings BEFORE inserting —
   // for folders this prevents duplicates at creation; for files it catches the
-  // conflict before the client wastes a large S3 upload. confirmUpload does a
-  // second check to guard against draft-vs-active races during upload.
-  const finalName = await applyConflictResolution(db, input.orgId, parent, input.name, input.onConflict ?? 'fail', {
+  // conflict before the client wastes a large S3 upload.
+  const plan = await planConflictResolution(db, input.orgId, parent, input.name, input.onConflict ?? 'fail', {
     isFolder,
     userId: input.userId,
   })
+  // Overwriting the incumbent for a draft-file 'replace' is deferred to
+  // confirmUpload (which purges it after the new bytes land). That keeps a
+  // failed/abandoned upload from destroying the existing file, and lets the
+  // replace be charged as a net-size change. Folders, active creates, and
+  // rename commit their plan immediately.
+  const deferOverwrite = !isFolder && input.status === 'draft' && plan.toTrash !== null
+  if (!deferOverwrite) {
+    await commitConflictPlan(db, input.orgId, plan, input.userId)
+  }
+  const finalName = plan.finalName
 
   const row: Matter = {
     id: nanoid(),
@@ -267,18 +276,28 @@ export async function confirmUpload(
   db: Database,
   id: string,
   orgId: string,
-  opts: { onConflict?: ConflictStrategy; userId?: string; teamQuotaEnabled?: boolean } = {},
+  opts: {
+    onConflict?: ConflictStrategy
+    userId?: string
+    teamQuotaEnabled?: boolean
+    /**
+     * Overwrites the file being replaced: hard-purge it (delete row, S3 object,
+     * shares). With it, a 'replace' frees the incumbent's quota so the upload is
+     * charged as a net-size change — matching normal overwrite semantics. Without
+     * it, replace falls back to trashing the incumbent.
+     */
+    purgeReplaced?: (incumbent: Matter) => Promise<void>
+  } = {},
 ): Promise<{ matter: Matter | null; quotaExceeded?: boolean }> {
   try {
     const existing = await getMatter(db, id, orgId)
     if (!existing) return { matter: null }
     if (existing.status !== 'draft') return { matter: null }
 
-    // Plan-then-commit: between draft creation and now, another user may have
-    // created a conflicting active row. We plan (side-effect-free) first so the
-    // quota check below can short-circuit without ever trashing an incumbent
-    // file. The DB's partial unique index fires on the status update as a final
-    // safety net against concurrent confirms.
+    // Plan the overwrite now (side-effect-free). createMatter deferred it for
+    // draft 'replace', so the incumbent is still active and the quota check
+    // below accounts for its bytes being freed. The DB's partial unique index
+    // fires on the status update as a final safety net against concurrent confirms.
     const plan = await planConflictResolution(db, orgId, existing.parent, existing.name, opts.onConflict ?? 'fail', {
       excludeId: existing.id,
       isFolder: false,
@@ -286,12 +305,31 @@ export async function confirmUpload(
     })
 
     const bytes = existing.size ?? 0
+    // Purging the incumbent frees its bytes, so only the net size increase needs
+    // headroom; a final reconcile then sets usage to the exact active+trashed sum.
+    const overwrites = plan.toTrash != null && opts.purgeReplaced != null
+    const reserveBytes = overwrites ? Math.max(0, bytes - (plan.toTrash?.size ?? 0)) : bytes
+
     return await withStorageUsageReservation(
       db,
-      { orgId, storageId: existing.storageId, bytes, teamQuotaEnabled: opts.teamQuotaEnabled ?? true },
+      { orgId, storageId: existing.storageId, bytes: reserveBytes, teamQuotaEnabled: opts.teamQuotaEnabled ?? true },
       async () => {
-        // Quota reserved — now safe to execute the replace (if any).
-        await commitConflictPlan(db, orgId, plan, opts.userId)
+        // Quota reserved — now safe to execute the overwrite (if any).
+        if (plan.toTrash && opts.purgeReplaced) {
+          await opts.purgeReplaced(plan.toTrash)
+          if (opts.userId) {
+            await recordActivity(db, {
+              orgId,
+              userId: opts.userId,
+              action: 'replace',
+              targetType: 'file',
+              targetId: plan.toTrash.id,
+              targetName: plan.toTrash.name,
+            })
+          }
+        } else {
+          await commitConflictPlan(db, orgId, plan, opts.userId)
+        }
 
         const now = new Date()
         const updated = await db
@@ -303,6 +341,10 @@ export async function confirmUpload(
         if (updated.length === 0) {
           throw new Error('CONFIRM_UPLOAD_RACE')
         }
+
+        // The purge reconciled usage before this row became active; recompute
+        // once more so the new file's bytes are reflected.
+        if (overwrites) await reconcileStorageUsage(db, orgId, [existing.storageId])
 
         const confirmed = { ...existing, name: plan.finalName, status: 'active', updatedAt: now }
 

--- a/src/components/upload/upload-dropzone.tsx
+++ b/src/components/upload/upload-dropzone.tsx
@@ -1,4 +1,5 @@
 import { DirType } from '@shared/constants'
+import type { ConflictStrategy } from '@shared/schemas'
 import { Upload } from 'lucide-react'
 import { forwardRef, useCallback, useImperativeHandle } from 'react'
 import { useDropzone } from 'react-dropzone'
@@ -130,20 +131,25 @@ async function uploadFile(
   ctx: UploadRunnerContext,
 ): Promise<boolean | 'cancelled'> {
   ctx.setStatus('preparing')
-  // Step 1: create draft (resolves conflict against existing actives BEFORE the S3 PUT).
+  // Step 1: create draft (detects the conflict against existing actives BEFORE
+  // the S3 PUT). For 'replace' the backend defers the overwrite to confirm, so
+  // remember the chosen strategy to reuse there without prompting again.
+  let resolvedStrategy: ConflictStrategy | undefined
   const created = prompt
     ? await withConflictRetry(
         prompt,
         'file',
-        (strategy) =>
-          createObject({
+        (strategy) => {
+          resolvedStrategy = strategy
+          return createObject({
             name: file.name,
             type: file.type || 'application/octet-stream',
             size: file.size,
             parent,
             dirtype: DirType.FILE,
             onConflict: strategy,
-          }),
+          })
+        },
         { showApplyToAll },
       )
     : await createObject({
@@ -174,11 +180,12 @@ async function uploadFile(
   }
   if (ctx.signal.aborted) throw new DOMException('Upload cancelled', 'AbortError')
 
-  // Step 2: confirm. Another client may have activated the same name during our
-  // S3 PUT — repeat the resolver here so replace/rename still works.
+  // Step 2: confirm using the strategy already chosen at create, so the user is
+  // not prompted twice. A conflict can still surface here if another client
+  // activated the same name during our S3 PUT — the resolver handles that.
   ctx.setStatus('confirming')
   try {
-    await confirmUpload(created.id)
+    await confirmUpload(created.id, resolvedStrategy)
   } catch (e) {
     if (!prompt || !isNameConflictError(e)) throw e
     const res = await prompt({ kind: 'file', name: e.body.conflictingName, showApplyToAll })


### PR DESCRIPTION
The leftover audit bug, fixed the way normal file systems behave. **Stacked on #430** (its base retargets to `main` once #430 merges).

## The bug
Replacing a same-named file (upload conflict → "replace") trashed the existing file at create time. Because trashed files still count toward quota, the new file then needed headroom for **both** copies — so replacing a same-size file at high quota failed with 422. And since the trash happened at create, a failed/abandoned upload destroyed the existing file.

That's not how overwrite works in a normal OS: copy/move with overwrite replaces the file (it's gone), it does not go to the recycle bin.

## The fix
- `createMatter` **defers** the overwrite for a draft `replace` — the incumbent stays active until the upload succeeds, so a failed upload never destroys it.
- `confirmUpload` performs the overwrite: **purges** the incumbent (row + S3 object + shares), reserves only the **net size increase**, then reconciles. A same-size replace is net-neutral; the replaced file is gone (overwritten), consistent with the cross-space move fix already shipped.
- The client reuses the strategy chosen at create when confirming, so the user isn't prompted twice.

Tests: incumbent stays active after `createMatter` (deferred); replacing a same-size file at full quota now succeeds, leaves usage unchanged, and purges the incumbent. Full create/conflict regression (282 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)