### PR TITLE
refactor(errors)!: unify error handling on typed AppError + single jsonError renderer

### DIFF
--- a/cmd/internal/openapi/client.gen.go
+++ b/cmd/internal/openapi/client.gen.go
@@ -25709,6 +25709,7 @@ type SaveShareResponse struct {
 	JSON403      *Error
 	JSON404      *Error
 	JSON410      *Error
+	JSON422      *Error
 }
 
 // Status returns HTTPResponse.Status
@@ -40376,6 +40377,13 @@ func ParseSaveShareResponse(rsp *http.Response) (*SaveShareResponse, error) {
 			return nil, err
 		}
 		response.JSON410 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	}
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -34,7 +34,7 @@ import { users } from './http/users'
 import webdav from './http/webdav'
 import { formatError } from './lib/errors'
 import { authMiddleware } from './middleware/auth'
-import { isHandledError, renderError } from './middleware/error-handler'
+import { isHandledError, jsonError } from './middleware/error-handler'
 import { imageHostingDomain } from './middleware/image-hosting-domain'
 import { accessLog } from './middleware/logger'
 import type { Env } from './middleware/platform'
@@ -226,12 +226,12 @@ export function createApp(platform: Platform, auth: Auth, deps: Deps = createDep
 
   // Backstop for errors thrown outside the accessLog boundary (earlier middleware,
   // or routes without accessLog like /r). For /api and /dav, accessLog already
-  // catches and renders via the same `renderError`, so this rarely fires there.
+  // catches and renders via the same `jsonError`, so this rarely fires there.
   // Genuinely unhandled errors are logged here since those routes aren't access-
-  // logged; mapped/ApiError cases are already carried by their access-log line.
+  // logged; AppError/mapped cases are already carried by their access-log line.
   app.onError((err, c) => {
     if (!isHandledError(err)) console.error(`http.unhandled_error code=${formatError(err)}`)
-    return renderError(c, err)
+    return jsonError(c, err)
   })
 
   return app

--- a/server/http/background-jobs.ts
+++ b/server/http/background-jobs.ts
@@ -9,8 +9,8 @@ import {
   listBackgroundJobs,
   retryBackgroundJob,
 } from '../usecases/background-job'
-import { BackgroundJobError } from '../usecases/ports'
-import { apiError, errorResponse, jsonBody, jsonContent } from './openapi'
+import { BackgroundJobError, notFound } from '../usecases/ports'
+import { errorResponse, jsonBody, jsonContent } from './openapi'
 
 // BackgroundJob is already wire-shaped (ISO string timestamps) — no DTO mapper.
 const backgroundJobProgressSchema = z.object({
@@ -130,7 +130,7 @@ app.use(requireAuth)
 const backgroundJobs = app
   .openapi(listRoute, async (c) => {
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 404, 'No organization found')
+    if (!orgId) throw notFound('No organization found')
     const query = c.req.valid('query')
     const result = await listBackgroundJobs(c.get('deps'), orgId, query)
     return c.json({ ...result, page: query.page, pageSize: query.pageSize }, 200)

--- a/server/http/downloads/download-tasks.ts
+++ b/server/http/downloads/download-tasks.ts
@@ -17,7 +17,8 @@ import {
   performDownloadTaskAction,
   updateDownloadTask,
 } from '../../usecases/downloads/downloads'
-import { apiError, errorResponse, jsonBody, jsonContent } from '../openapi'
+import { unauthorized } from '../../usecases/ports'
+import { errorResponse, jsonBody, jsonContent } from '../openapi'
 
 // Every task operation surfaces the same DownloadError-based failure model. The
 // usecases throw it; the global onError converts it (not_found→404, forbidden→403,
@@ -133,7 +134,7 @@ const downloadTasksRoute = new OpenAPIHono<Env>()
     const principal = c.get('principal')
     const query = c.req.valid('query')
     if (query.assignedTo === 'me') {
-      if (principal?.kind !== 'downloader') return apiError(c, 401, 'Unauthorized')
+      if (principal?.kind !== 'downloader') throw unauthorized()
       const result = await listDownloadTasks(c.get('deps'), c.get('platform'), {
         downloaderId: principal.downloaderId,
         status: query.status,
@@ -149,7 +150,7 @@ const downloadTasksRoute = new OpenAPIHono<Env>()
     }
 
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 401, 'Unauthorized')
+    if (!orgId) throw unauthorized()
     const result = await listDownloadTasks(c.get('deps'), c.get('platform'), {
       orgId,
       status: query.status,
@@ -165,25 +166,25 @@ const downloadTasksRoute = new OpenAPIHono<Env>()
   .openapi(createRouteDoc, async (c) => {
     const principal = c.get('principal')
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 401, 'Unauthorized')
+    if (!orgId) throw unauthorized()
     const actorId = principal?.kind === 'api-key' ? `api-key:${principal.keyId}` : (c.get('userId') as string)
     return c.json(await createDownloadTask(c.get('deps'), orgId, actorId, c.req.valid('json')), 201)
   })
   .openapi(getRoute, async (c) => {
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 401, 'Unauthorized')
+    if (!orgId) throw unauthorized()
     return c.json(await getDownloadTask(c.get('deps'), orgId, c.req.valid('param').id), 200)
   })
   .openapi(statusRoute, async (c) => {
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 401, 'Unauthorized')
+    if (!orgId) throw unauthorized()
     const { status } = c.req.valid('json')
     const action = status === 'paused' ? 'pause' : status === 'queued' ? 'resume' : 'cancel'
     return c.json(await performDownloadTaskAction(c.get('deps'), orgId, c.req.valid('param').id, action), 200)
   })
   .openapi(attemptRoute, async (c) => {
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 401, 'Unauthorized')
+    if (!orgId) throw unauthorized()
     const { fresh } = c.req.valid('json')
     return c.json(
       await performDownloadTaskAction(c.get('deps'), orgId, c.req.valid('param').id, fresh ? 'restart' : 'retry'),
@@ -192,7 +193,7 @@ const downloadTasksRoute = new OpenAPIHono<Env>()
   })
   .openapi(deleteRoute, async (c) => {
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 401, 'Unauthorized')
+    if (!orgId) throw unauthorized()
     return c.json(await performDownloadTaskAction(c.get('deps'), orgId, c.req.valid('param').id, 'delete'), 200)
   })
   .openapi(updateRoute, async (c) => {
@@ -206,7 +207,7 @@ const downloadTasksRoute = new OpenAPIHono<Env>()
       )
     }
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 401, 'Unauthorized')
+    if (!orgId) throw unauthorized()
     return c.json(await updateDownloadTask(c.get('deps'), c.get('platform'), id, input, { orgId }), 200)
   })
 

--- a/server/http/downloads/downloaders.ts
+++ b/server/http/downloads/downloaders.ts
@@ -5,7 +5,6 @@ import {
   deleteDownloaderResponseSchema,
   downloaderHeartbeatSchema,
   downloaderSchema,
-  ErrorReason,
   pageSchema,
   updateDownloaderSchema,
 } from '@shared/schemas'
@@ -20,8 +19,9 @@ import {
   recordDownloaderHeartbeat,
   updateDownloader,
 } from '../../usecases/downloads/downloads'
+import { featureBlocked, unauthorized } from '../../usecases/ports'
 import { loadBindingState } from '../../usecases/site/licensing'
-import { apiError, errorResponse, jsonBody, jsonContent } from '../openapi'
+import { errorResponse, jsonBody, jsonContent } from '../openapi'
 
 const downloaderListSchema = pageSchema(downloaderSchema, 'DownloaderList')
 
@@ -106,12 +106,11 @@ const downloadersRoute = new OpenAPIHono<Env>()
   })
   .openapi(createRouteDoc, async (c) => {
     const userId = c.get('userId')
-    if (!userId) return apiError(c, 401, 'Unauthorized')
+    if (!userId) throw unauthorized()
     const deps = c.get('deps')
     const [existing, state] = await Promise.all([listDownloaders(deps), loadBindingState(deps)])
     if (!hasFeature('downloaders_unlimited', state) && existing.length >= FREE_DOWNLOADER_LIMIT) {
-      return apiError(c, 402, 'Feature not available', {
-        reason: ErrorReason.FEATURE_NOT_AVAILABLE,
+      throw featureBlocked('Feature not available', {
         metadata: {
           feature: 'downloaders_unlimited',
           currentCount: String(existing.length),
@@ -129,8 +128,7 @@ const downloadersRoute = new OpenAPIHono<Env>()
     if (input.remoteDownloadCreditBillingEnabled === true) {
       const state = await loadBindingState(c.get('deps'))
       if (!hasFeature('quota_store', state)) {
-        return apiError(c, 402, 'Feature not available', {
-          reason: ErrorReason.FEATURE_NOT_AVAILABLE,
+        throw featureBlocked('Feature not available', {
           metadata: { feature: 'quota_store' },
         })
       }
@@ -144,7 +142,7 @@ const downloadersRoute = new OpenAPIHono<Env>()
 
 export const downloaderSelfRoute = new OpenAPIHono<Env>().openapi(heartbeatRoute, async (c) => {
   const principal = c.get('principal')
-  if (principal?.kind !== 'downloader') return apiError(c, 401, 'Unauthorized')
+  if (principal?.kind !== 'downloader') throw unauthorized()
   return c.json(await recordDownloaderHeartbeat(c.get('deps'), principal.downloaderId, c.req.valid('json')), 200)
 })
 

--- a/server/http/image-hosting/config.ts
+++ b/server/http/image-hosting/config.ts
@@ -9,7 +9,8 @@ import {
   getImageHostingConfig,
   putImageHostingConfig,
 } from '../../usecases/image-hosting/config'
-import { apiError, errorResponse, jsonBody, jsonContent } from '../openapi'
+import { unauthorized } from '../../usecases/ports'
+import { errorResponse, jsonBody, jsonContent } from '../openapi'
 
 const ihostConfigSchema = z
   .object({
@@ -126,7 +127,7 @@ app.use(requireAuth)
 const ihostConfig = app
   .openapi(getRoute, async (c) => {
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 401, 'Unauthorized')
+    if (!orgId) throw unauthorized()
     const { isCfConfigured, cnameTarget, cf } = cfFrom(c)
     const row = await getImageHostingConfig(c.get('deps'), orgId, cf)
     if (!row) return c.json({ enabled: false as const }, 200)
@@ -134,18 +135,15 @@ const ihostConfig = app
   })
   .openapi(putRoute, async (c) => {
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 401, 'Unauthorized')
+    if (!orgId) throw unauthorized()
     const { isCfConfigured, cnameTarget, cf } = cfFrom(c)
     const result = await putImageHostingConfig(c.get('deps'), orgId, c.req.valid('json'), cf)
-    if (!result.ok) {
-      if (result.reason === 'app_host') return apiError(c, 400, 'Custom domain cannot be the application default host')
-      return apiError(c, 409, 'Domain already registered by another organization')
-    }
+    if (!result.ok) throw result.error
     return c.json(buildResponse(result.config, cnameTarget, isCfConfigured), 200)
   })
   .openapi(deleteRoute, async (c) => {
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 401, 'Unauthorized')
+    if (!orgId) throw unauthorized()
     await deleteImageHostingConfig(c.get('deps'), orgId)
     return c.body(null, 204)
   })

--- a/server/http/image-hosting/images.integration.test.ts
+++ b/server/http/image-hosting/images.integration.test.ts
@@ -1322,7 +1322,7 @@ describe('image-hosting usecase — direct calls', () => {
     `)
 
     const result = await confirmImageHosting(deps, id, orgId)
-    expect(result.row).toBeTruthy()
-    expect(result.row?.status).toBe('active')
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.row.status).toBe('active')
   })
 })

--- a/server/http/image-hosting/images.ts
+++ b/server/http/image-hosting/images.ts
@@ -22,8 +22,15 @@ import {
   requireImageHostingEnabled,
   uploadImageHosting,
 } from '../../usecases/image-hosting/images'
-import type { ImageHostingRecord } from '../../usecases/ports'
-import { apiError, errorResponse, jsonBody, jsonContent } from '../openapi'
+import {
+  AppError,
+  badRequest,
+  type ImageHostingRecord,
+  notFound,
+  unauthorized,
+  unsupportedMediaType,
+} from '../../usecases/ports'
+import { errorResponse, jsonBody, jsonContent } from '../openapi'
 
 // The stored image's wire shape — timestamps as ISO strings (the record carries
 // them as Date).
@@ -186,11 +193,11 @@ const app = new OpenAPIHono<Env>()
 // below keeps its typing.
 app.post('/images', requirePermission('ihost', 'upload'), async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return apiError(c, 401, 'Unauthorized')
+  if (!orgId) throw unauthorized()
 
   const contentType = c.req.header('Content-Type') ?? ''
   const enabled = await requireImageHostingEnabled(c.get('deps'), orgId)
-  if (!enabled.ok) return apiError(c, 403, 'image hosting not enabled for this organization')
+  if (!enabled.ok) throw enabled.error
   const config = enabled.config
 
   let fileBytes: Uint8Array
@@ -203,14 +210,14 @@ app.post('/images', requirePermission('ihost', 'upload'), async (c) => {
     try {
       body = (await c.req.json()) as Record<string, unknown>
     } catch {
-      return apiError(c, 400, 'Invalid JSON body')
+      throw badRequest('Invalid JSON body')
     }
     const b64 = body.file
-    if (typeof b64 !== 'string' || !b64) return apiError(c, 400, 'file field (base64 string) is required')
+    if (typeof b64 !== 'string' || !b64) throw badRequest('file field (base64 string) is required')
     try {
       fileBytes = Uint8Array.from(atob(b64), (ch) => ch.charCodeAt(0))
     } catch {
-      return apiError(c, 400, 'Invalid base64 in file field')
+      throw badRequest('Invalid base64 in file field')
     }
     fileName = typeof body.filename === 'string' && body.filename ? body.filename : 'upload'
     fileMime = detectMimeFromBytes(fileBytes) || 'application/octet-stream'
@@ -218,26 +225,24 @@ app.post('/images', requirePermission('ihost', 'upload'), async (c) => {
   } else if (contentType.includes('multipart/form-data')) {
     const contentLength = Number(c.req.header('Content-Length') ?? '0')
     if (Number.isFinite(contentLength) && contentLength > MAX_IMAGE_SIZE)
-      return apiError(c, 413, 'File exceeds the maximum allowed size', {
+      throw new AppError(413, 'File exceeds the maximum allowed size', {
         reason: ErrorReason.PAYLOAD_TOO_LARGE,
         metadata: { maxBytes: String(MAX_IMAGE_SIZE) },
       })
     const formData = await c.req.formData()
     const file = formData.get('file')
-    if (!(file instanceof File)) return apiError(c, 400, 'file field is required')
+    if (!(file instanceof File)) throw badRequest('file field is required')
     fileBytes = new Uint8Array(await file.arrayBuffer())
     fileName = file.name || 'upload'
     fileMime = file.type || ''
     const pathParam = formData.get('path')
     if (typeof pathParam === 'string' && pathParam) explicitPath = pathParam
   } else {
-    return apiError(c, 415, 'Unsupported Content-Type. Use multipart/form-data or application/json with base64.', {
-      reason: ErrorReason.UNSUPPORTED_MEDIA_TYPE,
-    })
+    throw unsupportedMediaType('Unsupported Content-Type. Use multipart/form-data or application/json with base64.')
   }
 
   if (fileBytes.byteLength > MAX_IMAGE_SIZE)
-    return apiError(c, 413, 'File exceeds the maximum allowed size', {
+    throw new AppError(413, 'File exceeds the maximum allowed size', {
       reason: ErrorReason.PAYLOAD_TOO_LARGE,
       metadata: { maxBytes: String(MAX_IMAGE_SIZE) },
     })
@@ -255,17 +260,16 @@ app.post('/images', requirePermission('ihost', 'upload'), async (c) => {
     }
     mime = (ext && extMap[ext]) || mime || 'application/octet-stream'
   }
-  if (mime === 'image/svg+xml')
-    return apiError(c, 415, 'SVG images are not allowed', { reason: ErrorReason.UNSUPPORTED_MEDIA_TYPE })
+  if (mime === 'image/svg+xml') throw unsupportedMediaType('SVG images are not allowed')
   if (!(ALLOWED_IMAGE_MIMES as readonly string[]).includes(mime))
-    return apiError(c, 415, 'Unsupported media type', {
+    throw new AppError(415, 'Unsupported media type', {
       reason: ErrorReason.UNSUPPORTED_MEDIA_TYPE,
       metadata: { allowedTypes: ALLOWED_IMAGE_MIMES.join(',') },
     })
 
   const requestedPath = explicitPath || deriveDefaultPath(fileName, mime)
   const pathErr = validatePath(requestedPath)
-  if (pathErr) return apiError(c, 400, `${pathErr.error}: ${pathErr.detail}`)
+  if (pathErr) throw badRequest(`${pathErr.error}: ${pathErr.detail}`)
 
   try {
     const result = await uploadImageHosting(c.get('deps'), {
@@ -274,7 +278,7 @@ app.post('/images', requirePermission('ihost', 'upload'), async (c) => {
       mime: mime as (typeof ALLOWED_IMAGE_MIMES)[number],
       bytes: fileBytes,
     })
-    if (!result.ok) return apiError(c, 503, 'No storage configured', { reason: ErrorReason.NO_STORAGE_CONFIGURED })
+    if (!result.ok) throw result.error
     const row = result.row
     const origin = new URL(c.req.url).origin
     const tokenUrl = `${origin}/r/${row.token}`
@@ -301,28 +305,28 @@ app.post('/images', requirePermission('ihost', 'upload'), async (c) => {
 const ihost = app
   .openapi(presignRoute, async (c) => {
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 400, 'No active organization')
+    if (!orgId) throw badRequest('No active organization')
     const enabled = await requireImageHostingEnabled(c.get('deps'), orgId)
-    if (!enabled.ok) return apiError(c, 403, 'image hosting not enabled for this organization')
+    if (!enabled.ok) throw enabled.error
 
     const { path: requestedPath, mime, size } = c.req.valid('json')
     if (size > MAX_IMAGE_SIZE)
-      return apiError(c, 413, 'File exceeds the maximum allowed size', {
+      throw new AppError(413, 'File exceeds the maximum allowed size', {
         reason: ErrorReason.PAYLOAD_TOO_LARGE,
         metadata: { maxBytes: String(MAX_IMAGE_SIZE) },
       })
     const pathErr = validatePath(requestedPath)
-    if (pathErr) return apiError(c, 400, `${pathErr.error}: ${pathErr.detail}`)
+    if (pathErr) throw badRequest(`${pathErr.error}: ${pathErr.detail}`)
 
     const result = await presignImageHostingUpload(c.get('deps'), { orgId, path: requestedPath, mime, size })
-    if (!result.ok) return apiError(c, 503, 'No storage configured', { reason: ErrorReason.NO_STORAGE_CONFIGURED })
+    if (!result.ok) throw result.error
     return c.json(result.result, 201)
   })
   .openapi(listRoute, async (c) => {
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 400, 'No active organization')
+    if (!orgId) throw badRequest('No active organization')
     const enabled = await requireImageHostingEnabled(c.get('deps'), orgId)
-    if (!enabled.ok) return apiError(c, 403, 'image hosting not enabled for this organization')
+    if (!enabled.ok) throw enabled.error
 
     const { pathPrefix, cursor, limit } = c.req.valid('query')
     const result = await listImageHostings(c.get('deps'), orgId, { pathPrefix, cursor, limit })
@@ -330,34 +334,32 @@ const ihost = app
   })
   .openapi(getRoute, async (c) => {
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 400, 'No active organization')
+    if (!orgId) throw badRequest('No active organization')
     const enabled = await requireImageHostingEnabled(c.get('deps'), orgId)
-    if (!enabled.ok) return apiError(c, 403, 'image hosting not enabled for this organization')
+    if (!enabled.ok) throw enabled.error
 
     const row = await getImageHosting(c.get('deps'), c.req.valid('param').id, orgId)
-    if (!row) return apiError(c, 404, 'Not found')
+    if (!row) throw notFound()
     return c.json(toImageHostingDTO(row), 200)
   })
   .openapi(confirmRoute, async (c) => {
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 400, 'No active organization')
+    if (!orgId) throw badRequest('No active organization')
     const enabled = await requireImageHostingEnabled(c.get('deps'), orgId)
-    if (!enabled.ok) return apiError(c, 403, 'image hosting not enabled for this organization')
+    if (!enabled.ok) throw enabled.error
 
-    const { row, quotaExceeded } = await confirmImageHosting(c.get('deps'), c.req.valid('param').id, orgId)
-    if (quotaExceeded)
-      return apiError(c, 422, 'Quota exceeded', { reason: ErrorReason.QUOTA_EXCEEDED, status: 'RESOURCE_EXHAUSTED' })
-    if (!row) return apiError(c, 404, 'Not found or not in draft status')
-    return c.json(toImageHostingDTO(row), 200)
+    const result = await confirmImageHosting(c.get('deps'), c.req.valid('param').id, orgId)
+    if (!result.ok) throw result.error
+    return c.json(toImageHostingDTO(result.row), 200)
   })
   .openapi(deleteRoute, async (c) => {
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 400, 'No active organization')
+    if (!orgId) throw badRequest('No active organization')
     const enabled = await requireImageHostingEnabled(c.get('deps'), orgId)
-    if (!enabled.ok) return apiError(c, 403, 'image hosting not enabled for this organization')
+    if (!enabled.ok) throw enabled.error
 
     const deleted = await removeImageHosting(c.get('deps'), c.req.valid('param').id, orgId)
-    if (!deleted) return apiError(c, 404, 'Not found')
+    if (!deleted) throw notFound()
     return c.body(null, 204)
   })
 

--- a/server/http/internal.ts
+++ b/server/http/internal.ts
@@ -3,8 +3,8 @@ import { Hono } from 'hono'
 import { constantTimeEqual } from '../lib/constant-time'
 import type { Env } from '../middleware/platform'
 import { getDeployPlatform } from '../runtime-platform'
+import { notFound, unauthorized } from '../usecases/ports'
 import { INSTANCE_TELEMETRY_CRON, reportInstanceTelemetry } from '../usecases/site/instance-telemetry'
-import { apiError } from './openapi'
 
 const INTERNAL_API_TOKEN_ENV = 'ZPAN_INTERNAL_API_TOKEN'
 
@@ -17,10 +17,10 @@ function envAllowsIp(value: string | undefined): boolean {
 internal.post('/instance-telemetry/report', async (c) => {
   const platform = c.get('platform')
   const token = platform.getEnv(INTERNAL_API_TOKEN_ENV)?.trim()
-  if (!token) return apiError(c, 404, 'Not found')
+  if (!token) throw notFound()
 
   const auth = c.req.header('authorization') ?? ''
-  if (!constantTimeEqual(auth, `Bearer ${token}`)) return apiError(c, 401, 'Unauthorized')
+  if (!constantTimeEqual(auth, `Bearer ${token}`)) throw unauthorized()
 
   const runtime = platform.getBinding('DB')
     ? {

--- a/server/http/notifications.ts
+++ b/server/http/notifications.ts
@@ -8,8 +8,8 @@ import {
   markAllNotificationsRead,
   markNotificationRead,
 } from '../usecases/notification'
-import type { NotificationRecord } from '../usecases/ports'
-import { apiError, errorResponse, jsonContent } from './openapi'
+import { type NotificationRecord, notFound } from '../usecases/ports'
+import { errorResponse, jsonContent } from './openapi'
 
 const notificationSchema = z
   .object({
@@ -117,7 +117,7 @@ export const notifications = app
   })
   .openapi(markReadRoute, async (c) => {
     const found = await markNotificationRead(c.get('deps'), c.get('userId')!, c.req.valid('param').id)
-    if (!found) return apiError(c, 404, 'Not found')
+    if (!found) throw notFound()
     return c.body(null, 204)
   })
   .openapi(markAllReadRoute, async (c) => c.json(await markAllNotificationsRead(c.get('deps'), c.get('userId')!), 200))

--- a/server/http/objects.ts
+++ b/server/http/objects.ts
@@ -3,7 +3,6 @@ import {
   copyObjectBodySchema,
   createMatterSchema,
   createObjectUploadSessionSchema,
-  ErrorReason,
   objectStatusSchema,
   objectUploadSessionSchema,
   objectUploadStatusSchema,
@@ -39,8 +38,8 @@ import {
   trashObject,
   updateObject,
 } from '../usecases/object'
-import type { Matter } from '../usecases/ports'
-import { apiError, errorResponse, jsonBody, jsonContent } from './openapi'
+import { badRequest, conflict, forbidden, type Matter, notFound, unauthorized } from '../usecases/ports'
+import { errorResponse, jsonBody, jsonContent } from './openapi'
 
 // The wire shape of a file/folder — exactly what the API serializes. Timestamps
 // are strings here (the domain `Matter` carries them as `Date`); `toMatterDTO`
@@ -155,7 +154,8 @@ const requireObjectWriteAccess = createMiddleware<Env>(async (c, next) => {
     return
   }
   if (!(await hasEditorAccess(c.get('deps'), { orgId: c.get('orgId'), userId: c.get('userId') }))) {
-    return c.get('userId') ? apiError(c, 403, 'Forbidden') : apiError(c, 401, 'Unauthorized')
+    if (c.get('userId')) throw forbidden()
+    throw unauthorized()
   }
   await next()
 })
@@ -379,13 +379,13 @@ app.use(async (c, next) => {
     await next()
     return
   }
-  return apiError(c, 401, 'Unauthorized')
+  throw unauthorized()
 })
 
 const objects = app
   .openapi(listRoute, async (c) => {
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 400, 'No active organization')
+    if (!orgId) throw badRequest('No active organization')
 
     const query = c.req.valid('query')
     const result = await listObjects(c.get('deps'), {
@@ -401,19 +401,15 @@ const objects = app
         pageSize: query.pageSize,
       },
     })
-    if (!result.ok) return apiError(c, 403, 'Forbidden')
+    if (!result.ok) throw result.error
     return c.json({ ...result.result, items: result.result.items.map(toMatterDTO) }, 200)
   })
   .openapi(createObjectRoute, async (c) => {
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 400, 'No active organization')
+    if (!orgId) throw badRequest('No active organization')
 
     const result = await createObject(c.get('deps'), { orgId, actor: objectActor(c), input: c.req.valid('json') })
-    if (!result.ok) {
-      if (result.reason === 'target_outside_authorization')
-        return apiError(c, 403, 'Target folder is outside task authorization')
-      return apiError(c, 503, 'No storage configured', { reason: ErrorReason.NO_STORAGE_CONFIGURED })
-    }
+    if (!result.ok) throw result.error
     if ('uploadUrl' in result)
       return c.json(
         { ...toMatterDTO(result.matter), uploadUrl: result.uploadUrl, contentDisposition: result.contentDisposition },
@@ -467,7 +463,7 @@ const objects = app
   })
   .openapi(getObjectRoute, async (c) => {
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 400, 'No active organization')
+    if (!orgId) throw badRequest('No active organization')
 
     const result = await getObject(c.get('deps'), {
       orgId,
@@ -479,40 +475,25 @@ const objects = app
         return c.json({ ...toMatterDTO(result.matter), downloadUrl: result.downloadUrl }, 200)
       return c.json(toMatterDTO(result.matter), 200)
     }
-    switch (result.reason) {
-      case 'not_found':
-        return apiError(c, 404, 'Not found')
-      case 'storage_not_found':
-        return apiError(c, 404, 'Storage not found')
-      case 'quota_exceeded':
-        return apiError(c, 422, 'Traffic quota exceeded', {
-          reason: ErrorReason.QUOTA_EXCEEDED,
-          status: 'RESOURCE_EXHAUSTED',
-        })
-      case 'insufficient_credits':
-        return apiError(c, 402, 'Insufficient credits', {
-          reason: ErrorReason.INSUFFICIENT_CREDITS,
-          metadata: { resource: 'storage_egress' },
-        })
-    }
+    throw result.error
   })
   .openapi(patchObjectRoute, async (c) => {
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 400, 'No active organization')
+    if (!orgId) throw badRequest('No active organization')
     const result = await updateObject(c.get('deps'), {
       orgId,
       objectId: c.req.valid('param').id,
       actorId: actorId(c),
       input: c.req.valid('json'),
     })
-    if (!result.ok) return apiError(c, 404, 'Not found')
+    if (!result.ok) throw result.error
     return c.json(toMatterDTO(result.matter), 200)
   })
   // Lifecycle transitions: { status:'active' } confirms a draft or restores from
   // trash (server picks by current state); { status:'trashed' } soft-deletes.
   .openapi(objectStatusRoute, async (c) => {
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 400, 'No active organization')
+    if (!orgId) throw badRequest('No active organization')
     const objectId = c.req.valid('param').id
     const { status, onConflict } = c.req.valid('json')
 
@@ -520,7 +501,7 @@ const objects = app
     if (principal?.kind === 'download-task-upload') {
       // Upload tokens may only confirm their own draft.
       if (status !== 'active') {
-        return apiError(c, 403, 'Download task upload token can only confirm uploads')
+        throw forbidden('Download task upload token can only confirm uploads')
       }
       const authorized = await authorizeTaskUploadConfirm(c.get('deps'), {
         orgId,
@@ -529,12 +510,12 @@ const objects = app
         downloaderId: principal.downloaderId,
         targetFolder: principal.targetFolder,
       })
-      if (!authorized.ok) return apiError(c, 403, 'Forbidden')
+      if (!authorized.ok) throw authorized.error
     }
 
     if (status === 'trashed') {
       const result = await trashObject(c.get('deps'), { orgId, objectId, actorId: actorId(c) })
-      if (!result.ok) return apiError(c, 404, 'Not found')
+      if (!result.ok) throw result.error
       return c.json(toMatterDTO(result.matter), 200)
     }
 
@@ -543,16 +524,16 @@ const objects = app
     // global onError, which maps them to 409 / 422.
     const confirmed = await confirmObject(c.get('deps'), { orgId, objectId, actorId: actorId(c), onConflict })
     if (confirmed.ok) return c.json(toMatterDTO(confirmed.matter), 200)
-    if (confirmed.reason === 'quota_exceeded')
-      return apiError(c, 422, 'Quota exceeded', { reason: ErrorReason.QUOTA_EXCEEDED, status: 'RESOURCE_EXHAUSTED' })
+    // `not_found` falls through to a restore attempt; a quota block is terminal.
+    if ('error' in confirmed) throw confirmed.error
 
     const restored = await restoreObject(c.get('deps'), { orgId, objectId, actorId: actorId(c), onConflict })
-    if (!restored.ok) return apiError(c, 404, 'Not found')
+    if (!restored.ok) throw restored.error
     return c.json(toMatterDTO(restored.matter), 200)
   })
   .openapi(deleteObjectRoute, async (c) => {
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 400, 'No active organization')
+    if (!orgId) throw badRequest('No active organization')
     const objectId = c.req.valid('param').id
     const result = await deleteObject(c.get('deps'), { orgId, objectId, userId: c.get('userId')! })
     if (result.ok) return c.json({ id: result.id, deleted: true as const, purged: result.purged }, 200)
@@ -561,13 +542,13 @@ const objects = app
       // must be trashed before it can be permanently deleted.
       const cancelled = await cancelObject(c.get('deps'), { orgId, objectId, actorId: actorId(c) })
       if (cancelled.ok) return c.json({ id: cancelled.id, deleted: true as const, purged: false as const }, 200)
-      return apiError(c, 409, 'Object must be trashed before permanent deletion')
+      throw conflict('Object must be trashed before permanent deletion')
     }
-    return apiError(c, 404, 'Not found')
+    throw notFound()
   })
   .openapi(copyObjectRoute, async (c) => {
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 400, 'No active organization')
+    if (!orgId) throw badRequest('No active organization')
 
     const body = c.req.valid('json')
     const result = await copyObject(c.get('deps'), {
@@ -575,15 +556,12 @@ const objects = app
       userId: c.get('userId')!,
       input: { copyFrom: c.req.valid('param').id, parent: body.parent, onConflict: body.onConflict },
     })
-    if (!result.ok) {
-      if (result.reason === 'storage_not_found') return apiError(c, 404, 'Storage not found')
-      return apiError(c, 404, 'Not found')
-    }
+    if (!result.ok) throw result.error
     return c.json(toMatterDTO(result.matter), 201)
   })
   .openapi(transferObjectRoute, async (c) => {
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 400, 'No active organization')
+    if (!orgId) throw badRequest('No active organization')
 
     const result = await transferObject(c.get('deps'), {
       orgId,
@@ -591,21 +569,7 @@ const objects = app
       objectId: c.req.valid('param').id,
       input: c.req.valid('json'),
     })
-    if (!result.ok) {
-      switch (result.reason) {
-        case 'same_org':
-          return apiError(c, 400, 'Target must be a different space', { reason: 'SAME_ORG' })
-        case 'not_found':
-          return apiError(c, 404, 'Not found')
-        case 'forbidden':
-          return apiError(c, 403, 'Forbidden')
-        case 'quota_exceeded':
-          return apiError(c, 422, 'Quota exceeded', {
-            reason: ErrorReason.QUOTA_EXCEEDED,
-            status: 'RESOURCE_EXHAUSTED',
-          })
-      }
-    }
+    if (!result.ok) throw result.error
     return c.json(
       {
         saved: result.result.saved.map(toMatterDTO),

--- a/server/http/openapi.ts
+++ b/server/http/openapi.ts
@@ -1,9 +1,5 @@
 import type { z } from '@hono/zod-openapi'
 import { errorResponseSchema } from '@shared/schemas'
-import type { Context } from 'hono'
-import type { ContentfulStatusCode } from 'hono/utils/http-status'
-import { buildErrorBody, type ErrorOptions } from '../lib/http-errors'
-import type { Env } from '../middleware/platform'
 
 // Shared OpenAPI route helpers used by every resource router. Generic over the
 // schema so its precise type reaches `createRoute`: that types `c.req.valid(...)`
@@ -21,21 +17,7 @@ export const jsonBody = <T extends z.ZodType>(schema: T) => ({
   body: { content: { 'application/json': { schema } }, required: true },
 })
 
-// A route response carrying the shared AIP-193 `Error` envelope. Errors thrown by
-// usecases are converted centrally by `app.onError`; this just documents them.
+// A route response carrying the shared AIP-193 `Error` envelope. Handlers and
+// usecases produce errors as `AppError` values that `app.onError` renders via
+// `jsonError`; this just documents the response shape in the OpenAPI document.
 export const errorResponse = (description: string) => jsonContent(errorResponseSchema, description)
-
-// The single way a handler returns an error inline. Builds the AIP-193 body and
-// stashes the reason + message for the access log, so every 4xx/5xx is observable.
-// `reason` defaults to the canonical status for the HTTP code (e.g. 403 →
-// PERMISSION_DENIED); pass `opts.reason`/`opts.metadata` for specific errors.
-export function apiError<S extends ContentfulStatusCode>(
-  c: Context<Env>,
-  status: S,
-  message: string,
-  opts: ErrorOptions = {},
-) {
-  const body = buildErrorBody(status, message, opts)
-  c.set('errorLog', { reason: body.error.details?.[0]?.reason ?? body.error.status, message })
-  return c.json(body, status)
-}

--- a/server/http/quotas.ts
+++ b/server/http/quotas.ts
@@ -2,8 +2,9 @@ import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
 import { pageSchema } from '@shared/schemas'
 import { requireAdmin, requireAuth } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
+import { notFound } from '../usecases/ports'
 import { getUserQuota, listQuotaOverview } from '../usecases/quota'
-import { apiError, errorResponse, jsonContent } from './openapi'
+import { errorResponse, jsonContent } from './openapi'
 
 // Quota types are already wire-shaped (timestamps are ISO strings, not Date), so
 // the schemas match the usecase return types directly — no DTO mapper needed.
@@ -78,7 +79,7 @@ const adminQuotas = new OpenAPIHono<Env>().openapi(listQuotaOverviewRoute, async
 
 const userQuotas = new OpenAPIHono<Env>().openapi(getMyQuotaRoute, async (c) => {
   const quota = await getUserQuota(c.get('deps'), { userId: c.get('userId')!, orgId: c.get('orgId') ?? undefined })
-  if (!quota) return apiError(c, 404, 'No organization found')
+  if (!quota) throw notFound('No organization found')
   return c.json(quota, 200)
 })
 

--- a/server/http/redirect.integration.test.ts
+++ b/server/http/redirect.integration.test.ts
@@ -4,6 +4,7 @@ import { S3Service } from '../adapters/gateways/s3.js'
 import { createShareRepo } from '../adapters/repos/share'
 import { currentTrafficPeriod } from '../domain/quota.js'
 import { authedHeaders, createTestApp } from '../test/setup.js'
+import { insufficientCredits } from '../usecases/ports'
 
 const MOCK_PRESIGN_URL = 'https://presigned-download.example.com/file'
 const MOCK_INLINE_URL = 'https://presigned-inline.example.com/image.png'
@@ -354,7 +355,7 @@ describe('GET /r/:token (ih_ image hosting)', () => {
     const redirectUsecase = await import('../usecases/redirect.js')
     vi.spyOn(redirectUsecase, 'resolveImageHostingDownload').mockResolvedValueOnce({
       ok: false,
-      reason: 'insufficient_credits',
+      error: insufficientCredits('Insufficient credits', { metadata: { resource: 'storage_egress' } }),
     })
 
     const res = await app.request('/r/ih_credits', { redirect: 'manual' })

--- a/server/http/redirect.ts
+++ b/server/http/redirect.ts
@@ -1,15 +1,14 @@
 import type { Context } from 'hono'
 import { Hono } from 'hono'
 import { ZPAN_CLOUD_URL_DEFAULT } from '../../shared/constants'
-import { ErrorReason } from '../../shared/schemas'
 import type { Env } from '../middleware/platform'
+import { notFound } from '../usecases/ports'
 import {
   type DirectShareOutcome,
   type ImageHostingOutcome,
   resolveDirectShareDownload,
   resolveImageHostingDownload,
 } from '../usecases/redirect'
-import { apiError } from './openapi'
 
 // Strip optional file extension from token (e.g. "ih_aB3xK9.png" → "ih_aB3xK9")
 function stripExtension(token: string): string {
@@ -25,38 +24,13 @@ function presignedRedirect(c: Context<Env>, url: string): Response {
   return res
 }
 
-function insufficientCredits(c: Context<Env>): Response {
-  return apiError(c, 402, 'Insufficient credits', {
-    reason: ErrorReason.INSUFFICIENT_CREDITS,
-    metadata: { resource: 'storage_egress' },
-  })
-}
-
 async function handleDirectShare(c: Context<Env>, token: string): Promise<Response> {
   const outcome: DirectShareOutcome = await resolveDirectShareDownload(c.get('deps'), {
     token,
     cloudBaseUrl: cloudBaseUrl(c),
   })
   if (outcome.ok) return presignedRedirect(c, outcome.url)
-  switch (outcome.reason) {
-    case 'matter_trashed':
-      return apiError(c, 410, 'File no longer available')
-    case 'not_found':
-      return apiError(c, 404, 'Share not found or revoked')
-    case 'expired':
-      return apiError(c, 410, 'Share has expired')
-    case 'limit_exceeded':
-      return apiError(c, 410, 'Download limit exceeded')
-    case 'storage_not_found':
-      return apiError(c, 404, 'Storage not found')
-    case 'quota_exceeded':
-      return apiError(c, 422, 'Traffic quota exceeded', {
-        reason: ErrorReason.QUOTA_EXCEEDED,
-        status: 'RESOURCE_EXHAUSTED',
-      })
-    case 'insufficient_credits':
-      return insufficientCredits(c)
-  }
+  throw outcome.error
 }
 
 async function handleImageHosting(c: Context<Env>, token: string): Promise<Response> {
@@ -67,21 +41,7 @@ async function handleImageHosting(c: Context<Env>, token: string): Promise<Respo
     requestOrigin: new URL(c.req.url).origin,
   })
   if (outcome.ok) return presignedRedirect(c, outcome.url)
-  switch (outcome.reason) {
-    case 'not_found':
-      return apiError(c, 404, 'Not found')
-    case 'forbidden_referer':
-      return apiError(c, 403, 'forbidden referer')
-    case 'storage_not_found':
-      return apiError(c, 404, 'Storage not found')
-    case 'quota_exceeded':
-      return apiError(c, 422, 'Traffic quota exceeded', {
-        reason: ErrorReason.QUOTA_EXCEEDED,
-        status: 'RESOURCE_EXHAUSTED',
-      })
-    case 'insufficient_credits':
-      return insufficientCredits(c)
-  }
+  throw outcome.error
 }
 
 const app = new Hono<Env>().get('/:token', async (c) => {
@@ -91,7 +51,7 @@ const app = new Hono<Env>().get('/:token', async (c) => {
   if (token.startsWith('ds_')) return handleDirectShare(c, token)
   if (token.startsWith('ih_')) return handleImageHosting(c, token)
 
-  return apiError(c, 404, 'Not found')
+  throw notFound()
 })
 
 export default app

--- a/server/http/shares.integration.test.ts
+++ b/server/http/shares.integration.test.ts
@@ -640,7 +640,7 @@ describe('POST /api/shares/:token/objects', () => {
     expect(res.status).toBe(401)
   })
 
-  it('returns 400 QUOTA_EXCEEDED when target org quota is exhausted [spec: shares/save-quota-exceeded]', async () => {
+  it('returns 422 QUOTA_EXCEEDED when target org quota is exhausted [spec: shares/save-quota-exceeded]', async () => {
     const { app, db } = await createTestApp()
     await seedProLicense(db)
     const headers = await authedHeaders(app)
@@ -659,7 +659,7 @@ describe('POST /api/shares/:token/objects', () => {
       headers: { ...headers, 'Content-Type': 'application/json' },
       body: JSON.stringify({ targetOrgId: orgId, targetParent: '' }),
     })
-    expect(res.status).toBe(400)
+    expect(res.status).toBe(422)
 
     const body = (await res.json()) as { error: { details: Array<{ reason: string }> } }
     expect(body.error.details[0].reason).toBe('QUOTA_EXCEEDED')

--- a/server/http/shares.ts
+++ b/server/http/shares.ts
@@ -2,7 +2,7 @@ import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
 import type { Context } from 'hono'
 import { getCookie, setCookie } from 'hono/cookie'
 import { ZPAN_CLOUD_URL_DEFAULT } from '../../shared/constants'
-import { ErrorReason, pageSchema } from '../../shared/schemas'
+import { pageSchema } from '../../shared/schemas'
 import { createShareRequestSchema, listSharesQuerySchema, saveShareRequestSchema } from '../../shared/schemas/share'
 import { requireAuth, requireTeamRole } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
@@ -19,7 +19,7 @@ import {
   verifySharePassword,
   viewShare,
 } from '../usecases/share'
-import { apiError, errorResponse, jsonBody, jsonContent } from './openapi'
+import { errorResponse, jsonBody, jsonContent } from './openapi'
 import { cookieName, decodeChildRef, readUserId, viewCookieName } from './share-utils'
 
 function shareUrls(kind: string, token: string): { landing?: string; direct?: string } {
@@ -249,34 +249,7 @@ pub.get('/:token/objects/:ref', async (c) => {
     res.headers.set('Cache-Control', 'no-store')
     return res
   }
-  switch (out.reason) {
-    case 'matter_trashed':
-      return apiError(c, 410, 'File no longer available')
-    case 'not_found':
-      return apiError(c, 404, 'File not found or not accessible')
-    case 'invalid_ref':
-      return apiError(c, 400, 'Invalid reference')
-    case 'password_required':
-      return apiError(c, 401, 'Password required')
-    case 'expired':
-      return apiError(c, 410, 'Share has expired')
-    case 'folder':
-      return apiError(c, 400, 'Cannot download a folder directly')
-    case 'limit_exceeded':
-      return apiError(c, 410, 'Download limit exceeded')
-    case 'storage_not_found':
-      return apiError(c, 404, 'Storage not found')
-    case 'quota_exceeded':
-      return apiError(c, 422, 'Traffic quota exceeded', {
-        reason: ErrorReason.QUOTA_EXCEEDED,
-        status: 'RESOURCE_EXHAUSTED',
-      })
-    case 'insufficient_credits':
-      return apiError(c, 402, 'Insufficient credits', {
-        reason: ErrorReason.INSUFFICIENT_CREDITS,
-        metadata: { resource: 'storage_egress' },
-      })
-  }
+  throw out.error
 })
 
 export const publicShares = pub
@@ -300,8 +273,7 @@ export const publicShares = pub
       }
       return c.json(toShareViewDTO(out.dto), 200)
     }
-    if (out.reason === 'matter_trashed') return apiError(c, 410, 'File no longer available')
-    return apiError(c, 404, 'Share not found or revoked')
+    throw out.error
   })
   .openapi(verifyShareRoute, async (c) => {
     const token = c.req.valid('param').token
@@ -316,8 +288,7 @@ export const publicShares = pub
       })
       return c.json({ ok: true as const }, 200)
     }
-    if (out.reason === 'invalid_password') return apiError(c, 403, 'Invalid password')
-    return apiError(c, 404, 'Share not found or revoked')
+    throw out.error
   })
   .openapi(listShareObjectsRoute, async (c) => {
     const token = c.req.valid('param').token
@@ -337,20 +308,7 @@ export const publicShares = pub
       pageSize,
     })
     if (out.ok) return c.json(out.result, 200)
-    switch (out.reason) {
-      case 'matter_trashed':
-        return apiError(c, 410, 'File no longer available')
-      case 'not_found':
-        return apiError(c, 404, 'Share not found or revoked')
-      case 'not_a_folder':
-        return apiError(c, 400, 'Not a folder share')
-      case 'password_required':
-        return apiError(c, 401, 'Password required')
-      case 'expired':
-        return apiError(c, 410, 'Share has expired')
-      case 'invalid_path':
-        return apiError(c, 400, 'Invalid path')
-    }
+    throw out.error
   })
 
 // ─── AUTHED SEGMENT ─────────────────────────────────────────────────────────
@@ -407,6 +365,7 @@ const saveShareRoute = createRoute({
     403: errorResponse('Forbidden'),
     404: errorResponse('Share not found'),
     410: errorResponse('Share target deleted'),
+    422: errorResponse('Quota exceeded'),
   },
 })
 
@@ -438,16 +397,7 @@ export const authedShares = authedApp
         201,
       )
     }
-    switch (out.reason) {
-      case 'MATTER_NOT_FOUND':
-        return apiError(c, 404, 'Matter not found', { reason: 'MATTER_NOT_FOUND' })
-      case 'DIRECT_NO_FOLDER':
-        return apiError(c, 400, 'Direct shares cannot be folders', { reason: 'DIRECT_NO_FOLDER' })
-      case 'DIRECT_NO_PASSWORD':
-        return apiError(c, 400, 'Direct shares cannot have a password', { reason: 'DIRECT_NO_PASSWORD' })
-      case 'DIRECT_NO_RECIPIENTS':
-        return apiError(c, 400, 'Direct shares cannot have recipients', { reason: 'DIRECT_NO_RECIPIENTS' })
-    }
+    throw out.error
   })
   .openapi(revokeShareRoute, async (c) => {
     const out = await revokeShare(c.get('deps'), {
@@ -456,8 +406,7 @@ export const authedShares = authedApp
       orgId: c.get('orgId')!,
     })
     if (out.ok) return c.body(null, 204)
-    if (out.reason === 'forbidden') return apiError(c, 403, 'Forbidden')
-    return apiError(c, 404, 'Not found')
+    throw out.error
   })
   .openapi(saveShareRoute, async (c) => {
     const token = c.req.valid('param').token
@@ -470,20 +419,5 @@ export const authedShares = authedApp
       accessCookie: getCookie(c, cookieName(token)),
     })
     if (out.ok) return c.json({ saved: out.result.saved.map(toSavedMatterDTO), skipped: out.result.skipped }, 201)
-    switch (out.reason) {
-      case 'matter_trashed':
-        return apiError(c, 410, 'Share target has been deleted')
-      case 'not_found':
-        return apiError(c, 404, 'Share not found')
-      case 'direct_forbidden':
-        return apiError(c, 400, 'Direct link shares cannot be saved. Ask the sender for a landing share.', {
-          reason: 'DIRECT_SAVE_FORBIDDEN',
-        })
-      case 'password_required':
-        return apiError(c, 401, 'Authentication required for password-protected share')
-      case 'forbidden':
-        return apiError(c, 403, 'Forbidden')
-      case 'quota_exceeded':
-        return apiError(c, 400, 'Quota exceeded', { reason: ErrorReason.QUOTA_EXCEEDED, status: 'RESOURCE_EXHAUSTED' })
-    }
+    throw out.error
   })

--- a/server/http/site/announcements.ts
+++ b/server/http/site/announcements.ts
@@ -3,7 +3,7 @@ import { announcementInputSchema, announcementStatusSchema, pageQuerySchema, pag
 import { requireAdmin, requireAuth } from '../../middleware/auth'
 import type { Env } from '../../middleware/platform'
 import { requireFeature } from '../../middleware/require-feature'
-import type { AnnouncementRecord } from '../../usecases/ports'
+import { type AnnouncementRecord, forbidden, notFound } from '../../usecases/ports'
 import {
   createAnnouncement,
   deleteAnnouncement,
@@ -12,7 +12,7 @@ import {
   listUserAnnouncements,
   updateAnnouncement,
 } from '../../usecases/site/announcement'
-import { apiError, errorResponse, jsonBody, jsonContent } from '../openapi'
+import { errorResponse, jsonBody, jsonContent } from '../openapi'
 
 const announcementSchema = z
   .object({
@@ -129,7 +129,7 @@ export const announcements = app
     const { page, pageSize } = query
     const wantsManagement = query.scope === 'all' || query.status !== undefined
     if (wantsManagement) {
-      if (c.get('userRole') !== 'admin') return apiError(c, 403, 'Forbidden')
+      if (c.get('userRole') !== 'admin') throw forbidden()
       const result = await listAdminAnnouncements(c.get('deps'), { status: query.status, page, pageSize })
       return c.json({ ...result, items: result.items.map(toAnnouncementDTO) }, 200)
     }
@@ -145,17 +145,17 @@ export const announcements = app
   )
   .openapi(getAnnouncementRoute, async (c) => {
     const announcement = await getAnnouncement(c.get('deps'), c.req.valid('param').id)
-    if (!announcement) return apiError(c, 404, 'Announcement not found')
+    if (!announcement) throw notFound('Announcement not found')
     return c.json(toAnnouncementDTO(announcement), 200)
   })
   .openapi(updateAnnouncementRoute, async (c) => {
     const announcement = await updateAnnouncement(c.get('deps'), c.req.valid('param').id, c.req.valid('json'))
-    if (!announcement) return apiError(c, 404, 'Announcement not found')
+    if (!announcement) throw notFound('Announcement not found')
     return c.json(toAnnouncementDTO(announcement), 200)
   })
   .openapi(deleteAnnouncementRoute, async (c) => {
     const id = c.req.valid('param').id
     const deleted = await deleteAnnouncement(c.get('deps'), id)
-    if (!deleted) return apiError(c, 404, 'Announcement not found')
+    if (!deleted) throw notFound('Announcement not found')
     return c.json({ id, deleted: true as const }, 200)
   })

--- a/server/http/site/auth-providers.ts
+++ b/server/http/site/auth-providers.ts
@@ -1,15 +1,14 @@
 import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
-import { ErrorReason, pageSchema } from '@shared/schemas'
+import { pageSchema } from '@shared/schemas'
 import { requireAdmin } from '../../middleware/auth'
 import type { Env } from '../../middleware/platform'
 import {
   deleteAuthProvider,
   listAuthProviders,
   listPublicAuthProviders,
-  type SocialLoginFeatureBlock,
   upsertAuthProvider,
 } from '../../usecases/site/auth-provider'
-import { apiError, errorResponse, jsonBody, jsonContent } from '../openapi'
+import { errorResponse, jsonBody, jsonContent } from '../openapi'
 
 const maskedProviderConfigSchema = z
   .object({
@@ -38,15 +37,6 @@ const authProviderListSchema = pageSchema(
   z.union([maskedProviderConfigSchema, publicProviderSchema]),
   'AuthProviderList',
 )
-
-const invalidProviderIdMessage = 'Provider ID must contain only lowercase letters, numbers, and hyphens'
-
-const featureBlockMetadata = (block: SocialLoginFeatureBlock): Record<string, string> => ({
-  feature: block.feature,
-  currentCount: String(block.currentCount),
-  limit: String(block.limit),
-  upgradeUrl: '/settings/billing',
-})
 
 const upsertSchema = z.object({
   type: z.enum(['builtin', 'oidc']),
@@ -107,19 +97,12 @@ export const authProviders = new OpenAPIHono<Env>()
   })
   .openapi(upsertRoute, async (c) => {
     const result = await upsertAuthProvider(c.get('deps'), c.req.valid('param').providerId, c.req.valid('json'))
-    if (result.ok) return c.json(result.config, 200)
-    if (result.reason === 'invalid_id') return apiError(c, 400, invalidProviderIdMessage)
-    if (result.reason === 'unknown_builtin')
-      return apiError(c, 400, `Unknown builtin provider: ${c.req.valid('param').providerId}`)
-    if (result.reason === 'missing_discovery') return apiError(c, 400, 'discoveryUrl is required for OIDC providers')
-    return apiError(c, 402, 'Feature not available', {
-      reason: ErrorReason.FEATURE_NOT_AVAILABLE,
-      metadata: featureBlockMetadata(result.block),
-    })
+    if (!result.ok) throw result.error
+    return c.json(result.config, 200)
   })
   .openapi(deleteProviderRoute, async (c) => {
     const providerId = c.req.valid('param').providerId
     const result = await deleteAuthProvider(c.get('deps'), providerId)
-    if (!result.ok) return apiError(c, 400, invalidProviderIdMessage)
+    if (!result.ok) throw result.error
     return c.json({ providerId, deleted: true as const }, 200)
   })

--- a/server/http/site/branding.ts
+++ b/server/http/site/branding.ts
@@ -1,11 +1,11 @@
 import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
-import { ErrorReason } from '@shared/schemas'
 import { type BrandingField, type BrandingThemeMode, isBrandingThemePresetId } from '../../../shared/types'
 import { requireAdmin } from '../../middleware/auth'
 import type { Env } from '../../middleware/platform'
 import { requireFeature } from '../../middleware/require-feature'
+import { AppError, badRequest, noStorage, payloadTooLarge, unsupportedMediaType } from '../../usecases/ports'
 import { applyBrandingUpdate, readBranding, resetBranding, type ThemeUpdate } from '../../usecases/site/branding'
-import { apiError, errorResponse, jsonContent } from '../openapi'
+import { errorResponse, jsonContent } from '../openapi'
 
 const brandingThemeValuesSchema = z.object({
   primary_color: z.string(),
@@ -141,16 +141,16 @@ export const publicBranding = new OpenAPIHono<Env>().openapi(readRoute, async (c
 export const brandingAdmin = new OpenAPIHono<Env>()
   .openapi(updateRoute, async (c) => {
     if (!c.req.header('content-type')?.includes('multipart/form-data')) {
-      return apiError(c, 415, 'Expected multipart/form-data', { reason: ErrorReason.UNSUPPORTED_MEDIA_TYPE })
+      throw unsupportedMediaType('Expected multipart/form-data')
     }
     const form = await c.req.formData()
 
     const themeUpdate = parseThemeUpdate(form)
-    if (!themeUpdate.ok) return apiError(c, 422, themeUpdate.error)
+    if (!themeUpdate.ok) throw new AppError(422, themeUpdate.error)
 
     const wordmarkRaw = form.get('wordmark_text')
     if (typeof wordmarkRaw === 'string' && wordmarkRaw.length > 24) {
-      return apiError(c, 422, 'wordmark_text must be 24 characters or fewer')
+      throw new AppError(422, 'wordmark_text must be 24 characters or fewer')
     }
 
     const hidePoweredByRaw = form.get('hide_powered_by')
@@ -167,16 +167,16 @@ export const brandingAdmin = new OpenAPIHono<Env>()
       theme: themeUpdate.values,
     })
     if (!result.ok) {
-      if (result.status === 503) return apiError(c, 503, result.error, { reason: ErrorReason.NO_STORAGE_CONFIGURED })
-      if (result.status === 413) return apiError(c, 413, result.error, { reason: ErrorReason.PAYLOAD_TOO_LARGE })
-      return apiError(c, 400, result.error)
+      if (result.status === 503) throw noStorage(result.error)
+      if (result.status === 413) throw payloadTooLarge(result.error)
+      throw badRequest(result.error)
     }
     return c.json(result.config, 200)
   })
   .openapi(resetRoute, async (c) => {
     const rawField = c.req.valid('param').field
     if (!VALID_RESET_FIELDS.has(rawField as BrandingField)) {
-      return apiError(c, 400, `Invalid field. Valid fields: ${[...VALID_RESET_FIELDS].join(', ')}`)
+      throw badRequest(`Invalid field. Valid fields: ${[...VALID_RESET_FIELDS].join(', ')}`)
     }
     await resetBranding(c.get('deps'), {
       userId: c.get('userId')!,

--- a/server/http/site/email-config.ts
+++ b/server/http/site/email-config.ts
@@ -2,7 +2,7 @@ import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
 import { requireAdmin } from '../../middleware/auth'
 import type { Env } from '../../middleware/platform'
 import { getEmailConfig, saveEmailConfig, sendTestEmail } from '../../usecases/site/email-config'
-import { apiError, errorResponse, jsonContent } from '../openapi'
+import { errorResponse, jsonContent } from '../openapi'
 
 const smtpConfigSchema = z.object({
   enabled: z.boolean(),
@@ -88,8 +88,8 @@ const emailConfig = app
   })
   .openapi(testRoute, async (c) => {
     const result = await sendTestEmail(c.get('deps'), c.get('platform'), c.req.valid('json').to)
-    if (result.ok) return c.json({ success: true }, 200)
-    return apiError(c, 400, result.message)
+    if (!result.ok) throw result.error
+    return c.json({ success: true }, 200)
   })
 
 export default emailConfig

--- a/server/http/site/invitations.ts
+++ b/server/http/site/invitations.ts
@@ -2,6 +2,7 @@ import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
 import { pageQuerySchema, pageSchema } from '@shared/schemas'
 import { requireAdmin } from '../../middleware/auth'
 import type { Env } from '../../middleware/platform'
+import { notFound, unauthorized } from '../../usecases/ports'
 import {
   createSiteInvitation,
   getSiteInvitationByToken,
@@ -9,7 +10,7 @@ import {
   resendSiteInvitation,
   revokeSiteInvitation,
 } from '../../usecases/site/invitation'
-import { apiError, errorResponse, jsonBody, jsonContent } from '../openapi'
+import { errorResponse, jsonBody, jsonContent } from '../openapi'
 
 // SiteInvitation is already wire-shaped (ISO string timestamps) — no DTO mapper.
 const siteInvitationSchema = z
@@ -112,14 +113,14 @@ export const adminSiteInvitations = new OpenAPIHono<Env>()
   })
   .openapi(createRouteDoc, async (c) => {
     const userId = c.get('userId')
-    if (!userId) return apiError(c, 401, 'Unauthorized')
+    if (!userId) throw unauthorized()
     const result = await createSiteInvitation(c.get('deps'), c.get('platform'), {
       userId,
       orgId: c.get('orgId')!,
       email: c.req.valid('json').email,
       requestUrl: c.req.url,
     })
-    if (!result.ok) return apiError(c, 409, result.message)
+    if (!result.ok) throw result.error
     return c.json(result.invitation, 201)
   })
   .openapi(resendRoute, async (c) => {
@@ -127,24 +128,20 @@ export const adminSiteInvitations = new OpenAPIHono<Env>()
       id: c.req.valid('param').id,
       requestUrl: c.req.url,
     })
-    if (result.ok) return c.json(result.invitation, 200)
-    if (result.reason === 'not_found') return apiError(c, 404, 'Invitation not found')
-    if (result.reason === 'already_accepted') return apiError(c, 400, 'Invitation has already been used')
-    return apiError(c, 400, 'Invitation has been revoked')
+    if (!result.ok) throw result.error
+    return c.json(result.invitation, 200)
   })
   .openapi(revokeRoute, async (c) => {
     const userId = c.get('userId')
-    if (!userId) return apiError(c, 401, 'Unauthorized')
+    if (!userId) throw unauthorized()
     const id = c.req.valid('param').id
     const result = await revokeSiteInvitation(c.get('deps'), { userId, orgId: c.get('orgId')!, id })
-    if (result.ok) return c.json({ id, revoked: true as const }, 200)
-    if (result.reason === 'not_found') return apiError(c, 404, 'Invitation not found')
-    if (result.reason === 'already_accepted') return apiError(c, 400, 'Invitation has already been used')
-    return apiError(c, 400, 'Invitation has already been revoked')
+    if (!result.ok) throw result.error
+    return c.json({ id, revoked: true as const }, 200)
   })
 
 export const publicSiteInvitations = new OpenAPIHono<Env>().openapi(getByTokenRoute, async (c) => {
   const invitation = await getSiteInvitationByToken(c.get('deps'), c.req.valid('param').token)
-  if (!invitation) return apiError(c, 404, 'Invitation not found')
+  if (!invitation) throw notFound('Invitation not found')
   return c.json(invitation, 200)
 })

--- a/server/http/site/invite-codes.ts
+++ b/server/http/site/invite-codes.ts
@@ -2,14 +2,14 @@ import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
 import { pageQuerySchema, pageSchema } from '@shared/schemas'
 import { requireAdmin } from '../../middleware/auth'
 import type { Env } from '../../middleware/platform'
-import type { InviteCodeRecord } from '../../usecases/ports'
+import { type InviteCodeRecord, unauthorized } from '../../usecases/ports'
 import {
   deleteInviteCode,
   generateInviteCodes,
   listInviteCodes,
   validateInviteCode,
 } from '../../usecases/site/invite-code'
-import { apiError, errorResponse, jsonBody, jsonContent } from '../openapi'
+import { errorResponse, jsonBody, jsonContent } from '../openapi'
 
 const inviteCodeSchema = z
   .object({
@@ -108,7 +108,7 @@ export const adminInviteCodes = new OpenAPIHono<Env>()
   })
   .openapi(generateRoute, async (c) => {
     const userId = c.get('userId')
-    if (!userId) return apiError(c, 401, 'Unauthorized')
+    if (!userId) throw unauthorized()
     const { count, expiresInDays } = c.req.valid('json')
     const result = await generateInviteCodes(c.get('deps'), { userId, orgId: c.get('orgId')!, count, expiresInDays })
     return c.json({ codes: result.codes.map(toInviteCodeDTO) }, 201)
@@ -116,9 +116,8 @@ export const adminInviteCodes = new OpenAPIHono<Env>()
   .openapi(deleteRoute, async (c) => {
     const id = c.req.valid('param').id
     const result = await deleteInviteCode(c.get('deps'), { userId: c.get('userId')!, orgId: c.get('orgId')!, id })
-    if (result.ok) return c.json({ id, deleted: true as const }, 200)
-    if (result.reason === 'not_found') return apiError(c, 404, 'Invite code not found')
-    return apiError(c, 400, 'Cannot delete a used invite code')
+    if (!result.ok) throw result.error
+    return c.json({ id, deleted: true as const }, 200)
   })
 
 export const publicInviteCodes = new OpenAPIHono<Env>().openapi(validateRoute, async (c) => {

--- a/server/http/site/licensing.ts
+++ b/server/http/site/licensing.ts
@@ -7,6 +7,7 @@ import { originFromRequestUrl } from '../../domain/site-public-origin'
 import { requireAdmin } from '../../middleware/auth'
 import type { Env } from '../../middleware/platform'
 import { syncPendingRemoteDownloadUsageReports } from '../../usecases/downloads/remote-download-usage'
+import { unauthorized } from '../../usecases/ports'
 import { buildCloudInstanceInfo, runtimeInfo } from '../../usecases/site/instance-info'
 import {
   initiatePairing,
@@ -19,7 +20,7 @@ import {
 } from '../../usecases/site/licensing'
 import { getSitePublicOrigin } from '../../usecases/site/public-origin'
 import { syncPendingCloudTrafficReports } from '../../usecases/store/traffic-metering'
-import { apiError, errorResponse, jsonContent } from '../openapi'
+import { errorResponse, jsonContent } from '../openapi'
 
 function getCloudBaseUrl(c: Context<Env>): string {
   return c.get('platform').getEnv('ZPAN_CLOUD_URL') ?? ZPAN_CLOUD_URL_DEFAULT
@@ -147,7 +148,7 @@ const publicApp = new OpenAPIHono<Env>()
 // Cron-secret-authorized sync endpoints — called by external schedulers, not SDK
 // users. Kept as plain routes, excluded from the OpenAPI document.
 publicApp.post('/refresh-cron', async (c) => {
-  if (!isAuthorizedCronRequest(c)) return apiError(c, 401, 'Unauthorized')
+  if (!isAuthorizedCronRequest(c)) throw unauthorized()
   const cloudBaseUrl = getCloudBaseUrl(c)
   const origin = await getInstanceOrigin(c)
   const instance = origin
@@ -157,7 +158,7 @@ publicApp.post('/refresh-cron', async (c) => {
   return c.json({ ok: true })
 })
 publicApp.post('/traffic-sync-runs', async (c) => {
-  if (!isAuthorizedCronRequest(c)) return apiError(c, 401, 'Unauthorized')
+  if (!isAuthorizedCronRequest(c)) throw unauthorized()
   const cloudBaseUrl = getCloudBaseUrl(c)
   const [traffic, remoteDownload] = await Promise.all([
     syncPendingCloudTrafficReports(c.get('deps'), { cloudBaseUrl }),
@@ -195,15 +196,7 @@ export const licensingAdmin = adminApp
       userId: c.get('userId')!,
       orgId: c.get('orgId')!,
     })
-    if (!result.ok) {
-      return apiError(c, 502, 'Invalid certificate', {
-        reason: 'INVALID_CERTIFICATE',
-        metadata: {
-          certificateReason: result.reason,
-          ...(result.cloudUnbindError ? { cloudUnbindError: result.cloudUnbindError } : {}),
-        },
-      })
-    }
+    if (!result.ok) throw result.error
     if (result.status === 'approved') {
       return c.json({ status: 'approved', edition: result.edition, cloud_store_id: result.cloudStoreId }, 200)
     }

--- a/server/http/site/storages.ts
+++ b/server/http/site/storages.ts
@@ -1,17 +1,10 @@
 import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
-import { createStorageSchema, ErrorReason, pageSchema, updateStorageSchema } from '@shared/schemas'
+import { createStorageSchema, pageSchema, updateStorageSchema } from '@shared/schemas'
 import { requireAdmin } from '../../middleware/auth'
 import type { Env } from '../../middleware/platform'
-import type { StorageRecord } from '../../usecases/ports'
-import {
-  createStorage,
-  deleteStorage,
-  getStorage,
-  listStorages,
-  type StorageFeatureBlock,
-  updateStorage,
-} from '../../usecases/site/storage'
-import { apiError, errorResponse, jsonBody, jsonContent } from '../openapi'
+import { type StorageRecord, storageNotFound } from '../../usecases/ports'
+import { createStorage, deleteStorage, getStorage, listStorages, updateStorage } from '../../usecases/site/storage'
+import { errorResponse, jsonBody, jsonContent } from '../openapi'
 
 // Admin storage config. The response intentionally includes the S3 credentials
 // (accessKey/secretKey) so the admin UI can pre-fill the edit form — admin-only.
@@ -46,12 +39,6 @@ function toStorageDTO(s: StorageRecord): StorageDTO {
 }
 
 const storageListSchema = pageSchema(storageSchema, 'StorageList')
-
-const featureBlockMetadata = (block: StorageFeatureBlock): Record<string, string> => ({
-  feature: block.feature,
-  ...('currentCount' in block ? { currentCount: String(block.currentCount) } : {}),
-  ...('limit' in block ? { limit: String(block.limit) } : {}),
-})
 
 const listRoute = createRoute({
   operationId: 'listStorages',
@@ -133,16 +120,12 @@ const storages = new OpenAPIHono<Env>()
       orgId: c.get('orgId')!,
       input: c.req.valid('json'),
     })
-    if (!result.ok)
-      return apiError(c, 402, 'Feature not available', {
-        reason: ErrorReason.FEATURE_NOT_AVAILABLE,
-        metadata: featureBlockMetadata(result.block),
-      })
+    if (!result.ok) throw result.error
     return c.json(toStorageDTO(result.storage), 201)
   })
   .openapi(getStorageRoute, async (c) => {
     const storage = await getStorage(c.get('deps'), c.req.valid('param').id)
-    if (!storage) return apiError(c, 404, 'Storage not found')
+    if (!storage) throw storageNotFound()
     return c.json(toStorageDTO(storage), 200)
   })
   .openapi(updateStorageRoute, async (c) => {
@@ -152,19 +135,14 @@ const storages = new OpenAPIHono<Env>()
       id: c.req.valid('param').id,
       input: c.req.valid('json'),
     })
-    if (result.ok) return c.json(toStorageDTO(result.storage), 200)
-    if (result.reason === 'not_found') return apiError(c, 404, 'Storage not found')
-    return apiError(c, 402, 'Feature not available', {
-      reason: ErrorReason.FEATURE_NOT_AVAILABLE,
-      metadata: featureBlockMetadata(result.block),
-    })
+    if (!result.ok) throw result.error
+    return c.json(toStorageDTO(result.storage), 200)
   })
   .openapi(deleteStorageRoute, async (c) => {
     const id = c.req.valid('param').id
     const result = await deleteStorage(c.get('deps'), { userId: c.get('userId')!, orgId: c.get('orgId')!, id })
-    if (result.ok) return c.json({ id, deleted: true as const }, 200)
-    if (result.reason === 'not_found') return apiError(c, 404, 'Storage not found')
-    return apiError(c, 409, 'Storage is referenced by existing files')
+    if (!result.ok) throw result.error
+    return c.json({ id, deleted: true as const }, 200)
   })
 
 export default storages

--- a/server/http/site/system.ts
+++ b/server/http/site/system.ts
@@ -1,5 +1,5 @@
 import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
-import { ErrorReason, pageSchema } from '@shared/schemas'
+import { pageSchema } from '@shared/schemas'
 import { requireAdmin } from '../../middleware/auth'
 import type { Env } from '../../middleware/platform'
 import { runtimeInfo } from '../../usecases/site/instance-info'
@@ -11,7 +11,7 @@ import {
   resolveInstanceInfo,
   setSystemOption,
 } from '../../usecases/site/system'
-import { apiError, errorResponse, jsonBody, jsonContent } from '../openapi'
+import { errorResponse, jsonBody, jsonContent } from '../openapi'
 
 const instanceInfoSchema = z
   .object({
@@ -145,9 +145,8 @@ const system = new OpenAPIHono<Env>()
       key: c.req.valid('param').key,
       isAdmin: c.get('userRole') === 'admin',
     })
-    if (result.ok) return c.json(result.option, 200)
-    if (result.reason === 'not_found') return apiError(c, 404, 'Option not found')
-    return apiError(c, 403, 'Forbidden')
+    if (!result.ok) throw result.error
+    return c.json(result.option, 200)
   })
   .openapi(setOptionRoute, async (c) => {
     const body = c.req.valid('json')
@@ -158,14 +157,7 @@ const system = new OpenAPIHono<Env>()
       value: body.value,
       public: body.public,
     })
-    if (!result.ok) {
-      if (result.reason === 'feature_blocked')
-        return apiError(c, 402, 'Feature not available', {
-          reason: ErrorReason.FEATURE_NOT_AVAILABLE,
-          metadata: { feature: result.feature, upgradeUrl: '/settings/billing' },
-        })
-      return apiError(c, 400, result.message)
-    }
+    if (!result.ok) throw result.error
     return result.created ? c.json(result.option, 201) : c.json(result.option, 200)
   })
   .openapi(deleteOptionRoute, async (c) =>

--- a/server/http/store/storefront.ts
+++ b/server/http/store/storefront.ts
@@ -3,6 +3,7 @@ import { checkoutInputSchema, discountQuoteInputSchema, redeemGiftCardInputSchem
 import { requireAuth, requireTeamRole } from '../../middleware/auth'
 import type { Env } from '../../middleware/platform'
 import { requireFeature } from '../../middleware/require-feature'
+import { badGateway, badRequest, forbidden } from '../../usecases/ports'
 import {
   cancelOrder,
   continueOrderPayment,
@@ -17,7 +18,7 @@ import {
   listTargets,
   redeemGiftCard,
 } from '../../usecases/store/store'
-import { apiError, errorResponse, jsonBody, jsonContent } from '../openapi'
+import { errorResponse, jsonBody, jsonContent } from '../openapi'
 import { cloudStoreOrdersQuerySchema, getCloudBaseUrl } from './helpers'
 import { getCloudOrders, getInstanceOrigin } from './shared'
 
@@ -207,112 +208,103 @@ app.use(requireFeature('quota_store'))
 export const cloudStore = app
   .openapi(packagesRoute, async (c) => {
     const result = await listPackages(c.get('deps'), getCloudBaseUrl(c))
-    if (!result.ok) return apiError(c, result.reason === 'binding_missing' ? 403 : 502, result.error)
+    if (!result.ok) throw result.error
     return c.json(result.value, 200)
   })
   .openapi(creditProductsRoute, async (c) => {
     const result = await listCreditProducts(c.get('deps'), getCloudBaseUrl(c))
-    if (!result.ok) return apiError(c, result.reason === 'binding_missing' ? 403 : 502, result.error)
+    if (!result.ok) throw result.error
     return c.json(result.value, 200)
   })
   .openapi(targetsRoute, async (c) => {
     const result = await listTargets(c.get('deps'), c.get('userId')!)
-    if (!result.ok) return apiError(c, result.reason === 'binding_missing' ? 403 : 502, result.error)
+    if (!result.ok) throw result.error
     return c.json(result.value, 200)
   })
   .openapi(creditsRoute, async (c) => {
     const targetOrgId = c.get('orgId')
-    if (!targetOrgId) return apiError(c, 400, 'No active organization')
+    if (!targetOrgId) throw badRequest('No active organization')
     const result = await getCreditBalance(c.get('deps'), getCloudBaseUrl(c), targetOrgId)
-    if (!result.ok) return apiError(c, result.reason === 'binding_missing' ? 403 : 502, result.error)
+    if (!result.ok) throw result.error
     return c.json(result.value, 200)
   })
   .openapi(ledgerRoute, async (c) => {
     const targetOrgId = c.get('orgId')
-    if (!targetOrgId) return apiError(c, 400, 'No active organization')
+    if (!targetOrgId) throw badRequest('No active organization')
     const result = await getCreditLedger(c.get('deps'), getCloudBaseUrl(c), targetOrgId)
-    if (!result.ok) return apiError(c, result.reason === 'binding_missing' ? 403 : 502, result.error)
+    if (!result.ok) throw result.error
     return c.json(result.value, 200)
   })
   .openapi(redeemRoute, async (c) => {
     const targetOrgId = c.get('orgId')
-    if (!targetOrgId) return apiError(c, 400, 'No active organization')
+    if (!targetOrgId) throw badRequest('No active organization')
     const result = await redeemGiftCard(c.get('deps'), getCloudBaseUrl(c), {
       orgId: targetOrgId,
       input: c.req.valid('json'),
     })
-    if (!result.ok) return apiError(c, result.reason === 'binding_missing' ? 403 : 502, result.error)
+    if (!result.ok) throw result.error
     return c.json(result.value, 200)
   })
   .openapi(checkoutRoute, async (c) => {
     const targetOrgId = c.get('orgId')
-    if (!targetOrgId) return apiError(c, 400, 'No active organization')
+    if (!targetOrgId) throw badRequest('No active organization')
     const result = await createCheckout(c.get('deps'), getCloudBaseUrl(c), {
       userId: c.get('userId')!,
       orgId: targetOrgId,
       origin: await getInstanceOrigin(c),
       input: c.req.valid('json'),
     })
-    if (result.ok) return c.json(result.value, 200)
-    if (result.reason === 'binding_missing') return apiError(c, 403, result.error)
-    if (result.reason === 'price_missing')
-      return apiError(c, 400, 'Package price missing', { reason: 'PACKAGE_PRICE_MISSING' })
-    if (result.reason === 'workspace_plan_exists')
-      return apiError(c, 409, 'Workspace plan already exists', { reason: 'WORKSPACE_PLAN_EXISTS' })
-    return apiError(c, 502, result.error)
+    if (!result.ok) throw result.error
+    return c.json(result.value, 200)
   })
   .openapi(discountRoute, async (c) => {
     const result = await getDiscountQuote(c.get('deps'), getCloudBaseUrl(c), c.req.valid('json'))
-    if (!result.ok) return apiError(c, result.reason === 'binding_missing' ? 403 : 502, result.error)
+    if (!result.ok) throw result.error
     return c.json(result.value, 200)
   })
   .openapi(billingPortalRoute, async (c) => {
     const targetOrgId = c.get('orgId')
-    if (!targetOrgId) return apiError(c, 400, 'No active organization')
+    if (!targetOrgId) throw badRequest('No active organization')
     const result = await createBillingPortalSession(c.get('deps'), getCloudBaseUrl(c), {
       orgId: targetOrgId,
       origin: await getInstanceOrigin(c),
     })
-    if (!result.ok) return apiError(c, result.reason === 'binding_missing' ? 403 : 502, result.error)
+    if (!result.ok) throw result.error
     return c.json(result.value, 200)
   })
   .openapi(ordersRoute, async (c) => {
     const ready = await getStoreReadiness(c.get('deps'))
-    if (!ready.ready) return apiError(c, 403, ready.error)
+    if (!ready.ready) throw forbidden(ready.error)
     const targetOrgId = c.get('orgId')
-    if (!targetOrgId) return apiError(c, 400, 'No active organization')
+    if (!targetOrgId) throw badRequest('No active organization')
     const query = c.req.valid('query')
     const result = await getCloudOrders(c, { limit: query.limit, offset: query.offset, customerId: targetOrgId })
-    if ('error' in result) return apiError(c, 502, result.error)
+    if ('error' in result) throw badGateway(result.error)
     return c.json(result, 200)
   })
   .openapi(continuePaymentRoute, async (c) => {
     const ready = await getStoreReadiness(c.get('deps'))
-    if (!ready.ready) return apiError(c, 403, ready.error)
+    if (!ready.ready) throw forbidden(ready.error)
     const targetOrgId = c.get('orgId')
-    if (!targetOrgId) return apiError(c, 400, 'No active organization')
+    if (!targetOrgId) throw badRequest('No active organization')
     const result = await continueOrderPayment(c.get('deps'), getCloudBaseUrl(c), {
       orgId: targetOrgId,
       orderId: c.req.valid('param').orderId,
       origin: await getInstanceOrigin(c),
     })
-    if (result.ok) return c.json(result.value, 200)
-    if (result.reason === 'not_found') return apiError(c, 404, 'Order not found')
-    if (result.reason === 'forbidden') return apiError(c, 403, 'Forbidden')
-    return apiError(c, 502, result.error)
+    if (!result.ok) throw result.error
+    return c.json(result.value, 200)
   })
   .openapi(cancelOrderRoute, async (c) => {
     const ready = await getStoreReadiness(c.get('deps'))
-    if (!ready.ready) return apiError(c, 403, ready.error)
+    if (!ready.ready) throw forbidden(ready.error)
     const targetOrgId = c.get('orgId')
-    if (!targetOrgId) return apiError(c, 400, 'No active organization')
+    if (!targetOrgId) throw badRequest('No active organization')
     const result = await cancelOrder(c.get('deps'), getCloudBaseUrl(c), {
       orgId: targetOrgId,
       orderId: c.req.valid('param').orderId,
       status: c.req.valid('json').status,
     })
-    if (result.ok) return c.json(result.value, 200)
-    if (result.reason === 'not_found') return apiError(c, 404, 'Order not found')
-    if (result.reason === 'forbidden') return apiError(c, 403, 'Forbidden')
-    return apiError(c, 502, result.error)
+    if (!result.ok) throw result.error
+    return c.json(result.value, 200)
   })

--- a/server/http/store/traffic-metering.ts
+++ b/server/http/store/traffic-metering.ts
@@ -1,7 +1,7 @@
-import { ErrorReason } from '@shared/schemas'
 import type { Context } from 'hono'
 import { ZPAN_CLOUD_URL_DEFAULT } from '../../../shared/constants'
 import type { Env } from '../../middleware/platform'
+import { insufficientCredits } from '../../usecases/ports'
 import {
   type DownloadTrafficOutcome,
   type DownloadTrafficStorage,
@@ -9,7 +9,6 @@ import {
   reportDownloadEgress,
   type TrafficReportSource,
 } from '../../usecases/store/traffic-metering'
-import { apiError } from '../openapi'
 
 // Thin http adapters over the download-metering usecase: resolve the cloud base
 // URL from the request, call the usecase (deps passed whole), and render the
@@ -30,11 +29,8 @@ interface DownloadTrafficParams {
 
 const cloudBaseUrl = (c: Context<Env>) => c.get('platform').getEnv('ZPAN_CLOUD_URL') ?? ZPAN_CLOUD_URL_DEFAULT
 
-function insufficientCredits(c: Context<Env>): Response {
-  return apiError(c, 402, 'Insufficient credits', {
-    reason: ErrorReason.INSUFFICIENT_CREDITS,
-    metadata: { resource: 'storage_egress' },
-  })
+function throwInsufficientCredits(): never {
+  throw insufficientCredits('Insufficient credits', { metadata: { resource: 'storage_egress' } })
 }
 
 /**
@@ -57,7 +53,7 @@ export async function consumeAndReportDownloadTraffic(
     onRejected: params.onRejected,
   })
   if (outcome.ok) return null
-  return outcome.reason === 'quota_exceeded' ? params.quotaExceeded() : insufficientCredits(c)
+  return outcome.reason === 'quota_exceeded' ? params.quotaExceeded() : throwInsufficientCredits()
 }
 
 export async function reportTrafficForDownload(
@@ -81,5 +77,5 @@ export async function reportTrafficForDownload(
     onRejected: params.onRejected,
   })
   // reportDownloadEgress never consumes quota, so it cannot return quota_exceeded.
-  return outcome.ok ? null : insufficientCredits(c)
+  return outcome.ok ? null : throwInsufficientCredits()
 }

--- a/server/http/store/webhooks.ts
+++ b/server/http/store/webhooks.ts
@@ -2,7 +2,6 @@ import { Hono } from 'hono'
 import type { Env } from '../../middleware/platform'
 import { requireFeature } from '../../middleware/require-feature'
 import { processDeliveryWebhook } from '../../usecases/store/store'
-import { apiError } from '../openapi'
 import { getCloudBaseUrl, parseJson, sha256Hex } from './helpers'
 
 export const cloudStoreWebhooks = new Hono<Env>().use(requireFeature('quota_store')).post('/webhook', async (c) => {
@@ -14,9 +13,6 @@ export const cloudStoreWebhooks = new Hono<Env>().use(requireFeature('quota_stor
     payloadHash: await sha256Hex(rawPayload),
     body: parseJson(rawPayload),
   })
-  if (outcome.ok) return c.json({ success: true, duplicate: outcome.duplicate, eventId: outcome.eventId })
-  if (outcome.reason === 'invalid_token')
-    return apiError(c, 401, 'Invalid event token', { reason: 'INVALID_EVENT_TOKEN' })
-  if (outcome.reason === 'invalid_payload') return apiError(c, 400, 'Invalid payload', { reason: 'INVALID_PAYLOAD' })
-  return apiError(c, 400, outcome.error)
+  if (!outcome.ok) throw outcome.error
+  return c.json({ success: true, duplicate: outcome.duplicate, eventId: outcome.eventId })
 })

--- a/server/http/teams.ts
+++ b/server/http/teams.ts
@@ -1,8 +1,20 @@
 import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
-import { ErrorReason, pageQuerySchema, pageSchema } from '@shared/schemas'
+import { pageQuerySchema, pageSchema } from '@shared/schemas'
 import { requireAdmin, requireAuth } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
-import type { ActivityEventWithUser, InviteLinkInfo, PendingInvitation } from '../usecases/ports'
+import {
+  type ActivityEventWithUser,
+  badRequest,
+  conflict,
+  expired,
+  forbidden,
+  type InviteLinkInfo,
+  noStorage,
+  notFound,
+  type PendingInvitation,
+  payloadTooLarge,
+  unsupportedMediaType,
+} from '../usecases/ports'
 import {
   createInviteLink,
   deleteTeamLogo,
@@ -24,7 +36,7 @@ import {
   toEntitlementResultDTO,
   toQuotaEntitlementDTO,
 } from './entitlements'
-import { apiError, errorResponse, jsonBody, jsonContent } from './openapi'
+import { errorResponse, jsonBody, jsonContent } from './openapi'
 
 const inviteLinkInfoSchema = z
   .object({
@@ -114,6 +126,20 @@ const updateEntitlementSchema = z.object({
   note: z.string().max(500).nullable().optional(),
 })
 
+// Maps a UserOperationFailure ({ error, status }) threaded from the UserAdminRepo
+// to the matching error factory — the http boundary the rule keeps the sub-usecase
+// status out of.
+function failureError(failure: { status: 400 | 404; error: string }) {
+  return failure.status === 404 ? notFound(failure.error) : badRequest(failure.error)
+}
+
+// Maps the image-upload gateway outcome ({ status, error }) to its error factory.
+function imageUploadError(status: 400 | 413 | 503, error: string) {
+  if (status === 413) return payloadTooLarge(error)
+  if (status === 503) return noStorage(error)
+  return badRequest(error)
+}
+
 // ── publicTeams ──────────────────────────────────────────────────────────────
 const inviteLinkInfoRoute = createRoute({
   operationId: 'getTeamInviteLink',
@@ -130,7 +156,7 @@ const inviteLinkInfoRoute = createRoute({
 
 export const publicTeams = new OpenAPIHono<Env>().openapi(inviteLinkInfoRoute, async (c) => {
   const info = await getInviteLinkInfo(c.get('deps'), c.req.valid('param').token)
-  if (!info) return apiError(c, 404, 'Invalid or expired invite link')
+  if (!info) throw notFound('Invalid or expired invite link')
   return c.json(toInviteLinkInfoDTO(info), 200)
 })
 
@@ -236,7 +262,7 @@ export const teams = teamsApp
       role,
       expiresIn,
     })
-    if (!result.ok) return apiError(c, 403, 'Forbidden')
+    if (!result.ok) throw forbidden()
     return c.json({ token: result.token, expiresAt: result.expiresAt.toISOString() }, 201)
   })
   .openapi(listInvitationsRoute, async (c) => {
@@ -244,7 +270,7 @@ export const teams = teamsApp
       teamId: c.req.valid('param').teamId,
       userId: c.get('userId')!,
     })
-    if (!result.ok) return apiError(c, 403, 'Forbidden')
+    if (!result.ok) throw forbidden()
     const items = result.invitations.map(toPendingInvitationDTO)
     return c.json({ items, total: items.length, page: 1, pageSize: items.length }, 200)
   })
@@ -255,9 +281,9 @@ export const teams = teamsApp
       token: c.req.valid('json').token,
     })
     if (result.ok) return c.json({ ok: true as const }, 200)
-    if (result.reason === 'invalid') return apiError(c, 404, 'Invalid invite link')
-    if (result.reason === 'expired') return apiError(c, 410, 'Invite link has expired')
-    return apiError(c, 409, 'Already a member of this team')
+    if (result.reason === 'invalid') throw notFound('Invalid invite link')
+    if (result.reason === 'expired') throw expired('Invite link has expired')
+    throw conflict('Already a member of this team')
   })
   .openapi(activityRoute, async (c) => {
     const { page, pageSize } = c.req.valid('query')
@@ -267,7 +293,7 @@ export const teams = teamsApp
       page,
       pageSize,
     })
-    if (!result.ok) return apiError(c, 403, 'Forbidden')
+    if (!result.ok) throw forbidden()
     return c.json(
       { items: result.result.items.map(toActivityEventDTO), total: result.result.total, page, pageSize },
       200,
@@ -276,12 +302,9 @@ export const teams = teamsApp
   .openapi(setLogoRoute, async (c) => {
     const teamId = c.req.valid('param').teamId
     const form = await c.req.formData().catch(() => null)
-    if (!form)
-      return apiError(c, 415, 'Expected multipart/form-data with a file field', {
-        reason: ErrorReason.UNSUPPORTED_MEDIA_TYPE,
-      })
+    if (!form) throw unsupportedMediaType('Expected multipart/form-data with a file field')
     const file = form.get('file')
-    if (!(file instanceof File)) return apiError(c, 400, 'file field is required')
+    if (!(file instanceof File)) throw badRequest('file field is required')
 
     const result = await setTeamLogo(c.get('deps'), {
       platform: c.get('platform'),
@@ -290,10 +313,8 @@ export const teams = teamsApp
       file,
     })
     if (result.ok) return c.json({ url: result.url }, 200)
-    if (result.reason === 'forbidden') return apiError(c, 403, 'Forbidden')
-    if (result.status === 413) return apiError(c, 413, result.error, { reason: ErrorReason.PAYLOAD_TOO_LARGE })
-    if (result.status === 503) return apiError(c, 503, result.error, { reason: ErrorReason.NO_STORAGE_CONFIGURED })
-    return apiError(c, 400, result.error)
+    if (result.reason === 'forbidden') throw forbidden()
+    throw imageUploadError(result.status, result.error)
   })
   .openapi(deleteLogoRoute, async (c) => {
     const result = await deleteTeamLogo(c.get('deps'), {
@@ -301,7 +322,7 @@ export const teams = teamsApp
       teamId: c.req.valid('param').teamId,
       userId: c.get('userId') as string,
     })
-    if (!result.ok) return apiError(c, 403, 'Forbidden')
+    if (!result.ok) throw forbidden()
     return c.json({ ok: true as const }, 200)
   })
 
@@ -397,12 +418,12 @@ export const adminTeams = new OpenAPIHono<Env>()
   })
   .openapi(getTeamRoute, async (c) => {
     const team = await getTeam(c.get('deps'), c.req.valid('param').teamId)
-    if (!team) return apiError(c, 404, 'Team not found')
+    if (!team) throw notFound('Team not found')
     return c.json(team, 200)
   })
   .openapi(listEntitlementsRoute, async (c) => {
     const result = await listTeamEntitlements(c.get('deps'), c.req.valid('param').teamId)
-    if (!result.ok) return apiError(c, result.failure.status, result.failure.error)
+    if (!result.ok) throw failureError(result.failure)
     const items = result.result.items.map(toQuotaEntitlementDTO)
     return c.json({ items, total: items.length, page: 1, pageSize: items.length }, 200)
   })
@@ -417,7 +438,7 @@ export const adminTeams = new OpenAPIHono<Env>()
       expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
       note: body.note,
     })
-    if (!result.ok) return apiError(c, result.failure.status, result.failure.error)
+    if (!result.ok) throw failureError(result.failure)
     return c.json(toEntitlementResultDTO(result.result), 201)
   })
   .openapi(updateEntitlementRoute, async (c) => {
@@ -431,7 +452,7 @@ export const adminTeams = new OpenAPIHono<Env>()
       expiresAt: 'expiresAt' in body ? (body.expiresAt ? new Date(body.expiresAt) : null) : undefined,
       note: body.note,
     })
-    if (!result.ok) return apiError(c, result.failure.status, result.failure.error)
+    if (!result.ok) throw failureError(result.failure)
     return c.json(toEntitlementResultDTO(result.result), 200)
   })
   .openapi(revokeEntitlementRoute, async (c) => {
@@ -441,6 +462,6 @@ export const adminTeams = new OpenAPIHono<Env>()
       targetOrgId: c.req.valid('param').teamId,
       entitlementId: c.req.valid('param').eid,
     })
-    if (!result.ok) return apiError(c, result.failure.status, result.failure.error)
+    if (!result.ok) throw failureError(result.failure)
     return c.json(toEntitlementResultDTO(result.result), 200)
   })

--- a/server/http/trash.ts
+++ b/server/http/trash.ts
@@ -1,8 +1,9 @@
 import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
 import { requireAuth, requireTeamRole } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
+import { badRequest } from '../usecases/ports'
 import { emptyTrash } from '../usecases/trash'
-import { apiError, errorResponse, jsonContent } from './openapi'
+import { errorResponse, jsonContent } from './openapi'
 
 const emptyTrashRoute = createRoute({
   operationId: 'emptyTrash',
@@ -22,7 +23,7 @@ app.use(requireAuth)
 
 const trash = app.openapi(emptyTrashRoute, async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return apiError(c, 400, 'No active organization')
+  if (!orgId) throw badRequest('No active organization')
   const result = await emptyTrash(c.get('deps'), { orgId, userId: c.get('userId')! })
   return c.json({ purged: result.purged }, 200)
 })

--- a/server/http/users.ts
+++ b/server/http/users.ts
@@ -3,6 +3,7 @@ import { pageQuerySchema, pageSchema } from '@shared/schemas'
 import { requireAdmin, requireAuth } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
 import type { UserWithOrg } from '../usecases/ports'
+import { badRequest, noStorage, notFound, payloadTooLarge, unsupportedMediaType } from '../usecases/ports'
 import {
   deleteUser,
   deleteUsers,
@@ -24,7 +25,7 @@ import {
   toEntitlementResultDTO,
   toQuotaEntitlementDTO,
 } from './entitlements'
-import { apiError, errorResponse, jsonBody, jsonContent } from './openapi'
+import { errorResponse, jsonBody, jsonContent } from './openapi'
 
 const userSchema = z
   .object({
@@ -76,6 +77,20 @@ const updateEntitlementSchema = z.object({
   expiresAt: z.string().datetime().nullable().optional(),
   note: z.string().max(500).nullable().optional(),
 })
+
+// Maps a UserOperationFailure ({ error, status }) threaded from the UserAdminRepo
+// to the matching error factory — the http boundary the rule keeps the sub-usecase
+// status out of.
+function failureError(failure: { status: 400 | 404; error: string }) {
+  return failure.status === 404 ? notFound(failure.error) : badRequest(failure.error)
+}
+
+// Maps the image-upload gateway outcome ({ status, error }) to its error factory.
+function imageUploadError(status: 400 | 413 | 503, error: string) {
+  if (status === 413) return payloadTooLarge(error)
+  if (status === 503) return noStorage(error)
+  return badRequest(error)
+}
 
 async function resolveUserId(deps: Env['Variables']['deps'], handle: string): Promise<string | null> {
   const byId = await getUser(deps, handle)
@@ -273,15 +288,15 @@ const revokeUserEntitlementRoute = createRoute({
 export const users = new OpenAPIHono<Env>()
   .openapi(setAvatarRoute, async (c) => {
     const form = await c.req.formData().catch(() => null)
-    if (!form) return apiError(c, 415, 'Expected multipart/form-data with a file field')
+    if (!form) throw unsupportedMediaType('Expected multipart/form-data with a file field')
     const file = form.get('file')
-    if (!(file instanceof File)) return apiError(c, 400, 'file field is required')
+    if (!(file instanceof File)) throw badRequest('file field is required')
     const result = await updateAvatar(c.get('deps'), {
       platform: c.get('platform'),
       userId: c.get('userId') as string,
       file,
     })
-    if (!result.ok) return apiError(c, result.status, result.error)
+    if (!result.ok) throw imageUploadError(result.status, result.error)
     return c.json({ url: result.url }, 200)
   })
   .openapi(deleteAvatarRoute, async (c) => {
@@ -301,36 +316,36 @@ export const users = new OpenAPIHono<Env>()
       ids: body.ids,
       status: body.action === 'disable' ? 'disabled' : 'active',
     })
-    if (!result.ok) return apiError(c, result.failure.status, result.failure.error)
+    if (!result.ok) throw failureError(result.failure)
     return c.json({ ...result.result, status: result.status }, 200)
   })
   .openapi(batchDeleteRoute, async (c) => {
     const { ids } = c.req.valid('json')
     const result = await deleteUsers(c.get('deps'), { adminUserId: c.get('userId')!, orgId: c.get('orgId')!, ids })
-    if (!result.ok) return apiError(c, result.failure.status, result.failure.error)
+    if (!result.ok) throw failureError(result.failure)
     return c.json(result.result, 200)
   })
   .openapi(getUserRoute, async (c) => {
     const username = c.req.valid('param').username
     if (c.get('userRole') === 'admin') {
       const id = await resolveUserId(c.get('deps'), username)
-      if (!id) return apiError(c, 404, 'User not found')
+      if (!id) throw notFound('User not found')
       const result = await getUser(c.get('deps'), id)
-      if (!result.ok) return apiError(c, result.failure.status, result.failure.error)
+      if (!result.ok) throw failureError(result.failure)
       return c.json(toUserDTO(result.user), 200)
     }
     const user = await getPublicProfile(c.get('deps'), username)
-    if (!user) return apiError(c, 404, 'User not found')
+    if (!user) throw notFound('User not found')
     return c.json({ user, shares: [] }, 200)
   })
   .openapi(userObjectsRoute, async (c) => {
     const user = await getPublicProfile(c.get('deps'), c.req.valid('param').username)
-    if (!user) return apiError(c, 404, 'User not found')
+    if (!user) throw notFound('User not found')
     return c.json({ items: [], breadcrumb: [] }, 200)
   })
   .openapi(setUserStatusRoute, async (c) => {
     const id = await resolveUserId(c.get('deps'), c.req.valid('param').username)
-    if (!id) return apiError(c, 404, 'User not found')
+    if (!id) throw notFound('User not found')
     const { status } = c.req.valid('json')
     const result = await setUserStatus(c.get('deps'), {
       adminUserId: c.get('userId')!,
@@ -338,31 +353,31 @@ export const users = new OpenAPIHono<Env>()
       userId: id,
       status,
     })
-    if (!result.ok) return apiError(c, 404, 'User not found')
+    if (!result.ok) throw notFound('User not found')
     return c.json({ id, status }, 200)
   })
   .openapi(deleteUserRoute, async (c) => {
     const id = await resolveUserId(c.get('deps'), c.req.valid('param').username)
-    if (!id) return apiError(c, 404, 'User not found')
+    if (!id) throw notFound('User not found')
     const result = await deleteUser(c.get('deps'), {
       adminUserId: c.get('userId')!,
       orgId: c.get('orgId')!,
       userId: id,
     })
-    if (!result.ok) return apiError(c, 404, 'User not found')
+    if (!result.ok) throw notFound('User not found')
     return c.json({ id, deleted: true as const }, 200)
   })
   .openapi(listUserEntitlementsRoute, async (c) => {
     const id = await resolveUserId(c.get('deps'), c.req.valid('param').username)
-    if (!id) return apiError(c, 404, 'User not found')
+    if (!id) throw notFound('User not found')
     const result = await listUserEntitlements(c.get('deps'), id)
-    if (!result.ok) return apiError(c, result.failure.status, result.failure.error)
+    if (!result.ok) throw failureError(result.failure)
     const items = result.result.items.map(toQuotaEntitlementDTO)
     return c.json({ items, total: items.length, page: 1, pageSize: items.length }, 200)
   })
   .openapi(grantUserEntitlementRoute, async (c) => {
     const id = await resolveUserId(c.get('deps'), c.req.valid('param').username)
-    if (!id) return apiError(c, 404, 'User not found')
+    if (!id) throw notFound('User not found')
     const body = c.req.valid('json')
     const result = await grantUserEntitlement(c.get('deps'), {
       adminUserId: c.get('userId')!,
@@ -373,12 +388,12 @@ export const users = new OpenAPIHono<Env>()
       expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
       note: body.note,
     })
-    if (!result.ok) return apiError(c, result.failure.status, result.failure.error)
+    if (!result.ok) throw failureError(result.failure)
     return c.json(toEntitlementResultDTO(result.result), 201)
   })
   .openapi(updateUserEntitlementRoute, async (c) => {
     const id = await resolveUserId(c.get('deps'), c.req.valid('param').username)
-    if (!id) return apiError(c, 404, 'User not found')
+    if (!id) throw notFound('User not found')
     const body = c.req.valid('json')
     const result = await updateUserEntitlement(c.get('deps'), {
       adminUserId: c.get('userId')!,
@@ -389,18 +404,18 @@ export const users = new OpenAPIHono<Env>()
       expiresAt: 'expiresAt' in body ? (body.expiresAt ? new Date(body.expiresAt) : null) : undefined,
       note: body.note,
     })
-    if (!result.ok) return apiError(c, result.failure.status, result.failure.error)
+    if (!result.ok) throw failureError(result.failure)
     return c.json(toEntitlementResultDTO(result.result), 200)
   })
   .openapi(revokeUserEntitlementRoute, async (c) => {
     const id = await resolveUserId(c.get('deps'), c.req.valid('param').username)
-    if (!id) return apiError(c, 404, 'User not found')
+    if (!id) throw notFound('User not found')
     const result = await revokeUserEntitlement(c.get('deps'), {
       adminUserId: c.get('userId')!,
       adminOrgId: c.get('orgId')!,
       targetUserId: id,
       entitlementId: c.req.valid('param').eid,
     })
-    if (!result.ok) return apiError(c, result.failure.status, result.failure.error)
+    if (!result.ok) throw failureError(result.failure)
     return c.json(toEntitlementResultDTO(result.result), 200)
   })

--- a/server/http/webdav.ts
+++ b/server/http/webdav.ts
@@ -1,4 +1,3 @@
-import { ErrorReason } from '@shared/schemas'
 import type { Context } from 'hono'
 import { Hono } from 'hono'
 import { ApiKeyTemplate } from '../../shared/api-key-templates'
@@ -21,7 +20,13 @@ import {
 } from '../domain/webdav-xml'
 import { mapDomainError } from '../lib/http-errors'
 import type { Env } from '../middleware/platform'
-import { ApiKeyRateLimitError, type StorageRecord, WebDavPathError, type WebDavTarget } from '../usecases/ports'
+import {
+  ApiKeyRateLimitError,
+  insufficientCredits,
+  type StorageRecord,
+  WebDavPathError,
+  type WebDavTarget,
+} from '../usecases/ports'
 import {
   activeLocks,
   activeLocksForResources,
@@ -48,7 +53,6 @@ import {
   resolveWebDavDownload,
   resolveWebDavPath,
 } from '../usecases/webdav'
-import { apiError } from './openapi'
 
 const READ_METHODS = new Set(['OPTIONS', 'PROPFIND', 'GET', 'HEAD'])
 const WRITE_METHODS = new Set(['PUT', 'DELETE', 'MKCOL', 'MOVE', 'COPY', 'PROPPATCH', 'LOCK', 'UNLOCK'])
@@ -806,10 +810,7 @@ async function reserveWebDavTraffic(
   })
   if (outcome.ok) return null
   if (outcome.reason === 'quota_exceeded') return c.text('Traffic quota exceeded', 422)
-  return apiError(c, 402, 'Insufficient credits', {
-    reason: ErrorReason.INSUFFICIENT_CREDITS,
-    metadata: { resource: 'storage_egress' },
-  })
+  throw insufficientCredits('Insufficient credits', { metadata: { resource: 'storage_egress' } })
 }
 
 async function putFile(c: DavContext, auth: DavAuth): Promise<Response> {

--- a/server/lib/http-errors.test.ts
+++ b/server/lib/http-errors.test.ts
@@ -7,7 +7,7 @@ import {
   StorageQuotaExceededError,
   WebDavPathError,
 } from '../usecases/ports'
-import { ApiError, buildErrorBody, mapDomainError } from './http-errors'
+import { buildErrorBody, mapDomainError } from './http-errors'
 
 describe('buildErrorBody', () => {
   it('defaults reason and canonical status from the HTTP code', () => {
@@ -45,31 +45,6 @@ describe('buildErrorBody', () => {
 
   it('omits metadata when none is given', () => {
     expect(buildErrorBody(403, 'Forbidden').error.details?.[0]?.metadata).toBeUndefined()
-  })
-})
-
-describe('ApiError', () => {
-  it('renders its AIP-193 body and preserves the message', () => {
-    const err = new ApiError(402, 'Insufficient credits', {
-      reason: 'INSUFFICIENT_CREDITS',
-      metadata: { resource: 'storage_egress' },
-    })
-    expect(err.message).toBe('Insufficient credits')
-    expect(err.toBody()).toEqual({
-      error: {
-        code: 402,
-        message: 'Insufficient credits',
-        status: 'FAILED_PRECONDITION',
-        details: [
-          {
-            '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
-            reason: 'INSUFFICIENT_CREDITS',
-            domain: 'zpan.dev',
-            metadata: { resource: 'storage_egress' },
-          },
-        ],
-      },
-    })
   })
 })
 

--- a/server/lib/http-errors.ts
+++ b/server/lib/http-errors.ts
@@ -26,9 +26,8 @@ export interface ErrorOptions {
 }
 
 // The single place that builds an AIP-193 (`google.rpc.Status`) error body. Every
-// error the API surfaces — thrown domain errors mapped in `onError`, and inline
-// handler rejections via `apiError` — flows through here, so the wire shape is
-// defined exactly once.
+// error the API surfaces — `AppError` values and mapped domain errors, all rendered
+// by `jsonError` — flows through here, so the wire shape is defined exactly once.
 export function buildErrorBody(httpStatus: number, message: string, opts: ErrorOptions = {}): ErrorResponse {
   const status = opts.status ?? canonicalStatusForHttp(httpStatus)
   const reason = opts.reason ?? status
@@ -46,24 +45,6 @@ export function buildErrorBody(httpStatus: number, message: string, opts: ErrorO
         },
       ],
     },
-  }
-}
-
-// A throwable carrying everything needed to render an AIP-193 body. Handlers and
-// usecases can `throw new ApiError(...)`; `onError` renders it. Inline handler
-// sites that prefer `return` use the `apiError` helper instead (see http/openapi).
-export class ApiError extends Error {
-  constructor(
-    readonly httpStatus: ContentfulStatusCode,
-    message: string,
-    readonly options: ErrorOptions = {},
-  ) {
-    super(message)
-    this.name = 'ApiError'
-  }
-
-  toBody(): ErrorResponse {
-    return buildErrorBody(this.httpStatus, this.message, this.options)
   }
 }
 

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -1,6 +1,5 @@
 import { createMiddleware } from 'hono/factory'
-import { apiError } from '../http/openapi'
-import { ApiKeyRateLimitError } from '../usecases/ports'
+import { ApiKeyRateLimitError, forbidden, rateLimited, unauthorized } from '../usecases/ports'
 import type { Env } from './platform'
 
 // 'member' is the better-auth schema default; map it to viewer level so
@@ -46,10 +45,10 @@ export const authMiddleware = createMiddleware<Env>(async (c, next) => {
       apiKey = await deps.apiKeys.verifyApiKey(c.get('auth'), platform.db, token)
     } catch (error) {
       if (error instanceof ApiKeyRateLimitError) {
-        const res = apiError(c, 429, error.message)
-        if (error.retryAfterMs !== undefined)
-          res.headers.set('Retry-After', String(Math.ceil(error.retryAfterMs / 1000)))
-        return res
+        throw rateLimited(
+          error.message,
+          error.retryAfterMs === undefined ? undefined : Math.ceil(error.retryAfterMs / 1000),
+        )
       }
       throw error
     }
@@ -78,7 +77,7 @@ export const authMiddleware = createMiddleware<Env>(async (c, next) => {
 
   if (result?.user?.id) {
     if (await c.get('deps').userAdmin.isBanned(result.user.id)) {
-      return apiError(c, 403, 'Account disabled')
+      throw forbidden('Account disabled')
     }
   }
 
@@ -105,14 +104,14 @@ export const authMiddleware = createMiddleware<Env>(async (c, next) => {
 
 export const requireDownloader = createMiddleware<Env>(async (c, next) => {
   const principal = c.get('principal')
-  if (principal?.kind !== 'downloader') return apiError(c, 401, 'Unauthorized')
+  if (principal?.kind !== 'downloader') throw unauthorized('Unauthorized')
   await next()
 })
 
 export const requireAuth = createMiddleware<Env>(async (c, next) => {
   const userId = c.get('userId')
   if (!userId) {
-    return apiError(c, 401, 'Unauthorized')
+    throw unauthorized('Unauthorized')
   }
   await next()
 })
@@ -120,11 +119,11 @@ export const requireAuth = createMiddleware<Env>(async (c, next) => {
 export const requireAdmin = createMiddleware<Env>(async (c, next) => {
   const userId = c.get('userId')
   if (!userId) {
-    return apiError(c, 401, 'Unauthorized')
+    throw unauthorized('Unauthorized')
   }
   const userRole = c.get('userRole')
   if (userRole !== 'admin') {
-    return apiError(c, 403, 'Forbidden')
+    throw forbidden('Forbidden')
   }
   await next()
 })
@@ -137,7 +136,7 @@ export function requireTeamRole(minRole: 'viewer' | 'editor' | 'owner') {
     const orgId = c.get('orgId')
     const userId = c.get('userId')
     if (!orgId || !userId) {
-      return apiError(c, 401, 'Unauthorized')
+      throw unauthorized('Unauthorized')
     }
 
     // Query member role first — avoids an extra DB round trip for the common case.
@@ -147,7 +146,7 @@ export function requireTeamRole(minRole: 'viewer' | 'editor' | 'owner') {
     if (role !== null) {
       const userLevel = ROLE_LEVELS[role] ?? 0
       if (userLevel < ROLE_LEVELS[minRole]) {
-        return apiError(c, 403, 'Forbidden')
+        throw forbidden('Forbidden')
       }
       await next()
       return
@@ -159,6 +158,6 @@ export function requireTeamRole(minRole: 'viewer' | 'editor' | 'owner') {
       return
     }
 
-    return apiError(c, 403, 'Forbidden')
+    throw forbidden('Forbidden')
   })
 }

--- a/server/middleware/authz.ts
+++ b/server/middleware/authz.ts
@@ -1,5 +1,5 @@
 import { createMiddleware } from 'hono/factory'
-import { apiError } from '../http/openapi'
+import { forbidden, unauthorized } from '../usecases/ports'
 import type { Env } from './platform'
 
 const ROLE_LEVELS: Record<string, number> = {
@@ -16,35 +16,35 @@ export function requirePermission(
 ) {
   return createMiddleware<Env>(async (c, next) => {
     const principal = c.get('principal')
-    if (!principal) return apiError(c, 401, 'Unauthorized')
+    if (!principal) throw unauthorized('Unauthorized')
 
     if (principal.kind === 'downloader') {
       if (opts.allowDownloader) return next()
-      return apiError(c, 401, 'Unauthorized')
+      throw unauthorized('Unauthorized')
     }
 
-    if (principal.kind === 'download-task-upload') return apiError(c, 401, 'Unauthorized')
+    if (principal.kind === 'download-task-upload') throw unauthorized('Unauthorized')
 
     if (principal.kind === 'api-key') {
       if (!c.get('deps').apiKeys.hasApiKeyPermission(principal.permissions, resource, action)) {
-        return apiError(c, 403, 'Forbidden')
+        throw forbidden('Forbidden')
       }
       return next()
     }
 
     const userId = c.get('userId')
-    if (!userId) return apiError(c, 401, 'Unauthorized')
+    if (!userId) throw unauthorized('Unauthorized')
     if (!opts.minTeamRole) return next()
 
     const orgId = c.get('orgId')
-    if (!orgId) return apiError(c, 401, 'Unauthorized')
+    if (!orgId) throw unauthorized('Unauthorized')
 
     const role = await c.get('deps').org.getMemberRole(orgId, userId)
     if (role !== null) {
-      if ((ROLE_LEVELS[role] ?? 0) < ROLE_LEVELS[opts.minTeamRole]) return apiError(c, 403, 'Forbidden')
+      if ((ROLE_LEVELS[role] ?? 0) < ROLE_LEVELS[opts.minTeamRole]) throw forbidden('Forbidden')
       return next()
     }
     if (await c.get('deps').org.isPersonalOrg(orgId)) return next()
-    return apiError(c, 403, 'Forbidden')
+    throw forbidden('Forbidden')
   })
 }

--- a/server/middleware/error-handler.test.ts
+++ b/server/middleware/error-handler.test.ts
@@ -1,12 +1,11 @@
 import type { Context } from 'hono'
 import { Hono } from 'hono'
 import { describe, expect, it } from 'vitest'
-import { ApiError } from '../lib/http-errors'
-import { NameConflictError } from '../usecases/ports'
-import { isHandledError, renderError } from './error-handler'
+import { AppError, NameConflictError } from '../usecases/ports'
+import { isHandledError, jsonError } from './error-handler'
 import type { Env } from './platform'
 
-// Build a real Context so renderError's c.json / c.set behave as in production.
+// Build a real Context so jsonError's c.json / c.set behave as in production.
 async function ctx(): Promise<Context<Env>> {
   let captured!: Context<Env>
   const app = new Hono<Env>()
@@ -19,10 +18,10 @@ async function ctx(): Promise<Context<Env>> {
   return captured
 }
 
-describe('renderError', () => {
-  it('renders an ApiError as its AIP-193 body + status and records errorLog', async () => {
+describe('jsonError', () => {
+  it('renders an AppError as its AIP-193 body + status and records errorLog', async () => {
     const c = await ctx()
-    const res = renderError(c, new ApiError(402, 'Insufficient credits', { reason: 'INSUFFICIENT_CREDITS' }))
+    const res = jsonError(c, new AppError(402, 'Insufficient credits', { reason: 'INSUFFICIENT_CREDITS' }))
     expect(res.status).toBe(402)
     expect(await res.json()).toMatchObject({
       error: { status: 'FAILED_PRECONDITION', message: 'Insufficient credits' },
@@ -32,7 +31,7 @@ describe('renderError', () => {
 
   it('renders a mapped domain error with its mapped status + reason', async () => {
     const c = await ctx()
-    const res = renderError(c, new NameConflictError('doc.txt', 'id-1'))
+    const res = jsonError(c, new NameConflictError('doc.txt', 'id-1'))
     expect(res.status).toBe(409)
     expect(c.get('errorLog')?.reason).toBe('NAME_CONFLICT')
   })
@@ -41,7 +40,7 @@ describe('renderError', () => {
     const c = await ctx()
     const err = new Error('top') as Error & { cause?: unknown }
     err.cause = new Error('D1_ERROR: disk full')
-    const res = renderError(c, err)
+    const res = jsonError(c, err)
     expect(res.status).toBe(500)
     expect(((await res.json()) as { error: { message: string } }).error.message).toBe('Internal Server Error')
     const log = c.get('errorLog')
@@ -52,8 +51,8 @@ describe('renderError', () => {
 })
 
 describe('isHandledError', () => {
-  it('is true for ApiError and mapped domain errors, false otherwise', () => {
-    expect(isHandledError(new ApiError(400, 'x'))).toBe(true)
+  it('is true for AppError and mapped domain errors, false otherwise', () => {
+    expect(isHandledError(new AppError(400, 'x'))).toBe(true)
     expect(isHandledError(new NameConflictError('a', 'b'))).toBe(true)
     expect(isHandledError(new Error('boom'))).toBe(false)
     expect(isHandledError(null)).toBe(false)

--- a/server/middleware/error-handler.ts
+++ b/server/middleware/error-handler.ts
@@ -1,22 +1,28 @@
 import type { Context } from 'hono'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import { formatError } from '../lib/errors'
-import { ApiError, buildErrorBody, mapDomainError } from '../lib/http-errors'
+import { buildErrorBody, mapDomainError } from '../lib/http-errors'
+import { AppError } from '../usecases/ports'
 import type { Env } from './platform'
 
-// Turn any thrown error into the AIP-193 response we return to the client, and
-// stash its reason + message on the context for the access log. Shared by the
-// accessLog boundary (which catches /api throws so it can log the real mapped
-// status) and `app.onError` (the backstop for errors thrown outside that
-// boundary, e.g. earlier middleware or non-access-logged routes).
+// Render a business error as its AIP-193 JSON response, and stash reason + message
+// on the context for the access log. THE one place errors become responses: usecases
+// return `AppError` values, handlers `throw result.error`, and the accessLog boundary
+// + `app.onError` pass every thrown error through here.
 //
-// The client never sees an internal stack: an untranslated error becomes a
-// generic 500 body, while the full `cause` chain goes only to `errorLog` →
-// the access log. Domain errors and `ApiError` carry their own safe message.
-export function renderError(c: Context<Env>, err: unknown): Response {
-  if (err instanceof ApiError) {
-    const body = err.toBody()
+// An `AppError` carries its own status/reason/message/headers (built once by the
+// factories in usecases/ports/app-error). Legacy domain errors are still translated
+// by `mapDomainError`. Anything else is an unexpected failure: the client gets a
+// generic 500 while the full `cause` chain goes only to `errorLog` → the access log.
+export function jsonError(c: Context<Env>, err: unknown): Response {
+  if (err instanceof AppError) {
+    const body = buildErrorBody(err.httpStatus, err.message, {
+      reason: err.meta.reason,
+      status: err.meta.canonicalStatus,
+      metadata: err.meta.metadata,
+    })
     c.set('errorLog', { reason: body.error.details?.[0]?.reason ?? body.error.status, message: err.message })
-    return c.json(body, err.httpStatus)
+    return c.json(body, err.httpStatus as ContentfulStatusCode, err.meta.headers)
   }
 
   const mapped = mapDomainError(err)
@@ -33,8 +39,8 @@ export function renderError(c: Context<Env>, err: unknown): Response {
   return c.json(buildErrorBody(500, 'Internal Server Error', { reason: 'INTERNAL' }), 500)
 }
 
-// True when `renderError` would translate `err` into a specific (non-500) result.
+// True when `jsonError` would translate `err` into a specific (non-500) result.
 // Lets `app.onError` log only genuinely unhandled errors as `http.unhandled_error`.
 export function isHandledError(err: unknown): boolean {
-  return err instanceof ApiError || mapDomainError(err) !== null
+  return err instanceof AppError || mapDomainError(err) !== null
 }

--- a/server/middleware/image-hosting-domain.ts
+++ b/server/middleware/image-hosting-domain.ts
@@ -1,9 +1,8 @@
-import { ErrorReason } from '@shared/schemas'
 import type { Context, Next } from 'hono'
-import { apiError } from '../http/openapi'
 import { PRESIGN_TTL_SECS } from '../http/share-utils'
 import { reportTrafficForDownload } from '../http/store/traffic-metering'
 import type { Env } from '../middleware/platform'
+import { forbidden, notFound, quotaExceeded, storageNotFound } from '../usecases/ports'
 
 function stripPort(host: string): string {
   const lastColon = host.lastIndexOf(':')
@@ -43,24 +42,20 @@ function checkReferer(refererAllowlist: string[], refererHeader: string | null):
 
 async function handleImageByPath(c: Context<Env>, orgId: string, virtualPath: string): Promise<Response> {
   const resolved = await c.get('deps').imageHosting.resolveActiveByOrgPath(orgId, virtualPath)
-  if (!resolved) return apiError(c, 404, 'Not found')
+  if (!resolved) throw notFound('Not found')
 
   const { image, refererAllowlist } = resolved
 
   const refererHeader = c.req.header('Referer') ?? null
   if (!checkReferer(refererAllowlist, refererHeader)) {
-    return apiError(c, 403, 'forbidden referer')
+    throw forbidden('forbidden referer')
   }
 
   const storage = await c.get('deps').storages.get(image.storageId)
-  if (!storage) return apiError(c, 404, 'Storage not found')
+  if (!storage) throw storageNotFound('Storage not found')
 
   const trafficAllowed = await c.get('deps').quota.consumeTrafficIfQuotaAllows(image.orgId, image.size)
-  if (!trafficAllowed)
-    return apiError(c, 422, 'Traffic quota exceeded', {
-      reason: ErrorReason.QUOTA_EXCEEDED,
-      status: 'RESOURCE_EXHAUSTED',
-    })
+  if (!trafficAllowed) throw quotaExceeded('Traffic quota exceeded')
 
   let url: string
   try {
@@ -106,7 +101,7 @@ export async function imageHostingDomain(c: Context<Env>, next: Next): Promise<R
   if (!orgId) return next()
 
   const virtualPath = c.req.path.replace(/^\/+/, '')
-  if (!virtualPath) return apiError(c, 404, 'path required')
+  if (!virtualPath) throw notFound('path required')
 
   return handleImageByPath(c, orgId, virtualPath)
 }

--- a/server/middleware/logger.test.ts
+++ b/server/middleware/logger.test.ts
@@ -1,10 +1,8 @@
-import { ErrorReason } from '@shared/schemas'
 import type { Handler } from 'hono'
 import { Hono } from 'hono'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { apiError } from '../http/openapi'
-import { NameConflictError } from '../usecases/ports'
-import { renderError } from './error-handler'
+import { insufficientCredits, NameConflictError, notFound } from '../usecases/ports'
+import { jsonError } from './error-handler'
 import { accessLog } from './logger'
 import type { Env } from './platform'
 
@@ -28,7 +26,7 @@ describe('accessLog', () => {
   afterEach(() => vi.restoreAllMocks())
 
   // Mirror production: accessLog at the boundary, errorLog initialised like
-  // platformMiddleware, and app.onError rendering thrown errors via renderError
+  // platformMiddleware, and app.onError rendering thrown errors via jsonError
   // (Hono routes throws there, not to a middleware catch — see app.ts).
   function appWith(handler: Handler<Env>) {
     const app = new Hono<Env>()
@@ -38,7 +36,7 @@ describe('accessLog', () => {
       await next()
     })
     app.get('/x', handler)
-    app.onError((err, c) => renderError(c, err))
+    app.onError((err, c) => jsonError(c, err))
     return app
   }
 
@@ -51,8 +49,10 @@ describe('accessLog', () => {
     expect(f.reason).toBeUndefined()
   })
 
-  it('logs reason + message for an inline apiError', async () => {
-    const app = appWith((c) => apiError(c, 404, 'Widget not found'))
+  it('logs reason + message for a thrown AppError', async () => {
+    const app = appWith(() => {
+      throw notFound('Widget not found')
+    })
     const res = await app.request('/x')
     expect(res.status).toBe(404)
     const f = parseLine(lines[0])
@@ -62,12 +62,9 @@ describe('accessLog', () => {
   })
 
   it('carries the specific reason + metadata message for a special error', async () => {
-    const app = appWith((c) =>
-      apiError(c, 402, 'Insufficient credits', {
-        reason: ErrorReason.INSUFFICIENT_CREDITS,
-        metadata: { resource: 'storage_egress' },
-      }),
-    )
+    const app = appWith(() => {
+      throw insufficientCredits('Insufficient credits', { metadata: { resource: 'storage_egress' } })
+    })
     await app.request('/x')
     const f = parseLine(lines[0])
     expect(f.reason).toBe('INSUFFICIENT_CREDITS')

--- a/server/middleware/logger.ts
+++ b/server/middleware/logger.ts
@@ -4,12 +4,11 @@ import type { Env } from './platform'
 
 // The request boundary for /api and /dav: one structured line per request, logged
 // after the response is finalized. By the time `next()` returns, the status and
-// `errorLog` are settled regardless of how the response was produced — an inline
-// `apiError(...)` return sets `errorLog` directly, and a thrown error is rendered
-// by `app.onError` (via `renderError`, which also sets `errorLog`) before control
-// returns here. So the log records the REAL mapped status (a thrown 409 logs as
-// 409, not 500) and carries the error's reason + full message for every 4xx/5xx,
-// not just unhandled crashes.
+// `errorLog` are settled — every error is an `AppError` (or domain error) thrown by
+// the handler and rendered by `app.onError` via `jsonError`, which sets `errorLog`
+// before control returns here. So the log records the REAL mapped status (a thrown
+// 409 logs as 409, not 500) and carries the error's reason + full message for every
+// 4xx/5xx, not just unhandled crashes.
 export const accessLog = createMiddleware<Env>(async (c, next) => {
   const start = Date.now()
   await next()
@@ -43,9 +42,9 @@ function accessLogFields(c: Context<Env>, start: number): Array<[string, string 
     )
   }
 
-  // Every failed request carries its reason + full message — set by apiError on
-  // inline returns and by renderError on thrown errors (incl. the full cause
-  // chain for unhandled 500s, which never reaches the client body).
+  // Every failed request carries its reason + full message — set by jsonError when
+  // it renders the thrown error (incl. the full cause chain for unhandled 500s,
+  // which never reaches the client body).
   const errorLog = c.get('errorLog')
   if (errorLog) {
     fields.push(['reason', errorLog.reason], ['error', errorLog.message])

--- a/server/middleware/platform.ts
+++ b/server/middleware/platform.ts
@@ -12,8 +12,8 @@ export type Env = {
     userId: string | null
     userRole: string | null
     orgId: string | null
-    // Structured detail for the access log on a failed request. Set by `apiError`
-    // and `app.onError`; read by the accessLog middleware so every 4xx/5xx carries
+    // Structured detail for the access log on a failed request. Set by `jsonError`
+    // (via `app.onError`); read by the accessLog middleware so every 4xx/5xx carries
     // its reason + full message, not just unhandled crashes.
     errorLog: { reason: string; message: string } | null
   }

--- a/server/middleware/require-feature.ts
+++ b/server/middleware/require-feature.ts
@@ -1,10 +1,9 @@
-import { ErrorReason } from '@shared/schemas'
 import type { ProFeature } from '@shared/types'
 import type { Context } from 'hono'
 import { createMiddleware } from 'hono/factory'
 import { ZPAN_CLOUD_URL_DEFAULT } from '../../shared/constants'
 import { hasFeature } from '../domain/licensing'
-import { apiError } from '../http/openapi'
+import { featureBlocked } from '../usecases/ports'
 import { loadBindingState, normalizeHost } from '../usecases/site/licensing'
 import { getSitePublicOrigin } from '../usecases/site/public-origin'
 import type { Env } from './platform'
@@ -21,8 +20,7 @@ export function requireFeature(name: ProFeature) {
       (await configuredPublicHost(c)) ?? normalizeHost(c.req.header('host')) ?? new URL(c.req.url).host
     const state = await loadBindingState(c.get('deps'), { currentHost, cloudBaseUrl })
     if (!hasFeature(name, state)) {
-      return apiError(c, 402, 'Feature not available', {
-        reason: ErrorReason.FEATURE_NOT_AVAILABLE,
+      throw featureBlocked('Feature not available', {
         metadata: { feature: name, upgradeUrl: '/settings/billing' },
       })
     }

--- a/server/usecases/image-hosting/config.test.ts
+++ b/server/usecases/image-hosting/config.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  AppError,
   CfConflictError,
   type CfHostnameStatus,
   type CfHostnamesProvider,
@@ -128,7 +129,12 @@ describe('image-hosting-config usecase', () => {
         { enabled: true, customDomain: 'zpan.example.com' },
         { isConfigured: true, appHost: 'zpan.example.com' },
       )
-      expect(out).toEqual({ ok: false, reason: 'app_host', status: 400 })
+      expect(out.ok).toBe(false)
+      if (!out.ok) {
+        expect(out.error).toBeInstanceOf(AppError)
+        expect(out.error.httpStatus).toBe(400)
+        expect(out.error.message).toBe('Custom domain cannot be the application default host')
+      }
       expect(getByOrg).not.toHaveBeenCalled()
       expect(create).not.toHaveBeenCalled()
     })
@@ -199,7 +205,12 @@ describe('image-hosting-config usecase', () => {
         },
       })
       const out = await putImageHostingConfig(deps, 'o1', { enabled: true, customDomain: 'taken.com' }, CF_ON)
-      expect(out).toEqual({ ok: false, reason: 'domain_conflict', status: 409 })
+      expect(out.ok).toBe(false)
+      if (!out.ok) {
+        expect(out.error).toBeInstanceOf(AppError)
+        expect(out.error.httpStatus).toBe(409)
+        expect(out.error.message).toBe('Domain already registered by another organization')
+      }
     })
 
     it('propagates a non-conflict CF register error', async () => {
@@ -226,7 +237,12 @@ describe('image-hosting-config usecase', () => {
         },
       })
       const out = await putImageHostingConfig(deps, 'o1', { enabled: true, customDomain: 'dup.com' }, CF_OFF)
-      expect(out).toEqual({ ok: false, reason: 'domain_conflict', status: 409 })
+      expect(out.ok).toBe(false)
+      if (!out.ok) {
+        expect(out.error).toBeInstanceOf(AppError)
+        expect(out.error.httpStatus).toBe(409)
+        expect(out.error.message).toBe('Domain already registered by another organization')
+      }
     })
   })
 
@@ -305,7 +321,12 @@ describe('image-hosting-config usecase', () => {
         },
       })
       const out = await putImageHostingConfig(deps, 'o1', { enabled: true, customDomain: 'claimed.com' }, CF_OFF)
-      expect(out).toEqual({ ok: false, reason: 'domain_conflict', status: 409 })
+      expect(out.ok).toBe(false)
+      if (!out.ok) {
+        expect(out.error).toBeInstanceOf(AppError)
+        expect(out.error.httpStatus).toBe(409)
+        expect(out.error.message).toBe('Domain already registered by another organization')
+      }
     })
 
     it('clears the domain (null) → no CF register, domainVerifiedAt null', async () => {

--- a/server/usecases/image-hosting/config.ts
+++ b/server/usecases/image-hosting/config.ts
@@ -7,14 +7,18 @@
 // resolves the request-scoped CF env, calls these functions, and serializes the
 // ImageHostingConfigRecord into the IhostConfigResponse DTO.
 //
-// Expected business outcomes (no config, app-host-rejected, domain conflict)
-// come back as discriminated unions; the handler maps each to its HTTP status.
-// CF registration errors that are *not* conflicts propagate so the handler 500s.
+// Expected business outcomes (app-host-rejected, domain conflict) come back as a
+// returned AppError the handler throws; a missing config row on read is not an
+// error (handler → { enabled:false }). CF registration errors that are *not*
+// conflicts propagate so the handler 500s.
 
 import type { PutIhostConfigInput } from '@shared/schemas'
 import {
+  type AppError,
+  badRequest,
   CfConflictError,
   type CfHostnamesProvider,
+  conflict,
   type ImageHostingConfigRecord,
   type ImageHostingConfigRepo,
 } from '../ports'
@@ -69,8 +73,10 @@ export async function getImageHostingConfig(
 
 export type PutImageHostingConfigOutcome =
   | { ok: true; config: ImageHostingConfigRecord }
-  | { ok: false; reason: 'app_host'; status: number }
-  | { ok: false; reason: 'domain_conflict'; status: number }
+  | { ok: false; error: AppError }
+
+const appHostError = () => badRequest('Custom domain cannot be the application default host')
+const domainConflictError = () => conflict('Domain already registered by another organization')
 
 // Create or update the config row, threading the CF hostname lifecycle. The
 // returned record mirrors what was persisted (timestamps as Date) so the handler
@@ -83,7 +89,7 @@ export async function putImageHostingConfig(
 ): Promise<PutImageHostingConfigOutcome> {
   // Reject the app's own default host as a custom domain.
   if (body.customDomain && cf.appHost && body.customDomain === cf.appHost) {
-    return { ok: false, reason: 'app_host', status: 400 }
+    return { ok: false, error: appHostError() }
   }
 
   const existing = await deps.imageHostingConfigs.getByOrg(orgId)
@@ -100,7 +106,7 @@ export async function putImageHostingConfig(
         const result = await deps.cfHostnames.register(newDomain)
         cfHostnameId = result.id || null
       } catch (e) {
-        if (e instanceof CfConflictError) return { ok: false, reason: 'domain_conflict', status: 409 }
+        if (e instanceof CfConflictError) return { ok: false, error: domainConflictError() }
         throw e
       }
     }
@@ -109,7 +115,7 @@ export async function putImageHostingConfig(
     try {
       await deps.imageHostingConfigs.create({ orgId, customDomain: newDomain, cfHostnameId, refererAllowlist })
     } catch (e) {
-      if (isUniqueViolation(e)) return { ok: false, reason: 'domain_conflict', status: 409 }
+      if (isUniqueViolation(e)) return { ok: false, error: domainConflictError() }
       throw e
     }
 
@@ -153,7 +159,7 @@ export async function putImageHostingConfig(
         const result = await deps.cfHostnames.register(newDomain)
         cfHostnameId = result.id || null
       } catch (e) {
-        if (e instanceof CfConflictError) return { ok: false, reason: 'domain_conflict', status: 409 }
+        if (e instanceof CfConflictError) return { ok: false, error: domainConflictError() }
         throw e
       }
     }
@@ -174,7 +180,7 @@ export async function putImageHostingConfig(
       refererAllowlist: refererAllowlistValue,
     })
   } catch (e) {
-    if (isUniqueViolation(e)) return { ok: false, reason: 'domain_conflict', status: 409 }
+    if (isUniqueViolation(e)) return { ok: false, error: domainConflictError() }
     throw e
   }
 

--- a/server/usecases/image-hosting/images.test.ts
+++ b/server/usecases/image-hosting/images.test.ts
@@ -11,6 +11,7 @@ import type {
   StorageRepo,
   StorageUsageRepo,
 } from '../ports'
+import { AppError } from '../ports'
 import {
   confirmImageHosting,
   deleteImageHosting,
@@ -130,10 +131,15 @@ describe('image-hosting usecase', () => {
       expect(out).toEqual({ ok: true, config: sampleConfig })
     })
 
-    it('returns not_enabled when no config row exists', async () => {
+    it('returns a forbidden AppError when no config row exists', async () => {
       const deps = makeDeps({ imageHostingConfigs: { getByOrg: async () => null } })
       const out = await requireImageHostingEnabled(deps, 'o1')
-      expect(out).toEqual({ ok: false, reason: 'not_enabled' })
+      expect(out.ok).toBe(false)
+      if (!out.ok) {
+        expect(out.error).toBeInstanceOf(AppError)
+        expect(out.error.httpStatus).toBe(403)
+        expect(out.error.message).toBe('image hosting not enabled for this organization')
+      }
     })
   })
 
@@ -172,7 +178,12 @@ describe('image-hosting usecase', () => {
         mime: 'image/png',
         bytes: new Uint8Array(1),
       })
-      expect(out).toEqual({ ok: false, reason: 'no_storage' })
+      expect(out.ok).toBe(false)
+      if (!out.ok) {
+        expect(out.error).toBeInstanceOf(AppError)
+        expect(out.error.httpStatus).toBe(503)
+        expect(out.error.meta.reason).toBe('NO_STORAGE_CONFIGURED')
+      }
     })
 
     it('rolls back the row and object, then rethrows, when S3 put fails', async () => {
@@ -241,7 +252,12 @@ describe('image-hosting usecase', () => {
         },
       })
       const out = await presignImageHostingUpload(deps, { orgId: 'o1', path: 'a.png', mime: 'image/png', size: 1 })
-      expect(out).toEqual({ ok: false, reason: 'no_storage' })
+      expect(out.ok).toBe(false)
+      if (!out.ok) {
+        expect(out.error).toBeInstanceOf(AppError)
+        expect(out.error.httpStatus).toBe(503)
+        expect(out.error.meta.reason).toBe('NO_STORAGE_CONFIGURED')
+      }
     })
   })
 
@@ -252,35 +268,49 @@ describe('image-hosting usecase', () => {
         imageHosting: { get: async () => makeRow({ status: 'draft', size: 100 }), setActive },
       })
       const out = await confirmImageHosting(deps, 'ih-1', 'o1')
-      expect(out.row?.status).toBe('active')
-      expect(out.quotaExceeded).toBeUndefined()
+      expect(out.ok).toBe(true)
+      if (out.ok) expect(out.row.status).toBe('active')
       expect(setActive).toHaveBeenCalledTimes(1)
     })
 
-    it('returns { row: null } for a missing row', async () => {
+    it('returns a 404 AppError for a missing row', async () => {
       const deps = makeDeps({ imageHosting: { get: async () => null } })
-      expect(await confirmImageHosting(deps, 'x', 'o1')).toEqual({ row: null })
+      const out = await confirmImageHosting(deps, 'x', 'o1')
+      expect(out.ok).toBe(false)
+      if (!out.ok) {
+        expect(out.error).toBeInstanceOf(AppError)
+        expect(out.error.httpStatus).toBe(404)
+        expect(out.error.message).toBe('Not found or not in draft status')
+      }
     })
 
-    it('returns { row: null } for a non-draft (already active) row', async () => {
+    it('returns a 404 AppError for a non-draft (already active) row', async () => {
       const deps = makeDeps({ imageHosting: { get: async () => makeRow({ status: 'active' }) } })
-      expect(await confirmImageHosting(deps, 'ih-1', 'o1')).toEqual({ row: null })
+      const out = await confirmImageHosting(deps, 'ih-1', 'o1')
+      expect(out.ok).toBe(false)
+      if (!out.ok) expect(out.error.httpStatus).toBe(404)
     })
 
-    it('returns { row: null } when setActive loses the race', async () => {
+    it('returns a 404 AppError when setActive loses the race', async () => {
       const deps = makeDeps({
         imageHosting: { get: async () => makeRow({ status: 'draft' }), setActive: async () => false },
       })
-      expect(await confirmImageHosting(deps, 'ih-1', 'o1')).toEqual({ row: null })
+      const out = await confirmImageHosting(deps, 'ih-1', 'o1')
+      expect(out.ok).toBe(false)
+      if (!out.ok) expect(out.error.httpStatus).toBe(404)
     })
 
-    it('returns quotaExceeded when the reservation is denied', async () => {
+    it('returns a 422 quota AppError when the reservation is denied', async () => {
       const deps = makeDeps({
         imageHosting: { get: async () => makeRow({ status: 'draft', size: 100 }) },
         quota: { incrementUsageIfEffectiveQuotaAllows: async () => false },
       })
       const out = await confirmImageHosting(deps, 'ih-1', 'o1')
-      expect(out).toEqual({ row: null, quotaExceeded: true })
+      expect(out.ok).toBe(false)
+      if (!out.ok) {
+        expect(out.error.httpStatus).toBe(422)
+        expect(out.error.meta.reason).toBe('QUOTA_EXCEEDED')
+      }
     })
 
     it('skips quota for a size=0 draft and confirms', async () => {
@@ -290,7 +320,8 @@ describe('image-hosting usecase', () => {
         quota: { incrementUsageIfEffectiveQuotaAllows: inc },
       })
       const out = await confirmImageHosting(deps, 'ih-1', 'o1')
-      expect(out.row?.status).toBe('active')
+      expect(out.ok).toBe(true)
+      if (out.ok) expect(out.row.status).toBe('active')
       expect(inc).not.toHaveBeenCalled()
     })
   })

--- a/server/usecases/image-hosting/images.ts
+++ b/server/usecases/image-hosting/images.ts
@@ -13,12 +13,17 @@
 
 import type { AllowedImageMime } from '@shared/schemas'
 import {
+  type AppError,
+  forbidden,
   type ImageHostingConfigRecord,
   type ImageHostingConfigRepo,
   type ImageHostingRecord,
   type ImageHostingRepo,
   type ListImageHostingsOptions,
+  noStorage,
+  notFound,
   type QuotaRepo,
+  quotaExceeded,
   type S3Gateway,
   StorageQuotaExceededError,
   type StorageRecord,
@@ -44,16 +49,14 @@ const PRESIGN_TTL_SECS = 5 * 60
 // Every ihost route first checks the org has image hosting enabled. The row is
 // returned on success because the upload handler needs it to build the URL.
 
-export type ImageHostingEnabledOutcome =
-  | { ok: true; config: ImageHostingConfigRecord }
-  | { ok: false; reason: 'not_enabled' }
+export type ImageHostingEnabledOutcome = { ok: true; config: ImageHostingConfigRecord } | { ok: false; error: AppError }
 
 export async function requireImageHostingEnabled(
   deps: Pick<ImageHostingDeps, 'imageHostingConfigs'>,
   orgId: string,
 ): Promise<ImageHostingEnabledOutcome> {
   const config = await deps.imageHostingConfigs.getByOrg(orgId)
-  if (!config) return { ok: false, reason: 'not_enabled' }
+  if (!config) return { ok: false, error: forbidden('image hosting not enabled for this organization') }
   return { ok: true, config }
 }
 
@@ -102,9 +105,9 @@ export async function finalizeImageHostingUpload(
 
 // Select the org's private storage and finalize the upload. A missing private
 // storage is an expected outcome (no storage configured → 503), surfaced as a
-// discriminated union; quota overflow still throws StorageQuotaExceededError and
+// returned AppError; quota overflow still throws StorageQuotaExceededError and
 // is mapped by the handler via mapDomainError (→ 422).
-export type UploadImageHostingOutcome = { ok: true; row: ImageHostingRecord } | { ok: false; reason: 'no_storage' }
+export type UploadImageHostingOutcome = { ok: true; row: ImageHostingRecord } | { ok: false; error: AppError }
 
 export async function uploadImageHosting(
   deps: ImageHostingDeps,
@@ -114,7 +117,7 @@ export async function uploadImageHosting(
   try {
     storage = await deps.storages.select('private')
   } catch {
-    return { ok: false, reason: 'no_storage' }
+    return { ok: false, error: noStorage() }
   }
 
   const row = await finalizeImageHostingUpload(deps, {
@@ -141,7 +144,7 @@ export type PresignImageHostingResult = {
 
 export type PresignImageHostingOutcome =
   | { ok: true; result: PresignImageHostingResult }
-  | { ok: false; reason: 'no_storage' }
+  | { ok: false; error: AppError }
 
 export async function presignImageHostingUpload(
   deps: Pick<ImageHostingDeps, 'imageHosting' | 'storages' | 's3'>,
@@ -151,7 +154,7 @@ export async function presignImageHostingUpload(
   try {
     storage = await deps.storages.select('private')
   } catch {
-    return { ok: false, reason: 'no_storage' }
+    return { ok: false, error: noStorage() }
   }
 
   const row = await deps.imageHosting.create({
@@ -173,18 +176,20 @@ export async function presignImageHostingUpload(
 
 // ── Confirm (browser two-stage) ──────────────────────────────────────────────
 
-export type ConfirmImageHostingResult = { row: ImageHostingRecord | null; quotaExceeded?: boolean }
+export type ConfirmImageHostingOutcome = { ok: true; row: ImageHostingRecord } | { ok: false; error: AppError }
 
 // Browser two-stage flow: confirm a draft after the client uploaded to the
 // presigned URL. Reserves quota then flips the row active; a lost race or a
-// missing/non-draft row yields { row: null }.
+// missing/non-draft row is a 404, a quota overflow a 422.
 export async function confirmImageHosting(
   deps: ImageHostingDeps,
   id: string,
   orgId: string,
-): Promise<ConfirmImageHostingResult> {
+): Promise<ConfirmImageHostingOutcome> {
   const existing = await deps.imageHosting.get(id, orgId)
-  if (!existing || existing.status !== 'draft') return { row: null }
+  if (!existing || existing.status !== 'draft') {
+    return { ok: false, error: notFound('Not found or not in draft status') }
+  }
 
   try {
     return await withStorageUsageReservation(
@@ -192,12 +197,12 @@ export async function confirmImageHosting(
       { orgId, storageId: existing.storageId, bytes: existing.size },
       async () => {
         const flipped = await deps.imageHosting.setActive(id, orgId)
-        if (!flipped) return { row: null }
-        return { row: { ...existing, status: 'active' as const } }
+        if (!flipped) return { ok: false, error: notFound('Not found or not in draft status') }
+        return { ok: true, row: { ...existing, status: 'active' as const } }
       },
     )
   } catch (error) {
-    if (error instanceof StorageQuotaExceededError) return { row: null, quotaExceeded: true }
+    if (error instanceof StorageQuotaExceededError) return { ok: false, error: quotaExceeded() }
     throw error
   }
 }

--- a/server/usecases/object.integration.test.ts
+++ b/server/usecases/object.integration.test.ts
@@ -696,7 +696,7 @@ describe('POST /api/shares/:token/objects', () => {
     expect(res.status).toBe(403)
   })
 
-  it('returns 400 QUOTA_EXCEEDED when target org has insufficient quota', async () => {
+  it('returns 422 QUOTA_EXCEEDED when target org has insufficient quota', async () => {
     const { app, db, share, headers } = await setup()
     await seedProLicense(db)
 
@@ -749,7 +749,7 @@ describe('POST /api/shares/:token/objects', () => {
       body: JSON.stringify({ targetOrgId: quotaOrgId }),
     })
 
-    expect(res.status).toBe(400)
+    expect(res.status).toBe(422)
     const body = (await res.json()) as { error: { message: string; status: string; details: { reason: string }[] } }
     expect(body.error.message).toBe('Quota exceeded')
     expect(body.error.status).toBe('RESOURCE_EXHAUSTED')

--- a/server/usecases/object.test.ts
+++ b/server/usecases/object.test.ts
@@ -18,26 +18,27 @@ import {
   trashObject,
   updateObject,
 } from './object'
-import type {
-  ActivityRepo,
-  CloudTrafficReportRepo,
-  ConflictPlan,
-  DownloaderRepo,
-  DownloadTaskRecord,
-  DownloadTaskRepo,
-  LicenseBindingRepo,
-  LicensingCloudGateway,
-  Matter,
-  MatterRepo,
-  ObjectUploadSessionRecord,
-  ObjectUploadSessionRepo,
-  OrgRepo,
-  QuotaRepo,
-  S3Gateway,
-  ShareRepo,
-  StorageRecord,
-  StorageRepo,
-  StorageUsageRepo,
+import {
+  type ActivityRepo,
+  AppError,
+  type CloudTrafficReportRepo,
+  type ConflictPlan,
+  type DownloaderRepo,
+  type DownloadTaskRecord,
+  type DownloadTaskRepo,
+  type LicenseBindingRepo,
+  type LicensingCloudGateway,
+  type Matter,
+  type MatterRepo,
+  type ObjectUploadSessionRecord,
+  type ObjectUploadSessionRepo,
+  type OrgRepo,
+  type QuotaRepo,
+  type S3Gateway,
+  type ShareRepo,
+  type StorageRecord,
+  type StorageRepo,
+  type StorageUsageRepo,
 } from './ports'
 import { meterDownloadTraffic } from './store/traffic-metering'
 
@@ -193,6 +194,14 @@ function makeDeps(
 
 beforeEach(() => vi.clearAllMocks())
 
+function expectError(out: unknown, httpStatus: number, message: string, reason?: string) {
+  const e = (out as { ok: false; error: AppError }).error
+  expect(e).toBeInstanceOf(AppError)
+  expect(e.httpStatus).toBe(httpStatus)
+  expect(e.message).toBe(message)
+  if (reason) expect(e.meta.reason).toBe(reason)
+}
+
 describe('object usecase', () => {
   describe('listObjects', () => {
     it('lists the active org without an override', async () => {
@@ -231,7 +240,7 @@ describe('object usecase', () => {
         orgOverride: 'o2',
         filters: { parent: '', status: 'active', page: 1, pageSize: 20 },
       })
-      expect(out).toEqual({ ok: false, reason: 'forbidden' })
+      expectError(out, 403, 'Forbidden')
       expect(list).not.toHaveBeenCalled()
     })
   })
@@ -306,7 +315,7 @@ describe('object usecase', () => {
         actor: user,
         input: { name: 'x.txt', type: 'text/plain', dirtype: DirType.FILE, parent: '' },
       })
-      expect(out).toEqual({ ok: false, reason: 'no_storage' })
+      expectError(out, 503, 'No storage configured', 'NO_STORAGE_CONFIGURED')
     })
 
     it('rejects an agent upload outside its target folder', async () => {
@@ -323,7 +332,7 @@ describe('object usecase', () => {
         },
         input: { name: 'x.txt', type: 'text/plain', dirtype: DirType.FILE, parent: 'Other' },
       })
-      expect(out).toEqual({ ok: false, reason: 'target_outside_authorization' })
+      expectError(out, 403, 'Target folder is outside task authorization')
       expect(create).not.toHaveBeenCalled()
     })
 
@@ -409,13 +418,13 @@ describe('object usecase', () => {
     it('returns not_found for a missing object', async () => {
       const { deps } = makeDeps({ matter: { get: async () => null } })
       const out = await getObject(deps, { orgId: 'o1', objectId: 'x', cloudBaseUrl: 'https://cloud' })
-      expect(out).toEqual({ ok: false, reason: 'not_found' })
+      expectError(out, 404, 'Not found')
     })
 
     it('returns storage_not_found when a file has no storage row', async () => {
       const { deps } = makeDeps({ matter: { get: async () => file('m1') }, storages: { get: async () => null } })
       const out = await getObject(deps, { orgId: 'o1', objectId: 'm1', cloudBaseUrl: 'https://cloud' })
-      expect(out).toEqual({ ok: false, reason: 'storage_not_found' })
+      expectError(out, 404, 'Storage not found')
     })
 
     it('meters egress then presigns the download URL for a file', async () => {
@@ -441,7 +450,7 @@ describe('object usecase', () => {
       const presignDownload = vi.fn()
       const { deps } = makeDeps({ matter: { get: async () => file('m1') }, s3: { presignDownload } })
       const out = await getObject(deps, { orgId: 'o1', objectId: 'm1', cloudBaseUrl: 'https://cloud' })
-      expect(out).toEqual({ ok: false, reason: 'quota_exceeded' })
+      expectError(out, 422, 'Traffic quota exceeded', 'QUOTA_EXCEEDED')
       expect(presignDownload).not.toHaveBeenCalled()
     })
 
@@ -449,7 +458,8 @@ describe('object usecase', () => {
       vi.mocked(meterDownloadTraffic).mockResolvedValue({ ok: false, reason: 'insufficient_credits' })
       const { deps } = makeDeps({ matter: { get: async () => file('m1') } })
       const out = await getObject(deps, { orgId: 'o1', objectId: 'm1', cloudBaseUrl: 'https://cloud' })
-      expect(out).toEqual({ ok: false, reason: 'insufficient_credits' })
+      expectError(out, 402, 'Insufficient credits', 'INSUFFICIENT_CREDITS')
+      expect((out as { ok: false; error: AppError }).error.meta.metadata).toEqual({ resource: 'storage_egress' })
     })
 
     it('refunds the traffic and rethrows when presign fails after metering', async () => {
@@ -498,7 +508,7 @@ describe('object usecase', () => {
         actorId: 'u1',
         input: { name: 'X' },
       })
-      expect(out).toEqual({ ok: false, reason: 'not_found' })
+      expectError(out, 404, 'Not found')
     })
   })
 
@@ -530,7 +540,7 @@ describe('object usecase', () => {
         quota: { incrementUsageIfEffectiveQuotaAllows: async () => false },
       })
       const out = await confirmObject(deps, { orgId: 'o1', objectId: 'd1', actorId: 'u1' })
-      expect(out).toEqual({ ok: false, reason: 'quota_exceeded' })
+      expectError(out, 422, 'Quota exceeded', 'QUOTA_EXCEEDED')
     })
 
     it('propagates a name conflict thrown during confirm', async () => {
@@ -593,10 +603,7 @@ describe('object usecase', () => {
 
     it('trash returns not_found when missing', async () => {
       const { deps } = makeDeps({ matter: { trash: async () => null } })
-      expect(await trashObject(deps, { orgId: 'o1', objectId: 'x', actorId: 'u1' })).toEqual({
-        ok: false,
-        reason: 'not_found',
-      })
+      expectError(await trashObject(deps, { orgId: 'o1', objectId: 'x', actorId: 'u1' }), 404, 'Not found')
     })
 
     it('restores with the default fail strategy', async () => {
@@ -616,10 +623,7 @@ describe('object usecase', () => {
 
     it('restore returns not_found when missing', async () => {
       const { deps } = makeDeps({ matter: { restore: async () => null } })
-      expect(await restoreObject(deps, { orgId: 'o1', objectId: 'x', actorId: 'u1' })).toEqual({
-        ok: false,
-        reason: 'not_found',
-      })
+      expectError(await restoreObject(deps, { orgId: 'o1', objectId: 'x', actorId: 'u1' }), 404, 'Not found')
     })
   })
 
@@ -681,17 +685,18 @@ describe('object usecase', () => {
 
     it('returns not_found for a missing source', async () => {
       const { deps } = makeDeps({ matter: { get: async () => null } })
-      expect(await copyObject(deps, { orgId: 'o1', userId: 'u1', input: { copyFrom: 'x', parent: '' } })).toEqual({
-        ok: false,
-        reason: 'not_found',
-      })
+      expectError(
+        await copyObject(deps, { orgId: 'o1', userId: 'u1', input: { copyFrom: 'x', parent: '' } }),
+        404,
+        'Not found',
+      )
     })
 
     it('returns storage_not_found for an object-backed source with no storage', async () => {
       const source = file('src', { object: 'key/src' })
       const { deps } = makeDeps({ matter: { get: async () => source }, storages: { get: async () => null } })
       const out = await copyObject(deps, { orgId: 'o1', userId: 'u1', input: { copyFrom: 'src', parent: '' } })
-      expect(out).toEqual({ ok: false, reason: 'storage_not_found' })
+      expectError(out, 404, 'Storage not found')
     })
 
     it('rolls back the S3 copy when the matter copy fails', async () => {
@@ -726,7 +731,7 @@ describe('object usecase', () => {
         objectId: 'm1',
         input: { targetOrgId: 'o1', targetParent: '', mode: 'copy' },
       })
-      expect(out).toEqual({ ok: false, reason: 'same_org' })
+      expectError(out, 400, 'Target must be a different space', 'SAME_ORG')
     })
 
     it('returns not_found for a missing/inactive source', async () => {
@@ -737,7 +742,7 @@ describe('object usecase', () => {
         objectId: 'm1',
         input: { targetOrgId: 'o2', targetParent: '', mode: 'copy' },
       })
-      expect(out).toEqual({ ok: false, reason: 'not_found' })
+      expectError(out, 404, 'Not found')
     })
 
     it('forbids a move without editor access on the source space', async () => {
@@ -751,7 +756,7 @@ describe('object usecase', () => {
         objectId: 'm1',
         input: { targetOrgId: 'o2', targetParent: '', mode: 'move' },
       })
-      expect(out).toEqual({ ok: false, reason: 'forbidden' })
+      expectError(out, 403, 'Forbidden')
     })
 
     it('forbids a transfer into a target the user cannot write', async () => {
@@ -765,7 +770,7 @@ describe('object usecase', () => {
         objectId: 'm1',
         input: { targetOrgId: 'o2', targetParent: '', mode: 'copy' },
       })
-      expect(out).toEqual({ ok: false, reason: 'forbidden' })
+      expectError(out, 403, 'Forbidden')
     })
 
     it('rejects a transfer that exceeds the target quota', async () => {
@@ -779,7 +784,7 @@ describe('object usecase', () => {
         objectId: 'm1',
         input: { targetOrgId: 'o2', targetParent: '', mode: 'copy' },
       })
-      expect(out).toEqual({ ok: false, reason: 'quota_exceeded' })
+      expectError(out, 422, 'Quota exceeded', 'QUOTA_EXCEEDED')
     })
 
     it('copies into the target without deleting the source', async () => {
@@ -840,10 +845,7 @@ describe('object usecase', () => {
 
     it('forbids confirming an object outside the target folder', async () => {
       const { deps } = makeDeps({ matter: { get: async () => file('m1', { parent: 'Other' }) } })
-      expect(await authorizeTaskUploadConfirm(deps, taskParams)).toEqual({
-        ok: false,
-        reason: 'forbidden',
-      })
+      expectError(await authorizeTaskUploadConfirm(deps, taskParams), 403, 'Forbidden')
     })
 
     it('authorizes a confirm within the target folder for a live task', async () => {

--- a/server/usecases/object.ts
+++ b/server/usecases/object.ts
@@ -26,18 +26,26 @@ import type { Deps } from './deps'
 import { assertTaskUploadAllowed } from './downloads/downloads'
 import {
   type ActivityRepo,
+  type AppError,
+  badRequest,
+  forbidden,
+  insufficientCredits,
   type Matter,
   type MatterListFilters,
   type MatterRepo,
+  noStorage,
+  notFound,
   ObjectUploadSessionError,
   type ObjectUploadSessionRecord,
   type ObjectUploadSessionRepo,
   type QuotaRepo,
+  quotaExceeded,
   type S3Gateway,
   type ShareRepo,
   type StorageRecord,
   type StorageRepo,
   type StorageUsageRepo,
+  storageNotFound,
 } from './ports'
 import { StorageQuotaExceededError, withStorageUsageReservation } from './storage-usage'
 import { meterDownloadTraffic } from './store/traffic-metering'
@@ -109,7 +117,7 @@ function isWithinDownloadTarget(parent: string, targetFolder: string): boolean {
 
 export type ListObjectsOutcome =
   | { ok: true; result: Awaited<ReturnType<Deps['matter']['list']>> }
-  | { ok: false; reason: 'forbidden' }
+  | { ok: false; error: AppError }
 
 export async function listObjects(
   deps: Pick<Deps, 'matter' | 'org'>,
@@ -125,7 +133,7 @@ export async function listObjects(
   // folders of another space the user has access to.
   if (params.orgOverride && params.orgOverride !== orgId) {
     if (!(await deps.org.canReadOrg(params.userId, params.orgOverride))) {
-      return { ok: false, reason: 'forbidden' }
+      return { ok: false, error: forbidden() }
     }
     orgId = params.orgOverride
   }
@@ -138,8 +146,7 @@ export async function listObjects(
 export type CreateObjectOutcome =
   | { ok: true; matter: Matter }
   | { ok: true; matter: Matter; uploadUrl: string; contentDisposition: string }
-  | { ok: false; reason: 'target_outside_authorization' }
-  | { ok: false; reason: 'no_storage' }
+  | { ok: false; error: AppError }
 
 export async function createObject(
   deps: Pick<Deps, 'matter' | 'storages' | 's3' | 'downloaders' | 'downloadTasks'>,
@@ -151,7 +158,7 @@ export async function createObject(
 
   if (actor.kind === 'download-task-upload') {
     if (!isWithinDownloadTarget(parent, actor.targetFolder)) {
-      return { ok: false, reason: 'target_outside_authorization' }
+      return { ok: false, error: forbidden('Target folder is outside task authorization') }
     }
     await assertTaskUploadAllowed(deps as Deps, { taskId: actor.taskId, downloaderId: actor.downloaderId })
   }
@@ -161,7 +168,7 @@ export async function createObject(
     storage = await deps.storages.select('private')
   } catch (error) {
     if (error instanceof Error && error.message === 'No available storage') {
-      return { ok: false, reason: 'no_storage' }
+      return { ok: false, error: noStorage() }
     }
     throw error
   }
@@ -281,10 +288,7 @@ export async function patchUploadSession(
 export type GetObjectOutcome =
   | { ok: true; matter: Matter }
   | { ok: true; matter: Matter; downloadUrl: string }
-  | { ok: false; reason: 'not_found' }
-  | { ok: false; reason: 'storage_not_found' }
-  | { ok: false; reason: 'quota_exceeded' }
-  | { ok: false; reason: 'insufficient_credits' }
+  | { ok: false; error: AppError }
 
 // Loads an object; for files it meters egress (consume traffic quota → report to
 // Cloud, refunding on a block) before presigning the download URL, refunding the
@@ -298,11 +302,11 @@ export async function getObject(
   params: { orgId: string; objectId: string; cloudBaseUrl: string },
 ): Promise<GetObjectOutcome> {
   const matter = await deps.matter.get(params.objectId, params.orgId)
-  if (!matter) return { ok: false, reason: 'not_found' }
+  if (!matter) return { ok: false, error: notFound() }
   if (matter.dirtype !== DirType.FILE || !matter.object) return { ok: true, matter }
 
   const storage = await deps.storages.get(matter.storageId)
-  if (!storage) return { ok: false, reason: 'storage_not_found' }
+  if (!storage) return { ok: false, error: storageNotFound() }
 
   const bytes = matter.size ?? 0
   const metered = await meterDownloadTraffic(deps, {
@@ -313,7 +317,14 @@ export async function getObject(
     source: 'object_download',
     sourceId: matter.id,
   })
-  if (!metered.ok) return { ok: false, reason: metered.reason }
+  if (!metered.ok)
+    return {
+      ok: false,
+      error:
+        metered.reason === 'quota_exceeded'
+          ? quotaExceeded('Traffic quota exceeded')
+          : insufficientCredits('Insufficient credits', { metadata: { resource: 'storage_egress' } }),
+    }
 
   let downloadUrl: string
   try {
@@ -327,7 +338,7 @@ export async function getObject(
 
 // ─── Update / confirm / cancel / trash / restore ──────────────────────────────
 
-export type UpdateObjectOutcome = { ok: true; matter: Matter } | { ok: false; reason: 'not_found' }
+export type UpdateObjectOutcome = { ok: true; matter: Matter } | { ok: false; error: AppError }
 
 export async function updateObject(
   deps: Pick<Deps, 'matter'>,
@@ -335,24 +346,27 @@ export async function updateObject(
 ): Promise<UpdateObjectOutcome> {
   const { name, parent, onConflict } = params.input
   const matter = await deps.matter.update(params.objectId, params.orgId, { name, parent, onConflict }, params.actorId)
-  return matter ? { ok: true, matter } : { ok: false, reason: 'not_found' }
+  return matter ? { ok: true, matter } : { ok: false, error: notFound() }
 }
 
+// `not_found` stays a control-flow reason: the handler falls through to
+// `restoreObject` on it (status:'active' confirms a draft, otherwise restores
+// from trash). Quota exhaustion is a terminal error the handler throws.
 export type ConfirmObjectOutcome =
   | { ok: true; matter: Matter }
   | { ok: false; reason: 'not_found' }
-  | { ok: false; reason: 'quota_exceeded' }
+  | { ok: false; error: AppError }
 
 export async function confirmObject(
   deps: Pick<Deps, 'matter' | 'quota' | 'storageUsage' | 'activity' | 's3' | 'storages' | 'share'>,
   params: { orgId: string; objectId: string; actorId: string; onConflict?: ConflictStrategy },
 ): Promise<ConfirmObjectOutcome> {
-  const { matter, quotaExceeded } = await confirmUpload(deps, params.objectId, params.orgId, {
+  const { matter, quotaExceeded: exceeded } = await confirmUpload(deps, params.objectId, params.orgId, {
     onConflict: params.onConflict,
     userId: params.actorId,
     purgeReplaced: (incumbent) => purgeRecursively(deps, params.orgId, [incumbent]).then(() => undefined),
   })
-  if (quotaExceeded) return { ok: false, reason: 'quota_exceeded' }
+  if (exceeded) return { ok: false, error: quotaExceeded() }
   if (!matter) return { ok: false, reason: 'not_found' }
   return { ok: true, matter }
 }
@@ -378,29 +392,29 @@ export async function cancelObject(
   return { ok: true, id: matter.id }
 }
 
-export type TrashObjectOutcome = { ok: true; matter: Matter } | { ok: false; reason: 'not_found' }
+export type TrashObjectOutcome = { ok: true; matter: Matter } | { ok: false; error: AppError }
 
 export async function trashObject(
   deps: Pick<Deps, 'matter'>,
   params: { orgId: string; objectId: string; actorId: string },
 ): Promise<TrashObjectOutcome> {
   const matter = await deps.matter.trash(params.orgId, params.objectId, params.actorId)
-  return matter ? { ok: true, matter } : { ok: false, reason: 'not_found' }
+  return matter ? { ok: true, matter } : { ok: false, error: notFound() }
 }
 
-export type RestoreObjectOutcome = { ok: true; matter: Matter } | { ok: false; reason: 'not_found' }
+export type RestoreObjectOutcome = { ok: true; matter: Matter } | { ok: false; error: AppError }
 
 export async function restoreObject(
   deps: Pick<Deps, 'matter'>,
   params: { orgId: string; objectId: string; actorId: string; onConflict?: ConflictStrategy },
 ): Promise<RestoreObjectOutcome> {
   const matter = await deps.matter.restore(params.orgId, params.objectId, params.actorId, params.onConflict ?? 'fail')
-  return matter ? { ok: true, matter } : { ok: false, reason: 'not_found' }
+  return matter ? { ok: true, matter } : { ok: false, error: notFound() }
 }
 
 // Authorizes a download-task-upload token to confirm a specific object: it may
 // only confirm its draft (PUT /status {active}) and only within its target folder.
-export type ConfirmAuthorizationOutcome = { ok: true } | { ok: false; reason: 'forbidden' }
+export type ConfirmAuthorizationOutcome = { ok: true } | { ok: false; error: AppError }
 
 export async function authorizeTaskUploadConfirm(
   deps: Pick<Deps, 'matter' | 'downloaders' | 'downloadTasks'>,
@@ -414,7 +428,7 @@ export async function authorizeTaskUploadConfirm(
 ): Promise<ConfirmAuthorizationOutcome> {
   const matter = await deps.matter.get(params.objectId, params.orgId)
   if (!matter || !isWithinDownloadTarget(matter.parent, params.targetFolder)) {
-    return { ok: false, reason: 'forbidden' }
+    return { ok: false, error: forbidden() }
   }
   await assertTaskUploadAllowed(deps as Deps, { taskId: params.taskId, downloaderId: params.downloaderId })
   return { ok: true }
@@ -449,7 +463,7 @@ export async function deleteObject(
 
 // ─── Copy (same org, quota-reserved) ──────────────────────────────────────────
 
-export type CopyObjectOutcome = { ok: true; matter: Matter } | { ok: false; reason: 'not_found' | 'storage_not_found' }
+export type CopyObjectOutcome = { ok: true; matter: Matter } | { ok: false; error: AppError }
 
 export async function copyObject(
   deps: Pick<Deps, 'matter' | 'storages' | 's3' | 'quota' | 'storageUsage'>,
@@ -458,11 +472,11 @@ export async function copyObject(
   const { orgId, userId, input } = params
   const { copyFrom, parent, onConflict } = input
   const source = await deps.matter.get(copyFrom, orgId)
-  if (!source) return { ok: false, reason: 'not_found' }
+  if (!source) return { ok: false, error: notFound() }
 
   const sourceSize = source.size ?? 0
   const storage = source.object ? await deps.storages.get(source.storageId) : null
-  if (source.object && !storage) return { ok: false, reason: 'storage_not_found' }
+  if (source.object && !storage) return { ok: false, error: storageNotFound() }
 
   const copy = await withStorageUsageReservation(
     deps,
@@ -487,12 +501,7 @@ export async function copyObject(
 
 export type TransferObjectResult = Awaited<ReturnType<typeof copyMatterToOrg>> & { sourceDeleted: boolean }
 
-export type TransferObjectOutcome =
-  | { ok: true; result: TransferObjectResult }
-  | { ok: false; reason: 'same_org' }
-  | { ok: false; reason: 'not_found' }
-  | { ok: false; reason: 'forbidden' }
-  | { ok: false; reason: 'quota_exceeded' }
+export type TransferObjectOutcome = { ok: true; result: TransferObjectResult } | { ok: false; error: AppError }
 
 export async function transferObject(
   deps: Pick<Deps, 'matter' | 'storages' | 's3' | 'quota' | 'storageUsage' | 'share' | 'org' | 'activity'>,
@@ -500,23 +509,23 @@ export async function transferObject(
 ): Promise<TransferObjectOutcome> {
   const { orgId, userId, objectId, input } = params
   const { targetOrgId, targetParent, mode } = input
-  if (targetOrgId === orgId) return { ok: false, reason: 'same_org' }
+  if (targetOrgId === orgId) return { ok: false, error: badRequest('Target must be a different space', 'SAME_ORG') }
 
   const source = await deps.matter.get(objectId, orgId)
-  if (!source || source.status !== 'active') return { ok: false, reason: 'not_found' }
+  if (!source || source.status !== 'active') return { ok: false, error: notFound() }
 
   // Copying out only needs read access on the source space (granted by the route
   // middleware); moving also trashes the source, which needs editor.
   if (mode === 'move' && !(await hasEditorAccess(deps, { orgId, userId }))) {
-    return { ok: false, reason: 'forbidden' }
+    return { ok: false, error: forbidden() }
   }
   if (!(await deps.org.canWriteToOrg(userId, targetOrgId))) {
-    return { ok: false, reason: 'forbidden' }
+    return { ok: false, error: forbidden() }
   }
 
   const totalBytes = await deps.share.computeSourceBytes(source)
   if (!(await deps.share.hasQuotaForBytes(targetOrgId, totalBytes))) {
-    return { ok: false, reason: 'quota_exceeded' }
+    return { ok: false, error: quotaExceeded() }
   }
 
   const result = await copyMatterToOrg(deps, {

--- a/server/usecases/ports.ts
+++ b/server/usecases/ports.ts
@@ -6,6 +6,7 @@
 export * from './ports/activity'
 export * from './ports/announcement'
 export * from './ports/api-keys'
+export * from './ports/app-error'
 export * from './ports/archive-jobs'
 export * from './ports/archive-target-folder'
 export * from './ports/background-job'

--- a/server/usecases/ports/app-error.ts
+++ b/server/usecases/ports/app-error.ts
@@ -1,0 +1,63 @@
+import { type CanonicalStatus, ErrorReason } from '@shared/schemas'
+
+// A returned (or thrown) business error carrying everything the HTTP boundary
+// needs to render an AIP-193 body — without the usecase layer ever naming an
+// HTTP status. Usecases produce these via the factories below (`notFound()`,
+// `quotaExceeded()`, …); the status, wire reason and canonical code live in ONE
+// place (the factory), so no handler hand-writes `apiError(c, 404, …)` and no
+// reason string drifts. The HTTP boundary renders any AppError uniformly via
+// `jsonError(c, result.error)`.
+export class AppError extends Error {
+  constructor(
+    readonly httpStatus: number,
+    message: string,
+    readonly meta: {
+      reason?: string
+      canonicalStatus?: CanonicalStatus
+      metadata?: Record<string, string>
+      // Response headers the boundary must set (e.g. `Retry-After` on a 429).
+      headers?: Record<string, string>
+    } = {},
+  ) {
+    super(message)
+    this.name = 'AppError'
+  }
+}
+
+type ExtraMeta = { metadata?: Record<string, string> }
+
+// Shared, cross-resource business errors. Each bakes in its HTTP status + AIP-193
+// reason once. Pass a resource-specific message (e.g. `notFound('Order not found')`)
+// and, where relevant, `metadata`.
+export const notFound = (message = 'Not found') => new AppError(404, message)
+export const storageNotFound = (message = 'Storage not found') => new AppError(404, message)
+export const forbidden = (message = 'Forbidden') => new AppError(403, message)
+export const unauthorized = (message = 'Unauthorized') => new AppError(401, message)
+export const passwordRequired = (message = 'Password required') => new AppError(401, message)
+export const expired = (message = 'Expired') => new AppError(410, message)
+export const conflict = (message: string, reason?: string) => new AppError(409, message, { reason })
+export const badRequest = (message: string, reason?: string) => new AppError(400, message, { reason })
+export const badGateway = (message: string, reason?: string) => new AppError(502, message, { reason })
+
+export const payloadTooLarge = (message = 'Payload too large') =>
+  new AppError(413, message, { reason: ErrorReason.PAYLOAD_TOO_LARGE })
+
+export const rateLimited = (message: string, retryAfterSeconds?: number) =>
+  new AppError(429, message, {
+    headers: retryAfterSeconds === undefined ? undefined : { 'Retry-After': String(retryAfterSeconds) },
+  })
+
+export const unsupportedMediaType = (message = 'Unsupported media type') =>
+  new AppError(415, message, { reason: ErrorReason.UNSUPPORTED_MEDIA_TYPE })
+
+export const noStorage = (message = 'No storage configured') =>
+  new AppError(503, message, { reason: ErrorReason.NO_STORAGE_CONFIGURED })
+
+export const quotaExceeded = (message = 'Quota exceeded') =>
+  new AppError(422, message, { reason: ErrorReason.QUOTA_EXCEEDED, canonicalStatus: 'RESOURCE_EXHAUSTED' })
+
+export const insufficientCredits = (message = 'Insufficient credits', opts: ExtraMeta = {}) =>
+  new AppError(402, message, { reason: ErrorReason.INSUFFICIENT_CREDITS, metadata: opts.metadata })
+
+export const featureBlocked = (message = 'Feature not available', opts: ExtraMeta = {}) =>
+  new AppError(402, message, { reason: ErrorReason.FEATURE_NOT_AVAILABLE, metadata: opts.metadata })

--- a/server/usecases/redirect.test.ts
+++ b/server/usecases/redirect.test.ts
@@ -11,8 +11,25 @@ import type {
   StorageRecord,
   StorageRepo,
 } from './ports'
+import { AppError } from './ports'
 import { type RedirectDeps, resolveDirectShareDownload, resolveImageHostingDownload } from './redirect'
 import { type DownloadTrafficOutcome, meterDownloadTraffic, reportDownloadEgress } from './store/traffic-metering'
+
+// Asserts a usecase returned a failure AppError with the given HTTP status,
+// wire reason, and message — the AIP-193 fields the http boundary renders.
+function expectError(
+  out: { ok: true } | { ok: false; error: AppError },
+  httpStatus: number,
+  reason: string | undefined,
+  message: string,
+) {
+  expect(out.ok).toBe(false)
+  const { error } = out as { ok: false; error: AppError }
+  expect(error).toBeInstanceOf(AppError)
+  expect(error.httpStatus).toBe(httpStatus)
+  expect(error.meta.reason).toBe(reason)
+  expect(error.message).toBe(message)
+}
 
 // The end-to-end metering (quota consume → cloud egress report → refund) is
 // covered by cloud-traffic-metering.test.ts. Here we replace its two entry
@@ -163,19 +180,19 @@ describe('resolveDirectShareDownload', () => {
   it('returns matter_trashed when the share resolves to a trashed matter', async () => {
     const { deps } = makeDeps({ share: { resolveByToken: async () => ({ status: 'matter_trashed' }) } })
     const out = await resolveDirectShareDownload(deps, { token: 'ds_token1', cloudBaseUrl: CLOUD_BASE_URL })
-    expect(out).toEqual({ ok: false, reason: 'matter_trashed' })
+    expectError(out, 410, undefined, 'File no longer available')
   })
 
   it('returns not_found when the token does not resolve', async () => {
     const { deps } = makeDeps({ share: { resolveByToken: async () => ({ status: 'not_found' }) } })
     const out = await resolveDirectShareDownload(deps, { token: 'ds_token1', cloudBaseUrl: CLOUD_BASE_URL })
-    expect(out).toEqual({ ok: false, reason: 'not_found' })
+    expectError(out, 404, undefined, 'Share not found or revoked')
   })
 
   it('returns not_found when the share is revoked', async () => {
     const { deps } = makeDeps({ share: { resolveByToken: async () => ({ status: 'revoked' }) } })
     const out = await resolveDirectShareDownload(deps, { token: 'ds_token1', cloudBaseUrl: CLOUD_BASE_URL })
-    expect(out).toEqual({ ok: false, reason: 'not_found' })
+    expectError(out, 404, undefined, 'Share not found or revoked')
   })
 
   it('returns not_found when the share kind is not direct (e.g. landing)', async () => {
@@ -186,7 +203,7 @@ describe('resolveDirectShareDownload', () => {
       },
     })
     const out = await resolveDirectShareDownload(deps, { token: 'ds_token1', cloudBaseUrl: CLOUD_BASE_URL })
-    expect(out).toEqual({ ok: false, reason: 'not_found' })
+    expectError(out, 404, undefined, 'Share not found or revoked')
   })
 
   it('returns expired when expiresAt is in the past', async () => {
@@ -201,13 +218,13 @@ describe('resolveDirectShareDownload', () => {
       cloudBaseUrl: CLOUD_BASE_URL,
       now: new Date('2030-01-01'),
     })
-    expect(out).toEqual({ ok: false, reason: 'expired' })
+    expectError(out, 410, undefined, 'Share has expired')
   })
 
   it('returns limit_exceeded when no downloads remain', async () => {
     const { deps, presignDownload } = makeDeps({ share: { hasDownloadsAvailable: async () => false } })
     const out = await resolveDirectShareDownload(deps, { token: 'ds_token1', cloudBaseUrl: CLOUD_BASE_URL })
-    expect(out).toEqual({ ok: false, reason: 'limit_exceeded' })
+    expectError(out, 410, undefined, 'Download limit exceeded')
     expect(presignDownload).not.toHaveBeenCalled()
     expect(meter).not.toHaveBeenCalled()
   })
@@ -217,21 +234,21 @@ describe('resolveDirectShareDownload', () => {
       share: { incrementDownloadsAtomic: async () => ({ ok: false, downloads: 0 }) },
     })
     const out = await resolveDirectShareDownload(deps, { token: 'ds_token1', cloudBaseUrl: CLOUD_BASE_URL })
-    expect(out).toEqual({ ok: false, reason: 'limit_exceeded' })
+    expectError(out, 410, undefined, 'Download limit exceeded')
     expect(presignDownload).not.toHaveBeenCalled()
   })
 
   it('returns storage_not_found when the storage is missing', async () => {
     const { deps } = makeDeps({ storages: { get: async () => null } })
     const out = await resolveDirectShareDownload(deps, { token: 'ds_token1', cloudBaseUrl: CLOUD_BASE_URL })
-    expect(out).toEqual({ ok: false, reason: 'storage_not_found' })
+    expectError(out, 404, undefined, 'Storage not found')
   })
 
   it('returns quota_exceeded when the meter rejects on quota', async () => {
     meter.mockResolvedValue(quotaExceeded)
     const { deps, presignDownload } = makeDeps()
     const out = await resolveDirectShareDownload(deps, { token: 'ds_token1', cloudBaseUrl: CLOUD_BASE_URL })
-    expect(out).toEqual({ ok: false, reason: 'quota_exceeded' })
+    expectError(out, 422, 'QUOTA_EXCEEDED', 'Traffic quota exceeded')
     // The meter owns the compensating decrement; presign never runs.
     expect(presignDownload).not.toHaveBeenCalled()
   })
@@ -240,7 +257,7 @@ describe('resolveDirectShareDownload', () => {
     meter.mockResolvedValue(insufficientCredits)
     const { deps, presignDownload } = makeDeps()
     const out = await resolveDirectShareDownload(deps, { token: 'ds_token1', cloudBaseUrl: CLOUD_BASE_URL })
-    expect(out).toEqual({ ok: false, reason: 'insufficient_credits' })
+    expectError(out, 402, 'INSUFFICIENT_CREDITS', 'Insufficient credits')
     expect(presignDownload).not.toHaveBeenCalled()
   })
 
@@ -289,7 +306,7 @@ describe('resolveImageHostingDownload', () => {
   it('returns not_found when the token does not resolve', async () => {
     const { deps } = makeDeps({ imageHosting: { resolveActiveByToken: async () => null } })
     const out = await resolveImageHostingDownload(deps, baseParams)
-    expect(out).toEqual({ ok: false, reason: 'not_found' })
+    expectError(out, 404, undefined, 'Not found')
   })
 
   it('allows any referer when the allowlist is empty', async () => {
@@ -348,7 +365,7 @@ describe('resolveImageHostingDownload', () => {
       ...baseParams,
       refererHeader: 'https://evil.com/page',
     })
-    expect(out).toEqual({ ok: false, reason: 'forbidden_referer' })
+    expectError(out, 403, undefined, 'forbidden referer')
     expect(incrementAccessCount).not.toHaveBeenCalled()
   })
 
@@ -362,7 +379,7 @@ describe('resolveImageHostingDownload', () => {
       ...baseParams,
       refererHeader: 'https://sub.blog.com/page',
     })
-    expect(out).toEqual({ ok: false, reason: 'forbidden_referer' })
+    expectError(out, 403, undefined, 'forbidden referer')
   })
 
   it('throws on a malformed referer (same-origin check parses it unguarded → 500 at http)', async () => {
@@ -377,7 +394,7 @@ describe('resolveImageHostingDownload', () => {
   it('returns storage_not_found when the storage is missing', async () => {
     const { deps } = makeDeps({ storages: { get: async () => null } })
     const out = await resolveImageHostingDownload(deps, baseParams)
-    expect(out).toEqual({ ok: false, reason: 'storage_not_found' })
+    expectError(out, 404, undefined, 'Storage not found')
   })
 
   it('returns quota_exceeded before presigning when the quota is exhausted', async () => {
@@ -385,7 +402,7 @@ describe('resolveImageHostingDownload', () => {
       quota: { consumeTrafficIfQuotaAllows: async () => false },
     })
     const out = await resolveImageHostingDownload(deps, baseParams)
-    expect(out).toEqual({ ok: false, reason: 'quota_exceeded' })
+    expectError(out, 422, 'QUOTA_EXCEEDED', 'Traffic quota exceeded')
     expect(presignInline).not.toHaveBeenCalled()
     expect(incrementAccessCount).not.toHaveBeenCalled()
   })
@@ -427,7 +444,7 @@ describe('resolveImageHostingDownload', () => {
     reportEgress.mockResolvedValue(insufficientCredits)
     const { deps, incrementAccessCount } = makeDeps()
     const out = await resolveImageHostingDownload(deps, baseParams)
-    expect(out).toEqual({ ok: false, reason: 'insufficient_credits' })
+    expectError(out, 402, 'INSUFFICIENT_CREDITS', 'Insufficient credits')
     expect(incrementAccessCount).not.toHaveBeenCalled()
   })
 

--- a/server/usecases/redirect.ts
+++ b/server/usecases/redirect.ts
@@ -8,7 +8,20 @@
 // inputs (cloud base URL, referer header, request origin), and renders the
 // route-specific Responses from the discriminated outcomes below.
 
-import type { ImageHostingRepo, QuotaRepo, S3Gateway, ShareRepo, StorageRepo } from './ports'
+import {
+  type AppError,
+  expired as expiredError,
+  forbidden,
+  type ImageHostingRepo,
+  insufficientCredits,
+  notFound,
+  type QuotaRepo,
+  quotaExceeded,
+  type S3Gateway,
+  type ShareRepo,
+  type StorageRepo,
+  storageNotFound,
+} from './ports'
 import { PRESIGN_TTL_SECS } from './share'
 import { type CloudTrafficMeteringDeps, meterDownloadTraffic, reportDownloadEgress } from './store/traffic-metering'
 
@@ -24,15 +37,7 @@ export type RedirectDeps = CloudTrafficMeteringDeps & {
 
 // ─── Direct share (ds_) ──────────────────────────────────────────────────────
 
-export type DirectShareOutcome =
-  | { ok: true; url: string }
-  | { ok: false; reason: 'matter_trashed' }
-  | { ok: false; reason: 'not_found' }
-  | { ok: false; reason: 'expired' }
-  | { ok: false; reason: 'limit_exceeded' }
-  | { ok: false; reason: 'storage_not_found' }
-  | { ok: false; reason: 'quota_exceeded' }
-  | { ok: false; reason: 'insufficient_credits' }
+export type DirectShareOutcome = { ok: true; url: string } | { ok: false; error: AppError }
 
 // Resolve a ds_ token to a presigned download URL, running the share gates,
 // atomically reserving a download, metering traffic, and presigning. On a
@@ -45,22 +50,23 @@ export async function resolveDirectShareDownload(
   const now = params.now ?? new Date()
   const resolved = await deps.share.resolveByToken(params.token)
   if (resolved.status !== 'ok') {
-    if (resolved.status === 'matter_trashed') return { ok: false, reason: 'matter_trashed' }
-    return { ok: false, reason: 'not_found' }
+    if (resolved.status === 'matter_trashed') return { ok: false, error: expiredError('File no longer available') }
+    return { ok: false, error: notFound('Share not found or revoked') }
   }
 
   const { share, matter } = resolved
-  if (share.kind !== 'direct') return { ok: false, reason: 'not_found' }
+  if (share.kind !== 'direct') return { ok: false, error: notFound('Share not found or revoked') }
 
-  if (share.expiresAt && share.expiresAt < now) return { ok: false, reason: 'expired' }
+  if (share.expiresAt && share.expiresAt < now) return { ok: false, error: expiredError('Share has expired') }
 
-  if (!(await deps.share.hasDownloadsAvailable(share.id))) return { ok: false, reason: 'limit_exceeded' }
+  if (!(await deps.share.hasDownloadsAvailable(share.id)))
+    return { ok: false, error: expiredError('Download limit exceeded') }
 
   const storage = await deps.storages.get(matter.storageId)
-  if (!storage) return { ok: false, reason: 'storage_not_found' }
+  if (!storage) return { ok: false, error: storageNotFound() }
 
   const { ok } = await deps.share.incrementDownloadsAtomic(share.id)
-  if (!ok) return { ok: false, reason: 'limit_exceeded' }
+  if (!ok) return { ok: false, error: expiredError('Download limit exceeded') }
 
   const bytes = matter.size ?? 0
   const metered = await meterDownloadTraffic(deps, {
@@ -72,7 +78,14 @@ export async function resolveDirectShareDownload(
     sourceId: share.id,
     onRejected: () => deps.share.decrementDownloads(share.id),
   })
-  if (!metered.ok) return { ok: false, reason: metered.reason }
+  if (!metered.ok)
+    return {
+      ok: false,
+      error:
+        metered.reason === 'quota_exceeded'
+          ? quotaExceeded('Traffic quota exceeded')
+          : insufficientCredits('Insufficient credits', { metadata: { resource: 'storage_egress' } }),
+    }
 
   let url: string
   try {
@@ -88,13 +101,7 @@ export async function resolveDirectShareDownload(
 
 // ─── Image hosting (ih_) ─────────────────────────────────────────────────────
 
-export type ImageHostingOutcome =
-  | { ok: true; url: string }
-  | { ok: false; reason: 'not_found' }
-  | { ok: false; reason: 'forbidden_referer' }
-  | { ok: false; reason: 'storage_not_found' }
-  | { ok: false; reason: 'quota_exceeded' }
-  | { ok: false; reason: 'insufficient_credits' }
+export type ImageHostingOutcome = { ok: true; url: string } | { ok: false; error: AppError }
 
 // Resolve an ih_ token to a presigned inline URL. Order matters and mirrors the
 // historical flow: enforce the referer allowlist, consume traffic quota, presign
@@ -107,21 +114,21 @@ export async function resolveImageHostingDownload(
   params: { token: string; cloudBaseUrl: string; refererHeader: string | null; requestOrigin: string },
 ): Promise<ImageHostingOutcome> {
   const resolved = await deps.imageHosting.resolveActiveByToken(params.token)
-  if (!resolved) return { ok: false, reason: 'not_found' }
+  if (!resolved) return { ok: false, error: notFound() }
 
   const { image, refererAllowlist } = resolved
 
   // Allow same-origin requests (e.g. Web UI viewing its own images).
   const isSameOrigin = params.refererHeader ? new URL(params.refererHeader).origin === params.requestOrigin : false
   if (!isSameOrigin && !checkReferer(refererAllowlist, params.refererHeader)) {
-    return { ok: false, reason: 'forbidden_referer' }
+    return { ok: false, error: forbidden('forbidden referer') }
   }
 
   const storage = await deps.storages.get(image.storageId)
-  if (!storage) return { ok: false, reason: 'storage_not_found' }
+  if (!storage) return { ok: false, error: storageNotFound() }
 
   const trafficAllowed = await deps.quota.consumeTrafficIfQuotaAllows(image.orgId, image.size)
-  if (!trafficAllowed) return { ok: false, reason: 'quota_exceeded' }
+  if (!trafficAllowed) return { ok: false, error: quotaExceeded('Traffic quota exceeded') }
 
   let url: string
   try {
@@ -140,7 +147,11 @@ export async function resolveImageHostingDownload(
     sourceId: image.id,
   })
   // reportDownloadEgress never consumes quota, so it cannot return quota_exceeded.
-  if (!reported.ok) return { ok: false, reason: 'insufficient_credits' }
+  if (!reported.ok)
+    return {
+      ok: false,
+      error: insufficientCredits('Insufficient credits', { metadata: { resource: 'storage_egress' } }),
+    }
 
   try {
     await deps.imageHosting.incrementAccessCount(image.id)

--- a/server/usecases/share.test.ts
+++ b/server/usecases/share.test.ts
@@ -5,6 +5,7 @@ import type { Platform } from '../platform/interface'
 import { saveShareToDrive } from './object'
 import {
   type ActivityRepo,
+  AppError,
   CreateShareError,
   type Matter,
   type MatterListResult,
@@ -51,6 +52,22 @@ const CLOUD_BASE_URL = 'https://cloud.example.com'
 const meterOk: DownloadTrafficOutcome = { ok: true }
 const meterQuotaExceeded: DownloadTrafficOutcome = { ok: false, reason: 'quota_exceeded' }
 const meterInsufficientCredits: DownloadTrafficOutcome = { ok: false, reason: 'insufficient_credits' }
+
+// Asserts a usecase returned a failure AppError carrying the given HTTP status,
+// wire reason, and message — the AIP-193 fields the http boundary renders.
+function expectError(
+  out: { ok: true } | { ok: false; error: AppError },
+  httpStatus: number,
+  reason: string | undefined,
+  message: string,
+) {
+  expect(out.ok).toBe(false)
+  const { error } = out as { ok: false; error: AppError }
+  expect(error).toBeInstanceOf(AppError)
+  expect(error.httpStatus).toBe(httpStatus)
+  expect(error.meta.reason).toBe(reason)
+  expect(error.message).toBe(message)
+}
 
 const meter = vi.mocked(meterDownloadTraffic)
 const saveToDrive = vi.mocked(saveShareToDrive)
@@ -200,16 +217,22 @@ beforeEach(() => {
 describe('viewShare', () => {
   it('returns matter_trashed when the matter is trashed', async () => {
     const { deps } = makeDeps({ share: { resolveByToken: async () => ({ status: 'matter_trashed' }) } })
-    expect(
+    expectError(
       await viewShare(deps, { token: 't', viewerId: null, viewCookie: undefined, accessCookie: undefined }),
-    ).toEqual({ ok: false, reason: 'matter_trashed' })
+      410,
+      undefined,
+      'File no longer available',
+    )
   })
 
   it('returns not_found for revoked/missing shares', async () => {
     const { deps } = makeDeps({ share: { resolveByToken: async () => ({ status: 'revoked' }) } })
-    expect(
+    expectError(
       await viewShare(deps, { token: 't', viewerId: null, viewCookie: undefined, accessCookie: undefined }),
-    ).toEqual({ ok: false, reason: 'not_found' })
+      404,
+      undefined,
+      'Share not found or revoked',
+    )
   })
 
   it('hides a direct share from a non-creator (not_found)', async () => {
@@ -221,7 +244,7 @@ describe('viewShare', () => {
       viewCookie: undefined,
       accessCookie: undefined,
     })
-    expect(out).toEqual({ ok: false, reason: 'not_found' })
+    expectError(out, 404, undefined, 'Share not found or revoked')
   })
 
   it('returns the viewer DTO and signals the view cookie for an anonymous viewer', async () => {
@@ -337,30 +360,34 @@ describe('viewShare', () => {
 describe('verifySharePassword', () => {
   it('returns not_found when the token does not resolve', async () => {
     const { deps } = makeDeps({ share: { resolveByToken: async () => ({ status: 'not_found' }) } })
-    expect(await verifySharePassword(deps, { token: 't', password: 'x' })).toEqual({ ok: false, reason: 'not_found' })
+    expectError(
+      await verifySharePassword(deps, { token: 't', password: 'x' }),
+      404,
+      undefined,
+      'Share not found or revoked',
+    )
   })
 
   it('returns not_found for a non-landing share', async () => {
     const direct = { ...landingShare, kind: 'direct', passwordHash: hashPassword('pw') } as ShareRecord
     const { deps } = makeDeps({ share: { resolveByToken: async () => okResolution({ share: direct }) } })
-    expect(await verifySharePassword(deps, { token: 't', password: 'pw' })).toEqual({ ok: false, reason: 'not_found' })
+    expectError(
+      await verifySharePassword(deps, { token: 't', password: 'pw' }),
+      404,
+      undefined,
+      'Share not found or revoked',
+    )
   })
 
   it('returns invalid_password when the share has no password', async () => {
     const { deps } = makeDeps()
-    expect(await verifySharePassword(deps, { token: 't', password: 'pw' })).toEqual({
-      ok: false,
-      reason: 'invalid_password',
-    })
+    expectError(await verifySharePassword(deps, { token: 't', password: 'pw' }), 403, undefined, 'Invalid password')
   })
 
   it('returns invalid_password on a wrong password', async () => {
     const pw = { ...landingShare, passwordHash: hashPassword('correct') } as ShareRecord
     const { deps } = makeDeps({ share: { resolveByToken: async () => okResolution({ share: pw }) } })
-    expect(await verifySharePassword(deps, { token: 't', password: 'wrong' })).toEqual({
-      ok: false,
-      reason: 'invalid_password',
-    })
+    expectError(await verifySharePassword(deps, { token: 't', password: 'wrong' }), 403, undefined, 'Invalid password')
   })
 
   it('caps the cookie expiry at one day from now when no share expiry', async () => {
@@ -393,10 +420,10 @@ describe('listShareObjects', () => {
 
   it('returns matter_trashed / not_found from resolution', async () => {
     const trashed = makeDeps({ share: { resolveByToken: async () => ({ status: 'matter_trashed' }) } })
-    expect(await listShareObjects(trashed.deps, baseParams)).toEqual({ ok: false, reason: 'matter_trashed' })
+    expectError(await listShareObjects(trashed.deps, baseParams), 410, undefined, 'File no longer available')
 
     const revoked = makeDeps({ share: { resolveByToken: async () => ({ status: 'revoked' }) } })
-    expect(await listShareObjects(revoked.deps, baseParams)).toEqual({ ok: false, reason: 'not_found' })
+    expectError(await listShareObjects(revoked.deps, baseParams), 404, undefined, 'Share not found or revoked')
   })
 
   it('returns not_found for a non-landing share', async () => {
@@ -404,12 +431,12 @@ describe('listShareObjects', () => {
     const { deps } = makeDeps({
       share: { resolveByToken: async () => okResolution({ share: direct, matter: folderMatter }) },
     })
-    expect(await listShareObjects(deps, baseParams)).toEqual({ ok: false, reason: 'not_found' })
+    expectError(await listShareObjects(deps, baseParams), 404, undefined, 'Share not found or revoked')
   })
 
   it('returns not_a_folder for a file share', async () => {
     const { deps } = makeDeps() // default matter is a file
-    expect(await listShareObjects(deps, baseParams)).toEqual({ ok: false, reason: 'not_a_folder' })
+    expectError(await listShareObjects(deps, baseParams), 400, undefined, 'Not a folder share')
   })
 
   it('returns password_required when the gate blocks', async () => {
@@ -417,10 +444,12 @@ describe('listShareObjects', () => {
     const { deps } = makeDeps({
       share: { resolveByToken: async () => okResolution({ share: pw, matter: folderMatter }) },
     })
-    expect(await listShareObjects(deps, { ...baseParams, accessCookie: undefined })).toEqual({
-      ok: false,
-      reason: 'password_required',
-    })
+    expectError(
+      await listShareObjects(deps, { ...baseParams, accessCookie: undefined }),
+      401,
+      undefined,
+      'Password required',
+    )
   })
 
   it('returns expired before checking the path', async () => {
@@ -428,20 +457,17 @@ describe('listShareObjects', () => {
     const { deps } = makeDeps({
       share: { resolveByToken: async () => okResolution({ share: expired, matter: folderMatter }) },
     })
-    expect(
+    expectError(
       await listShareObjects(deps, { ...baseParams, relativePath: '../etc', now: new Date('2030-01-01') }),
-    ).toEqual({
-      ok: false,
-      reason: 'expired',
-    })
+      410,
+      undefined,
+      'Share has expired',
+    )
   })
 
   it('returns invalid_path for a traversal attempt', async () => {
     const { deps } = makeDeps({ share: { resolveByToken: async () => okResolution({ matter: folderMatter }) } })
-    expect(await listShareObjects(deps, { ...baseParams, relativePath: 'a/../b' })).toEqual({
-      ok: false,
-      reason: 'invalid_path',
-    })
+    expectError(await listShareObjects(deps, { ...baseParams, relativePath: 'a/../b' }), 400, undefined, 'Invalid path')
   })
 
   it('lists children, maps refs, and builds the breadcrumb at the folder root', async () => {
@@ -560,38 +586,37 @@ describe('downloadShareObject', () => {
 
   it('returns matter_trashed / not_found from resolution', async () => {
     const trashed = makeDeps({ share: { resolveByToken: async () => ({ status: 'matter_trashed' }) } })
-    expect(await downloadShareObject(trashed.deps, baseParams)).toEqual({ ok: false, reason: 'matter_trashed' })
+    expectError(await downloadShareObject(trashed.deps, baseParams), 410, undefined, 'File no longer available')
     const revoked = makeDeps({ share: { resolveByToken: async () => ({ status: 'revoked' }) } })
-    expect(await downloadShareObject(revoked.deps, baseParams)).toEqual({ ok: false, reason: 'not_found' })
+    expectError(await downloadShareObject(revoked.deps, baseParams), 404, undefined, 'File not found or not accessible')
   })
 
   it('returns not_found for a non-landing share', async () => {
     const direct = { ...landingShare, kind: 'direct' } as ShareRecord
     const { deps } = makeDeps({ share: { resolveByToken: async () => okResolution({ share: direct }) } })
-    expect(await downloadShareObject(deps, baseParams)).toEqual({ ok: false, reason: 'not_found' })
+    expectError(await downloadShareObject(deps, baseParams), 404, undefined, 'File not found or not accessible')
   })
 
   it('returns invalid_ref when the decoded matterId is null', async () => {
     const { deps } = makeDeps()
-    expect(await downloadShareObject(deps, { ...baseParams, matterId: null })).toEqual({
-      ok: false,
-      reason: 'invalid_ref',
-    })
+    expectError(await downloadShareObject(deps, { ...baseParams, matterId: null }), 400, undefined, 'Invalid reference')
   })
 
   it('returns password_required when the gate blocks', async () => {
     const pw = { ...landingShare, passwordHash: 'hash' } as ShareRecord
     const { deps } = makeDeps({ share: { resolveByToken: async () => okResolution({ share: pw }) } })
-    expect(await downloadShareObject(deps, { ...baseParams, accessCookie: undefined })).toEqual({
-      ok: false,
-      reason: 'password_required',
-    })
+    expectError(
+      await downloadShareObject(deps, { ...baseParams, accessCookie: undefined }),
+      401,
+      undefined,
+      'Password required',
+    )
   })
 
   it('returns expired when past the share expiry', async () => {
     const expired = { ...landingShare, expiresAt: new Date('2000-01-01') } as ShareRecord
     const { deps } = makeDeps({ share: { resolveByToken: async () => okResolution({ share: expired }) } })
-    expect(await downloadShareObject(deps, baseParams)).toEqual({ ok: false, reason: 'expired' })
+    expectError(await downloadShareObject(deps, baseParams), 410, undefined, 'Share has expired')
   })
 
   it('resolves a descendant ref via findShareChildMatter', async () => {
@@ -607,10 +632,12 @@ describe('downloadShareObject', () => {
 
   it('returns not_found when a descendant ref targets a file share root', async () => {
     const { deps } = makeDeps() // root is a file
-    expect(await downloadShareObject(deps, { ...baseParams, matterId: 'other' })).toEqual({
-      ok: false,
-      reason: 'not_found',
-    })
+    expectError(
+      await downloadShareObject(deps, { ...baseParams, matterId: 'other' }),
+      404,
+      undefined,
+      'File not found or not accessible',
+    )
   })
 
   it('returns not_found when the descendant child is missing', async () => {
@@ -620,23 +647,27 @@ describe('downloadShareObject', () => {
         findShareChildMatter: async () => null,
       },
     })
-    expect(await downloadShareObject(deps, { ...baseParams, matterId: 'm-child' })).toEqual({
-      ok: false,
-      reason: 'not_found',
-    })
+    expectError(
+      await downloadShareObject(deps, { ...baseParams, matterId: 'm-child' }),
+      404,
+      undefined,
+      'File not found or not accessible',
+    )
   })
 
   it('returns folder when the root itself is a folder requested directly', async () => {
     const { deps } = makeDeps({ share: { resolveByToken: async () => okResolution({ matter: folderMatter }) } })
-    expect(await downloadShareObject(deps, { ...baseParams, matterId: 'fld-1' })).toEqual({
-      ok: false,
-      reason: 'folder',
-    })
+    expectError(
+      await downloadShareObject(deps, { ...baseParams, matterId: 'fld-1' }),
+      400,
+      undefined,
+      'Cannot download a folder directly',
+    )
   })
 
   it('returns limit_exceeded when no downloads remain', async () => {
     const { deps, presignDownload } = makeDeps({ share: { hasDownloadsAvailable: async () => false } })
-    expect(await downloadShareObject(deps, baseParams)).toEqual({ ok: false, reason: 'limit_exceeded' })
+    expectError(await downloadShareObject(deps, baseParams), 410, undefined, 'Download limit exceeded')
     expect(presignDownload).not.toHaveBeenCalled()
     expect(meter).not.toHaveBeenCalled()
   })
@@ -645,27 +676,27 @@ describe('downloadShareObject', () => {
     const { deps, presignDownload } = makeDeps({
       share: { incrementDownloadsAtomic: async () => ({ ok: false, downloads: 0 }) },
     })
-    expect(await downloadShareObject(deps, baseParams)).toEqual({ ok: false, reason: 'limit_exceeded' })
+    expectError(await downloadShareObject(deps, baseParams), 410, undefined, 'Download limit exceeded')
     expect(presignDownload).not.toHaveBeenCalled()
     expect(meter).not.toHaveBeenCalled()
   })
 
   it('returns storage_not_found when the storage is missing', async () => {
     const { deps } = makeDeps({ storages: { get: async () => null } })
-    expect(await downloadShareObject(deps, baseParams)).toEqual({ ok: false, reason: 'storage_not_found' })
+    expectError(await downloadShareObject(deps, baseParams), 404, undefined, 'Storage not found')
   })
 
   it('returns quota_exceeded when the meter rejects on quota; presign never runs', async () => {
     meter.mockResolvedValue(meterQuotaExceeded)
     const { deps, presignDownload } = makeDeps()
-    expect(await downloadShareObject(deps, baseParams)).toEqual({ ok: false, reason: 'quota_exceeded' })
+    expectError(await downloadShareObject(deps, baseParams), 422, 'QUOTA_EXCEEDED', 'Traffic quota exceeded')
     expect(presignDownload).not.toHaveBeenCalled()
   })
 
   it('returns insufficient_credits when the meter rejects on credits', async () => {
     meter.mockResolvedValue(meterInsufficientCredits)
     const { deps, presignDownload } = makeDeps()
-    expect(await downloadShareObject(deps, baseParams)).toEqual({ ok: false, reason: 'insufficient_credits' })
+    expectError(await downloadShareObject(deps, baseParams), 402, 'INSUFFICIENT_CREDITS', 'Insufficient credits')
     expect(presignDownload).not.toHaveBeenCalled()
   })
 
@@ -809,17 +840,17 @@ describe('createShare', () => {
   })
 
   it.each([
-    ['MATTER_NOT_FOUND'],
-    ['DIRECT_NO_FOLDER'],
-    ['DIRECT_NO_PASSWORD'],
-    ['DIRECT_NO_RECIPIENTS'],
-  ] as const)('maps CreateShareError %s to a failure outcome without recording activity', async (code) => {
+    ['MATTER_NOT_FOUND', 404, 'Matter not found'],
+    ['DIRECT_NO_FOLDER', 400, 'Direct shares cannot be folders'],
+    ['DIRECT_NO_PASSWORD', 400, 'Direct shares cannot have a password'],
+    ['DIRECT_NO_RECIPIENTS', 400, 'Direct shares cannot have recipients'],
+  ] as const)('maps CreateShareError %s to a failure outcome without recording activity', async (code, status, message) => {
     const create = vi.fn(async () => {
       throw new CreateShareError(code)
     })
     const { deps, record, createNotification, sendEmail } = makeDeps({ share: { create } })
     const out = await createShare(deps, platform, { orgId: 'o-1', userId: 'creator-1', input: baseInput })
-    expect(out).toEqual({ ok: false, reason: code })
+    expectError(out, status, code, message)
     expect(record).not.toHaveBeenCalled()
     await flushDispatch()
     expect(createNotification).not.toHaveBeenCalled()
@@ -842,27 +873,18 @@ describe('createShare', () => {
 describe('revokeShare', () => {
   it('returns not_found when the token has no creator', async () => {
     const { deps, record } = makeDeps({ share: { getCreatorByToken: async () => null } })
-    expect(await revokeShare(deps, { token: 't', userId: 'u1', orgId: 'o-1' })).toEqual({
-      ok: false,
-      reason: 'not_found',
-    })
+    expectError(await revokeShare(deps, { token: 't', userId: 'u1', orgId: 'o-1' }), 404, undefined, 'Not found')
     expect(record).not.toHaveBeenCalled()
   })
 
   it('returns forbidden when the requester is not the creator', async () => {
     const { deps } = makeDeps({ share: { getCreatorByToken: async () => 'someone-else' } })
-    expect(await revokeShare(deps, { token: 't', userId: 'u1', orgId: 'o-1' })).toEqual({
-      ok: false,
-      reason: 'forbidden',
-    })
+    expectError(await revokeShare(deps, { token: 't', userId: 'u1', orgId: 'o-1' }), 403, undefined, 'Forbidden')
   })
 
   it('returns not_found when the scoped revoke loses the race', async () => {
     const { deps } = makeDeps({ share: { getCreatorByToken: async () => 'u1', revokeByToken: async () => false } })
-    expect(await revokeShare(deps, { token: 't', userId: 'u1', orgId: 'o-1' })).toEqual({
-      ok: false,
-      reason: 'not_found',
-    })
+    expectError(await revokeShare(deps, { token: 't', userId: 'u1', orgId: 'o-1' }), 404, undefined, 'Not found')
   })
 
   it('revokes and records activity on success', async () => {
@@ -889,27 +911,34 @@ describe('saveShare', () => {
 
   it('returns matter_trashed when the share target was trashed', async () => {
     const { deps } = makeDeps({ share: { resolveByToken: async () => ({ status: 'matter_trashed' }) } })
-    expect(await saveShare(deps, baseParams)).toEqual({ ok: false, reason: 'matter_trashed' })
+    expectError(await saveShare(deps, baseParams), 410, undefined, 'Share target has been deleted')
   })
 
   it('returns not_found for a revoked/missing share', async () => {
     const { deps } = makeDeps({ share: { resolveByToken: async () => ({ status: 'revoked' }) } })
-    expect(await saveShare(deps, baseParams)).toEqual({ ok: false, reason: 'not_found' })
+    expectError(await saveShare(deps, baseParams), 404, undefined, 'Share not found')
   })
 
   it('returns direct_forbidden for a direct share', async () => {
     const direct = { ...landingShare, kind: 'direct' } as ShareRecord
     const { deps } = makeDeps({ share: { resolveByToken: async () => okResolution({ share: direct }) } })
-    expect(await saveShare(deps, baseParams)).toEqual({ ok: false, reason: 'direct_forbidden' })
+    expectError(
+      await saveShare(deps, baseParams),
+      400,
+      'DIRECT_SAVE_FORBIDDEN',
+      'Direct link shares cannot be saved. Ask the sender for a landing share.',
+    )
   })
 
   it('returns password_required when the gate blocks a non-recipient', async () => {
     const pw = { ...landingShare, passwordHash: 'hash' } as ShareRecord
     const { deps } = makeDeps({ share: { resolveByToken: async () => okResolution({ share: pw }) } })
-    expect(await saveShare(deps, { ...baseParams, accessCookie: undefined })).toEqual({
-      ok: false,
-      reason: 'password_required',
-    })
+    expectError(
+      await saveShare(deps, { ...baseParams, accessCookie: undefined }),
+      401,
+      undefined,
+      'Authentication required for password-protected share',
+    )
   })
 
   it('bypasses the password gate when the cookie is ok', async () => {
@@ -921,14 +950,14 @@ describe('saveShare', () => {
 
   it('returns forbidden when the user cannot write to the target org', async () => {
     const { deps } = makeDeps({ org: { canWriteToOrg: async () => false } })
-    expect(await saveShare(deps, baseParams)).toEqual({ ok: false, reason: 'forbidden' })
+    expectError(await saveShare(deps, baseParams), 403, undefined, 'Forbidden')
   })
 
   it('returns quota_exceeded when the target org lacks quota', async () => {
     const computeSourceBytes = vi.fn(async () => 5000)
     const hasQuotaForBytes = vi.fn(async () => false)
     const { deps } = makeDeps({ share: { computeSourceBytes, hasQuotaForBytes } })
-    expect(await saveShare(deps, baseParams)).toEqual({ ok: false, reason: 'quota_exceeded' })
+    expectError(await saveShare(deps, baseParams), 422, 'QUOTA_EXCEEDED', 'Quota exceeded')
     expect(hasQuotaForBytes).toHaveBeenCalledWith('o-2', 5000)
     expect(saveToDrive).not.toHaveBeenCalled()
   })

--- a/server/usecases/share.ts
+++ b/server/usecases/share.ts
@@ -18,13 +18,21 @@ import type { Platform } from '../platform/interface'
 import { type SaveToDriveDeps, saveShareToDrive } from './object'
 import {
   type ActivityRepo,
+  AppError,
+  badRequest,
   CreateShareError,
   type EmailGateway,
+  expired as expiredError,
+  forbidden,
+  insufficientCredits,
   type Matter,
   type MatterRepo,
   type NotificationRepo,
+  notFound,
   type OrgRepo,
+  passwordRequired,
   type QuotaRepo,
+  quotaExceeded,
   type S3Gateway,
   type ShareNotificationRecipient,
   type ShareNotificationRepo,
@@ -33,6 +41,7 @@ import {
   type ShareRecord,
   type ShareRepo,
   type StorageRepo,
+  storageNotFound,
 } from './ports'
 import type { CloudTrafficMeteringDeps } from './store/traffic-metering'
 import { meterDownloadTraffic } from './store/traffic-metering'
@@ -93,22 +102,22 @@ export type ShareCreatorDto = ShareViewerDto & {
 
 export type ViewShareOutcome =
   | { ok: true; dto: ShareViewerDto | ShareCreatorDto; setViewCookie: boolean }
-  | { ok: false; reason: 'not_found' | 'matter_trashed' }
+  | { ok: false; error: AppError }
 
 export async function viewShare(deps: ShareDeps, params: ViewShareParams): Promise<ViewShareOutcome> {
   const { token, viewerId, viewCookie, accessCookie, now = new Date() } = params
 
   const resolved = await deps.share.resolveByToken(token)
   if (resolved.status !== 'ok') {
-    if (resolved.status === 'matter_trashed') return { ok: false, reason: 'matter_trashed' }
-    return { ok: false, reason: 'not_found' }
+    if (resolved.status === 'matter_trashed') return { ok: false, error: expiredError('File no longer available') }
+    return { ok: false, error: notFound('Share not found or revoked') }
   }
 
   const { share, matter, recipients } = resolved
   const isCreator = !!viewerId && viewerId === share.creatorId
 
   // Direct shares are not publicly viewable; only the creator sees metadata.
-  if (share.kind !== 'landing' && !isCreator) return { ok: false, reason: 'not_found' }
+  if (share.kind !== 'landing' && !isCreator) return { ok: false, error: notFound('Share not found or revoked') }
 
   // View-dedup increment: non-creators whose view cookie isn't yet 'seen'. The
   // handler sets the cookie when setViewCookie is true.
@@ -162,9 +171,7 @@ export async function viewShare(deps: ShareDeps, params: ViewShareParams): Promi
 
 export type VerifySharePasswordParams = { token: string; password: string; now?: Date }
 
-export type VerifySharePasswordOutcome =
-  | { ok: true; setAccessCookieExpiry: Date }
-  | { ok: false; reason: 'not_found' | 'invalid_password' }
+export type VerifySharePasswordOutcome = { ok: true; setAccessCookieExpiry: Date } | { ok: false; error: AppError }
 
 export async function verifySharePassword(
   deps: ShareDeps,
@@ -173,13 +180,13 @@ export async function verifySharePassword(
   const { token, password, now = new Date() } = params
 
   const resolved = await deps.share.resolveByToken(token)
-  if (resolved.status !== 'ok') return { ok: false, reason: 'not_found' }
+  if (resolved.status !== 'ok') return { ok: false, error: notFound('Share not found or revoked') }
 
   const { share } = resolved
-  if (share.kind !== 'landing') return { ok: false, reason: 'not_found' }
+  if (share.kind !== 'landing') return { ok: false, error: notFound('Share not found or revoked') }
 
   if (!share.passwordHash || !verifyPasswordHash(share.passwordHash, password))
-    return { ok: false, reason: 'invalid_password' }
+    return { ok: false, error: forbidden('Invalid password') }
 
   // Cookie lives for up to a day, never past the share's own expiry.
   const oneDayMs = 24 * 60 * 60 * 1000
@@ -212,12 +219,7 @@ export type ListShareObjectsResult = {
   breadcrumb: Array<{ name: string; path: string }>
 }
 
-export type ListShareObjectsOutcome =
-  | { ok: true; result: ListShareObjectsResult }
-  | {
-      ok: false
-      reason: 'not_found' | 'matter_trashed' | 'not_a_folder' | 'password_required' | 'expired' | 'invalid_path'
-    }
+export type ListShareObjectsOutcome = { ok: true; result: ListShareObjectsResult } | { ok: false; error: AppError }
 
 export async function listShareObjects(
   deps: ShareDeps,
@@ -227,20 +229,20 @@ export async function listShareObjects(
 
   const resolved = await deps.share.resolveByToken(token)
   if (resolved.status !== 'ok') {
-    if (resolved.status === 'matter_trashed') return { ok: false, reason: 'matter_trashed' }
-    return { ok: false, reason: 'not_found' }
+    if (resolved.status === 'matter_trashed') return { ok: false, error: expiredError('File no longer available') }
+    return { ok: false, error: notFound('Share not found or revoked') }
   }
 
   const { share, matter, recipients } = resolved
-  if (share.kind !== 'landing') return { ok: false, reason: 'not_found' }
-  if (matter.dirtype === DirType.FILE) return { ok: false, reason: 'not_a_folder' }
+  if (share.kind !== 'landing') return { ok: false, error: notFound('Share not found or revoked') }
+  if (matter.dirtype === DirType.FILE) return { ok: false, error: badRequest('Not a folder share') }
 
   if (checkAccessGate(share.passwordHash, recipients, viewerId, accessCookie) === 'password_required')
-    return { ok: false, reason: 'password_required' }
+    return { ok: false, error: passwordRequired() }
 
-  if (share.expiresAt && share.expiresAt < now) return { ok: false, reason: 'expired' }
+  if (share.expiresAt && share.expiresAt < now) return { ok: false, error: expiredError('Share has expired') }
 
-  if (relativePath.includes('..')) return { ok: false, reason: 'invalid_path' }
+  if (relativePath.includes('..')) return { ok: false, error: badRequest('Invalid path') }
 
   const root = folderRootPath(matter)
   const queryParent = relativePath ? `${root}/${relativePath}` : root
@@ -277,22 +279,7 @@ export type DownloadShareObjectParams = {
   cloudBaseUrl: string
 }
 
-export type DownloadShareObjectOutcome =
-  | { ok: true; url: string }
-  | {
-      ok: false
-      reason:
-        | 'not_found'
-        | 'matter_trashed'
-        | 'invalid_ref'
-        | 'password_required'
-        | 'expired'
-        | 'folder'
-        | 'limit_exceeded'
-        | 'storage_not_found'
-        | 'quota_exceeded'
-        | 'insufficient_credits'
-    }
+export type DownloadShareObjectOutcome = { ok: true; url: string } | { ok: false; error: AppError }
 
 export async function downloadShareObject(
   deps: ShareDeps,
@@ -302,37 +289,38 @@ export async function downloadShareObject(
 
   const resolved = await deps.share.resolveByToken(token)
   if (resolved.status !== 'ok') {
-    if (resolved.status === 'matter_trashed') return { ok: false, reason: 'matter_trashed' }
-    return { ok: false, reason: 'not_found' }
+    if (resolved.status === 'matter_trashed') return { ok: false, error: expiredError('File no longer available') }
+    return { ok: false, error: notFound('File not found or not accessible') }
   }
 
   const { share, matter, recipients } = resolved
-  if (share.kind !== 'landing') return { ok: false, reason: 'not_found' }
+  if (share.kind !== 'landing') return { ok: false, error: notFound('File not found or not accessible') }
 
-  if (matterId === null) return { ok: false, reason: 'invalid_ref' }
+  if (matterId === null) return { ok: false, error: badRequest('Invalid reference') }
 
   if (checkAccessGate(share.passwordHash, recipients, viewerId, accessCookie) === 'password_required')
-    return { ok: false, reason: 'password_required' }
+    return { ok: false, error: passwordRequired() }
 
-  if (share.expiresAt && share.expiresAt < new Date()) return { ok: false, reason: 'expired' }
+  if (share.expiresAt && share.expiresAt < new Date()) return { ok: false, error: expiredError('Share has expired') }
 
   let targetMatter = matter
   if (matterId !== matter.id) {
-    if (matter.dirtype === DirType.FILE) return { ok: false, reason: 'not_found' }
+    if (matter.dirtype === DirType.FILE) return { ok: false, error: notFound('File not found or not accessible') }
     const child = await deps.share.findShareChildMatter(matter, matterId)
-    if (!child) return { ok: false, reason: 'not_found' }
+    if (!child) return { ok: false, error: notFound('File not found or not accessible') }
     targetMatter = child
   } else if (matter.dirtype !== DirType.FILE) {
-    return { ok: false, reason: 'folder' }
+    return { ok: false, error: badRequest('Cannot download a folder directly') }
   }
 
-  if (!(await deps.share.hasDownloadsAvailable(share.id))) return { ok: false, reason: 'limit_exceeded' }
+  if (!(await deps.share.hasDownloadsAvailable(share.id)))
+    return { ok: false, error: expiredError('Download limit exceeded') }
 
   const storage = await deps.storages.get(targetMatter.storageId)
-  if (!storage) return { ok: false, reason: 'storage_not_found' }
+  if (!storage) return { ok: false, error: storageNotFound() }
 
   const { ok: incremented } = await deps.share.incrementDownloadsAtomic(share.id)
-  if (!incremented) return { ok: false, reason: 'limit_exceeded' }
+  if (!incremented) return { ok: false, error: expiredError('Download limit exceeded') }
 
   const bytes = targetMatter.size ?? 0
   const metered = await meterDownloadTraffic(deps, {
@@ -344,7 +332,14 @@ export async function downloadShareObject(
     sourceId: share.id,
     onRejected: () => deps.share.decrementDownloads(share.id),
   })
-  if (!metered.ok) return { ok: false, reason: metered.reason }
+  if (!metered.ok)
+    return {
+      ok: false,
+      error:
+        metered.reason === 'quota_exceeded'
+          ? quotaExceeded('Traffic quota exceeded')
+          : insufficientCredits('Insufficient credits', { metadata: { resource: 'storage_egress' } }),
+    }
 
   // Presign. On failure the metering already succeeded, so roll it back
   // ourselves: refund the consumed traffic and the download count, then rethrow.
@@ -418,7 +413,16 @@ export type CreatedShare = {
   downloadLimit: number | null
 }
 
-export type CreateShareOutcome = { ok: true; share: CreatedShare } | { ok: false; reason: CreateShareError['code'] }
+export type CreateShareOutcome = { ok: true; share: CreatedShare } | { ok: false; error: AppError }
+
+// The wire mapping for each CreateShareError code: a 404 (matter missing) or a
+// 400 (invalid direct-share shape), each preserving its stable reason.
+const CREATE_SHARE_ERRORS: Record<CreateShareError['code'], AppError> = {
+  MATTER_NOT_FOUND: new AppError(404, 'Matter not found', { reason: 'MATTER_NOT_FOUND' }),
+  DIRECT_NO_FOLDER: badRequest('Direct shares cannot be folders', 'DIRECT_NO_FOLDER'),
+  DIRECT_NO_PASSWORD: badRequest('Direct shares cannot have a password', 'DIRECT_NO_PASSWORD'),
+  DIRECT_NO_RECIPIENTS: badRequest('Direct shares cannot have recipients', 'DIRECT_NO_RECIPIENTS'),
+}
 
 export async function createShare(
   deps: ShareDeps,
@@ -448,7 +452,7 @@ export async function createShare(
       recipients: input.recipients,
     })
   } catch (err) {
-    if (err instanceof CreateShareError) return { ok: false, reason: err.code }
+    if (err instanceof CreateShareError) return { ok: false, error: CREATE_SHARE_ERRORS[err.code] }
     throw err
   }
 
@@ -486,20 +490,20 @@ export async function createShare(
 
 export type RevokeShareParams = { token: string; userId: string; orgId: string }
 
-export type RevokeShareOutcome = { ok: true } | { ok: false; reason: 'not_found' | 'forbidden' }
+export type RevokeShareOutcome = { ok: true } | { ok: false; error: AppError }
 
 export async function revokeShare(deps: ShareDeps, params: RevokeShareParams): Promise<RevokeShareOutcome> {
   const { token, userId, orgId } = params
 
   const creatorId = await deps.share.getCreatorByToken(token)
-  if (creatorId === null) return { ok: false, reason: 'not_found' }
-  if (creatorId !== userId) return { ok: false, reason: 'forbidden' }
+  if (creatorId === null) return { ok: false, error: notFound() }
+  if (creatorId !== userId) return { ok: false, error: forbidden() }
 
   // Race-safe: revokeByToken scopes the UPDATE to (token, creatorId). A
   // concurrent revoke or ownership change between the check above and this call
   // returns false — translate to not_found at the boundary.
   const revoked = await deps.share.revokeByToken(token, userId)
-  if (!revoked) return { ok: false, reason: 'not_found' }
+  if (!revoked) return { ok: false, error: notFound() }
 
   await deps.activity.record({
     orgId,
@@ -524,29 +528,33 @@ export type SaveShareParams = {
 
 export type SaveShareOutcome =
   | { ok: true; result: { saved: Matter[]; skipped: Array<{ name: string; reason: string }> } }
-  | {
-      ok: false
-      reason: 'matter_trashed' | 'not_found' | 'direct_forbidden' | 'password_required' | 'forbidden' | 'quota_exceeded'
-    }
+  | { ok: false; error: AppError }
 
 export async function saveShare(deps: ShareDeps, params: SaveShareParams): Promise<SaveShareOutcome> {
   const { token, currentUserId, targetOrgId, targetParent, accessCookie } = params
 
   const resolution = await deps.share.resolveByToken(token)
-  if (resolution.status === 'matter_trashed') return { ok: false, reason: 'matter_trashed' }
-  if (resolution.status !== 'ok') return { ok: false, reason: 'not_found' }
+  if (resolution.status === 'matter_trashed') return { ok: false, error: expiredError('Share target has been deleted') }
+  if (resolution.status !== 'ok') return { ok: false, error: notFound('Share not found') }
 
   const { share, matter, recipients } = resolution
 
-  if (share.kind === 'direct') return { ok: false, reason: 'direct_forbidden' }
+  if (share.kind === 'direct')
+    return {
+      ok: false,
+      error: badRequest(
+        'Direct link shares cannot be saved. Ask the sender for a landing share.',
+        'DIRECT_SAVE_FORBIDDEN',
+      ),
+    }
 
   if (checkAccessGate(share.passwordHash, recipients, currentUserId, accessCookie) === 'password_required')
-    return { ok: false, reason: 'password_required' }
+    return { ok: false, error: passwordRequired('Authentication required for password-protected share') }
 
-  if (!(await deps.org.canWriteToOrg(currentUserId, targetOrgId))) return { ok: false, reason: 'forbidden' }
+  if (!(await deps.org.canWriteToOrg(currentUserId, targetOrgId))) return { ok: false, error: forbidden() }
 
   const totalBytes = await deps.share.computeSourceBytes(matter)
-  if (!(await deps.share.hasQuotaForBytes(targetOrgId, totalBytes))) return { ok: false, reason: 'quota_exceeded' }
+  if (!(await deps.share.hasQuotaForBytes(targetOrgId, totalBytes))) return { ok: false, error: quotaExceeded() }
 
   const result = await saveShareToDrive(deps, { share, matter, currentUserId, targetOrgId, targetParent })
   return { ok: true, result }

--- a/server/usecases/site/auth-provider.test.ts
+++ b/server/usecases/site/auth-provider.test.ts
@@ -187,39 +187,53 @@ describe('auth-provider usecase', () => {
       expect(loadBindingState).not.toHaveBeenCalled() // free limit never checked on update
     })
 
-    it('returns invalid_id for a malformed provider id and never writes', async () => {
+    it('returns a 400 invalid-id error for a malformed provider id and never writes', async () => {
       const { deps, set } = makeDeps()
       const out = await upsertAuthProvider(deps, 'Not_Valid', githubInput)
-      expect(out).toEqual({ ok: false, reason: 'invalid_id' })
+      expect(out.ok).toBe(false)
+      if (out.ok) throw new Error('expected failure')
+      expect(out.error.httpStatus).toBe(400)
+      expect(out.error.message).toBe('Provider ID must contain only lowercase letters, numbers, and hyphens')
       expect(set).not.toHaveBeenCalled()
     })
 
-    it('returns unknown_builtin for a builtin id not in the registry', async () => {
+    it('returns a 400 unknown-builtin error for a builtin id not in the registry', async () => {
       const { deps, set } = makeDeps()
       const out = await upsertAuthProvider(deps, 'not-a-real-provider', githubInput)
-      expect(out).toEqual({ ok: false, reason: 'unknown_builtin' })
+      expect(out.ok).toBe(false)
+      if (out.ok) throw new Error('expected failure')
+      expect(out.error.httpStatus).toBe(400)
+      expect(out.error.message).toBe('Unknown builtin provider: not-a-real-provider')
       expect(set).not.toHaveBeenCalled()
     })
 
-    it('returns missing_discovery for an OIDC provider with no discoveryUrl', async () => {
+    it('returns a 400 missing-discovery error for an OIDC provider with no discoveryUrl', async () => {
       const { deps, set } = makeDeps()
       const { discoveryUrl: _omit, ...withoutDiscovery } = oidcInput
       const out = await upsertAuthProvider(deps, 'my-oidc', withoutDiscovery)
-      expect(out).toEqual({ ok: false, reason: 'missing_discovery' })
+      expect(out.ok).toBe(false)
+      if (out.ok) throw new Error('expected failure')
+      expect(out.error.httpStatus).toBe(400)
+      expect(out.error.message).toBe('discoveryUrl is required for OIDC providers')
       expect(set).not.toHaveBeenCalled()
     })
 
-    it('blocks the second provider on the free plan with feature_blocked', async () => {
+    it('blocks the second provider on the free plan with a 402 feature-blocked error', async () => {
       edition(COMMUNITY)
       const { deps, set } = makeDeps({
         get: async () => null,
         listByKeyLike: async () => [row({ providerId: 'github', enabled: true })],
       })
       const out = await upsertAuthProvider(deps, 'google', { ...githubInput })
-      expect(out).toEqual({
-        ok: false,
-        reason: 'feature_blocked',
-        block: { feature: 'social_login_unlimited', currentCount: 1, limit: FREE_SOCIAL_LOGIN_LIMIT },
+      expect(out.ok).toBe(false)
+      if (out.ok) throw new Error('expected failure')
+      expect(out.error.httpStatus).toBe(402)
+      expect(out.error.meta.reason).toBe('FEATURE_NOT_AVAILABLE')
+      expect(out.error.meta.metadata).toEqual({
+        feature: 'social_login_unlimited',
+        currentCount: '1',
+        limit: String(FREE_SOCIAL_LOGIN_LIMIT),
+        upgradeUrl: '/settings/billing',
       })
       expect(set).not.toHaveBeenCalled()
     })
@@ -251,10 +265,13 @@ describe('auth-provider usecase', () => {
       expect(del).toHaveBeenCalledWith('oauth_provider_never-configured')
     })
 
-    it('returns invalid_id for a malformed provider id and never deletes', async () => {
+    it('returns a 400 invalid-id error for a malformed provider id and never deletes', async () => {
       const { deps, del } = makeDeps()
       const out = await deleteAuthProvider(deps, 'Bad_Id')
-      expect(out).toEqual({ ok: false, reason: 'invalid_id' })
+      expect(out.ok).toBe(false)
+      if (out.ok) throw new Error('expected failure')
+      expect(out.error.httpStatus).toBe(400)
+      expect(out.error.message).toBe('Provider ID must contain only lowercase letters, numbers, and hyphens')
       expect(del).not.toHaveBeenCalled()
     })
   })

--- a/server/usecases/site/auth-provider.ts
+++ b/server/usecases/site/auth-provider.ts
@@ -20,7 +20,7 @@ import {
   parseProviderConfig,
 } from '@shared/oauth-providers'
 import { hasFeature } from '../../domain/licensing'
-import type { LicenseBindingRepo, SystemOptionsRepo } from '../ports'
+import { type AppError, badRequest, featureBlocked, type LicenseBindingRepo, type SystemOptionsRepo } from '../ports'
 import { loadBindingState } from './licensing'
 
 export type AuthProviderDeps = {
@@ -53,8 +53,8 @@ export type PublicProvider = {
   icon: string
 }
 
-// Why an upsert was rejected. `invalid_id` / `unknown_builtin` / `missing_discovery`
-// are 400 validations; `feature_blocked` is the 402 Community social-login gate.
+// `invalid_id` / `unknown_builtin` / `missing_discovery` are 400 validations;
+// `feature_blocked` is the 402 Community social-login gate.
 export type UpsertProviderInput = {
   type: OAuthProviderType
   clientId: string
@@ -64,20 +64,11 @@ export type UpsertProviderInput = {
   scopes?: string[]
 }
 
-export type SocialLoginFeatureBlock = {
-  feature: 'social_login_unlimited'
-  currentCount: number
-  limit: number
-}
+export type UpsertProviderOutcome = { ok: true; config: MaskedProviderConfig } | { ok: false; error: AppError }
 
-export type UpsertProviderOutcome =
-  | { ok: true; config: MaskedProviderConfig }
-  | { ok: false; reason: 'invalid_id' }
-  | { ok: false; reason: 'unknown_builtin' }
-  | { ok: false; reason: 'missing_discovery' }
-  | { ok: false; reason: 'feature_blocked'; block: SocialLoginFeatureBlock }
+export type DeleteProviderOutcome = { ok: true } | { ok: false; error: AppError }
 
-export type DeleteProviderOutcome = { ok: true } | { ok: false; reason: 'invalid_id' }
+const INVALID_PROVIDER_ID_MESSAGE = 'Provider ID must contain only lowercase letters, numbers, and hyphens'
 
 // Public: enabled providers only, no secrets (for login page buttons).
 export async function listPublicAuthProviders(
@@ -120,11 +111,12 @@ export async function upsertAuthProvider(
   providerId: string,
   input: UpsertProviderInput,
 ): Promise<UpsertProviderOutcome> {
-  if (!isValidProviderId(providerId)) return { ok: false, reason: 'invalid_id' }
+  if (!isValidProviderId(providerId)) return { ok: false, error: badRequest(INVALID_PROVIDER_ID_MESSAGE) }
   if (input.type === 'builtin' && !BUILTIN_PROVIDER_IDS.includes(providerId)) {
-    return { ok: false, reason: 'unknown_builtin' }
+    return { ok: false, error: badRequest(`Unknown builtin provider: ${providerId}`) }
   }
-  if (input.type === 'oidc' && !input.discoveryUrl) return { ok: false, reason: 'missing_discovery' }
+  if (input.type === 'oidc' && !input.discoveryUrl)
+    return { ok: false, error: badRequest('discoveryUrl is required for OIDC providers') }
 
   const config: OAuthProviderConfig = { providerId, ...input }
   const key = optionKey(providerId)
@@ -143,12 +135,14 @@ export async function upsertAuthProvider(
     if (!hasFeature('social_login_unlimited', state) && configured.length >= FREE_SOCIAL_LOGIN_LIMIT) {
       return {
         ok: false,
-        reason: 'feature_blocked',
-        block: {
-          feature: 'social_login_unlimited',
-          currentCount: configured.length,
-          limit: FREE_SOCIAL_LOGIN_LIMIT,
-        },
+        error: featureBlocked('Feature not available', {
+          metadata: {
+            feature: 'social_login_unlimited',
+            currentCount: String(configured.length),
+            limit: String(FREE_SOCIAL_LOGIN_LIMIT),
+            upgradeUrl: '/settings/billing',
+          },
+        }),
       }
     }
     await deps.systemOptions.set(key, value, false)
@@ -161,7 +155,7 @@ export async function deleteAuthProvider(
   deps: Pick<AuthProviderDeps, 'systemOptions'>,
   providerId: string,
 ): Promise<DeleteProviderOutcome> {
-  if (!isValidProviderId(providerId)) return { ok: false, reason: 'invalid_id' }
+  if (!isValidProviderId(providerId)) return { ok: false, error: badRequest(INVALID_PROVIDER_ID_MESSAGE) }
   await deps.systemOptions.delete(optionKey(providerId))
   return { ok: true }
 }

--- a/server/usecases/site/email-config.test.ts
+++ b/server/usecases/site/email-config.test.ts
@@ -205,13 +205,16 @@ describe('email-config usecase', () => {
       })
     })
 
-    it('reports send_failed with the error message when the gateway throws', async () => {
+    it('reports a 400 error with the error message when the gateway throws', async () => {
       const send = vi.fn(async () => {
         throw new Error('Email is disabled')
       })
       const { deps } = makeDeps({ email: { send } })
       const out = await sendTestEmail(deps, platform, 'recipient@example.com')
-      expect(out).toEqual({ ok: false, reason: 'send_failed', message: 'Email is disabled' })
+      expect(out.ok).toBe(false)
+      if (out.ok) throw new Error('expected failure')
+      expect(out.error.httpStatus).toBe(400)
+      expect(out.error.message).toBe('Email is disabled')
     })
 
     it('falls back to "Unknown error" when a non-Error is thrown', async () => {
@@ -220,7 +223,10 @@ describe('email-config usecase', () => {
       })
       const { deps } = makeDeps({ email: { send } })
       const out = await sendTestEmail(deps, platform, 'recipient@example.com')
-      expect(out).toEqual({ ok: false, reason: 'send_failed', message: 'Unknown error' })
+      expect(out.ok).toBe(false)
+      if (out.ok) throw new Error('expected failure')
+      expect(out.error.httpStatus).toBe(400)
+      expect(out.error.message).toBe('Unknown error')
     })
   })
 })

--- a/server/usecases/site/email-config.ts
+++ b/server/usecases/site/email-config.ts
@@ -10,7 +10,15 @@
 // All reads/writes go through the ports — nothing here touches infrastructure.
 
 import type { Platform } from '../../platform/interface'
-import type { EmailConfig, EmailGateway, EmailProvider, SmtpConfig, SystemOptionsRepo } from '../ports'
+import {
+  type AppError,
+  badRequest,
+  type EmailConfig,
+  type EmailGateway,
+  type EmailProvider,
+  type SmtpConfig,
+  type SystemOptionsRepo,
+} from '../ports'
 
 export type EmailConfigDeps = {
   email: EmailGateway
@@ -29,9 +37,9 @@ export type SaveEmailConfigInput =
 export type MaskedEmailSettings = { enabled: boolean } & (Record<string, unknown> | { provider: null })
 
 // A test send either succeeds or fails for a reportable reason (provider error,
-// or email being disabled — the gateway throws for both). The handler turns a
-// failure into a 400 carrying the message.
-export type SendTestEmailOutcome = { ok: true } | { ok: false; reason: 'send_failed'; message: string }
+// or email being disabled — the gateway throws for both). A failure becomes a 400
+// carrying the gateway's message.
+export type SendTestEmailOutcome = { ok: true } | { ok: false; error: AppError }
 
 function maskSecret(value: string): string {
   if (value.length === 0) return ''
@@ -124,7 +132,7 @@ export async function sendTestEmail(
     return { ok: true }
   } catch (e) {
     const message = e instanceof Error ? e.message : 'Unknown error'
-    return { ok: false, reason: 'send_failed', message }
+    return { ok: false, error: badRequest(message) }
   }
 }
 

--- a/server/usecases/site/invitation.test.ts
+++ b/server/usecases/site/invitation.test.ts
@@ -123,7 +123,10 @@ describe('site-invitation usecase', () => {
         email: 'dupe@example.com',
         requestUrl: 'https://app.example.com/api/admin/site-invitations',
       })
-      expect(out).toEqual({ ok: false, reason: 'conflict', message: 'Invitation already exists' })
+      expect(out.ok).toBe(false)
+      if (out.ok) throw new Error('expected failure')
+      expect(out.error.httpStatus).toBe(409)
+      expect(out.error.message).toBe('Invitation already exists')
       expect(send).not.toHaveBeenCalled()
       expect(record).not.toHaveBeenCalled()
     })
@@ -142,7 +145,10 @@ describe('site-invitation usecase', () => {
         email: 'dupe@example.com',
         requestUrl: 'https://app.example.com/api/admin/site-invitations',
       })
-      expect(out).toEqual({ ok: false, reason: 'conflict', message: 'Failed to create invitation' })
+      expect(out.ok).toBe(false)
+      if (out.ok) throw new Error('expected failure')
+      expect(out.error.httpStatus).toBe(409)
+      expect(out.error.message).toBe('Failed to create invitation')
     })
 
     it('propagates when email config validation throws, before creating', async () => {
@@ -183,21 +189,30 @@ describe('site-invitation usecase', () => {
     it('returns not_found and does not send', async () => {
       const { deps, send } = makeDeps({ siteInvitations: { resendSiteInvitation: async () => 'not_found' } })
       const out = await resendSiteInvitation(deps, platform, { id: 'x', requestUrl: 'https://app.example.com/r' })
-      expect(out).toEqual({ ok: false, reason: 'not_found' })
+      expect(out.ok).toBe(false)
+      if (out.ok) throw new Error('expected failure')
+      expect(out.error.httpStatus).toBe(404)
+      expect(out.error.message).toBe('Invitation not found')
       expect(send).not.toHaveBeenCalled()
     })
 
     it('returns already_accepted and does not send', async () => {
       const { deps, send } = makeDeps({ siteInvitations: { resendSiteInvitation: async () => 'already_accepted' } })
       const out = await resendSiteInvitation(deps, platform, { id: 'x', requestUrl: 'https://app.example.com/r' })
-      expect(out).toEqual({ ok: false, reason: 'already_accepted' })
+      expect(out.ok).toBe(false)
+      if (out.ok) throw new Error('expected failure')
+      expect(out.error.httpStatus).toBe(400)
+      expect(out.error.message).toBe('Invitation has already been used')
       expect(send).not.toHaveBeenCalled()
     })
 
     it('returns already_revoked and does not send', async () => {
       const { deps, send } = makeDeps({ siteInvitations: { resendSiteInvitation: async () => 'already_revoked' } })
       const out = await resendSiteInvitation(deps, platform, { id: 'x', requestUrl: 'https://app.example.com/r' })
-      expect(out).toEqual({ ok: false, reason: 'already_revoked' })
+      expect(out.ok).toBe(false)
+      if (out.ok) throw new Error('expected failure')
+      expect(out.error.httpStatus).toBe(400)
+      expect(out.error.message).toBe('Invitation has been revoked')
       expect(send).not.toHaveBeenCalled()
     })
   })
@@ -224,21 +239,30 @@ describe('site-invitation usecase', () => {
     it('returns not_found without recording', async () => {
       const { deps, record } = makeDeps({ siteInvitations: { revokeSiteInvitation: async () => 'not_found' } })
       const out = await revokeSiteInvitation(deps, { userId: 'u1', orgId: 'o1', id: 'x' })
-      expect(out).toEqual({ ok: false, reason: 'not_found' })
+      expect(out.ok).toBe(false)
+      if (out.ok) throw new Error('expected failure')
+      expect(out.error.httpStatus).toBe(404)
+      expect(out.error.message).toBe('Invitation not found')
       expect(record).not.toHaveBeenCalled()
     })
 
     it('returns already_accepted without recording', async () => {
       const { deps, record } = makeDeps({ siteInvitations: { revokeSiteInvitation: async () => 'already_accepted' } })
       const out = await revokeSiteInvitation(deps, { userId: 'u1', orgId: 'o1', id: 'inv-1' })
-      expect(out).toEqual({ ok: false, reason: 'already_accepted' })
+      expect(out.ok).toBe(false)
+      if (out.ok) throw new Error('expected failure')
+      expect(out.error.httpStatus).toBe(400)
+      expect(out.error.message).toBe('Invitation has already been used')
       expect(record).not.toHaveBeenCalled()
     })
 
     it('returns already_revoked without recording', async () => {
       const { deps, record } = makeDeps({ siteInvitations: { revokeSiteInvitation: async () => 'already_revoked' } })
       const out = await revokeSiteInvitation(deps, { userId: 'u1', orgId: 'o1', id: 'inv-1' })
-      expect(out).toEqual({ ok: false, reason: 'already_revoked' })
+      expect(out.ok).toBe(false)
+      if (out.ok) throw new Error('expected failure')
+      expect(out.error.httpStatus).toBe(400)
+      expect(out.error.message).toBe('Invitation has already been revoked')
       expect(record).not.toHaveBeenCalled()
     })
   })

--- a/server/usecases/site/invitation.ts
+++ b/server/usecases/site/invitation.ts
@@ -6,7 +6,15 @@
 
 import type { SiteInvitation } from '@shared/types'
 import type { Platform } from '../../platform/interface'
-import type { ActivityRepo, EmailGateway, SiteInvitationRepo } from '../ports'
+import {
+  type ActivityRepo,
+  type AppError,
+  badRequest,
+  conflict,
+  type EmailGateway,
+  notFound,
+  type SiteInvitationRepo,
+} from '../ports'
 
 export type SiteInvitationDeps = {
   siteInvitations: SiteInvitationRepo
@@ -14,21 +22,13 @@ export type SiteInvitationDeps = {
   activity: ActivityRepo
 }
 
-// createSiteInvitation throws on a duplicate pending invite; the handler turns a
-// thrown error into a 409. Surface the message so it round-trips into the body.
-export type CreateSiteInvitationOutcome =
-  | { ok: true; invitation: SiteInvitation }
-  | { ok: false; reason: 'conflict'; message: string }
+// createSiteInvitation throws on a duplicate pending invite, rendered as a 409
+// carrying the thrown message.
+export type CreateSiteInvitationOutcome = { ok: true; invitation: SiteInvitation } | { ok: false; error: AppError }
 
-// Maps to 404 (not_found) and 400 (already_accepted / already_revoked).
-export type ResendSiteInvitationOutcome =
-  | { ok: true; invitation: SiteInvitation }
-  | { ok: false; reason: 'not_found' | 'already_accepted' | 'already_revoked' }
+export type ResendSiteInvitationOutcome = { ok: true; invitation: SiteInvitation } | { ok: false; error: AppError }
 
-// Maps to 404 (not_found) and 400 (already_accepted / already_revoked).
-export type RevokeSiteInvitationOutcome =
-  | { ok: true; id: string }
-  | { ok: false; reason: 'not_found' | 'already_accepted' | 'already_revoked' }
+export type RevokeSiteInvitationOutcome = { ok: true; id: string } | { ok: false; error: AppError }
 
 function buildSignupInviteEmailHtml(data: { siteName: string; inviteLink: string; expiresAt: string }) {
   return `<div style="font-family:sans-serif;max-width:480px;margin:0 auto;padding:24px">
@@ -86,7 +86,7 @@ export async function createSiteInvitation(
     invitation = await deps.siteInvitations.createSiteInvitation(userId, email)
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to create invitation'
-    return { ok: false, reason: 'conflict', message }
+    return { ok: false, error: conflict(message) }
   }
   await sendSiteInvitationEmail(deps, platform, requestUrl, invitation)
   await deps.activity.record({
@@ -106,9 +106,9 @@ export async function resendSiteInvitation(
   params: { id: string; requestUrl: string },
 ): Promise<ResendSiteInvitationOutcome> {
   const invitation = await deps.siteInvitations.resendSiteInvitation(params.id)
-  if (invitation === 'not_found') return { ok: false, reason: 'not_found' }
-  if (invitation === 'already_accepted') return { ok: false, reason: 'already_accepted' }
-  if (invitation === 'already_revoked') return { ok: false, reason: 'already_revoked' }
+  if (invitation === 'not_found') return { ok: false, error: notFound('Invitation not found') }
+  if (invitation === 'already_accepted') return { ok: false, error: badRequest('Invitation has already been used') }
+  if (invitation === 'already_revoked') return { ok: false, error: badRequest('Invitation has been revoked') }
   await sendSiteInvitationEmail(deps, platform, params.requestUrl, invitation)
   return { ok: true, invitation }
 }
@@ -119,9 +119,9 @@ export async function revokeSiteInvitation(
 ): Promise<RevokeSiteInvitationOutcome> {
   const { userId, orgId, id } = params
   const result = await deps.siteInvitations.revokeSiteInvitation(id, userId)
-  if (result === 'not_found') return { ok: false, reason: 'not_found' }
-  if (result === 'already_accepted') return { ok: false, reason: 'already_accepted' }
-  if (result === 'already_revoked') return { ok: false, reason: 'already_revoked' }
+  if (result === 'not_found') return { ok: false, error: notFound('Invitation not found') }
+  if (result === 'already_accepted') return { ok: false, error: badRequest('Invitation has already been used') }
+  if (result === 'already_revoked') return { ok: false, error: badRequest('Invitation has already been revoked') }
   await deps.activity.record({
     orgId,
     userId,

--- a/server/usecases/site/invite-code.test.ts
+++ b/server/usecases/site/invite-code.test.ts
@@ -115,14 +115,20 @@ describe('invite-code usecase', () => {
     it('returns not_found for a missing code and records no activity', async () => {
       const { deps, record } = makeDeps({ delete: async () => 'not_found' })
       const out = await deleteInviteCode(deps, { userId: 'u1', orgId: 'o1', id: 'x' })
-      expect(out).toEqual({ ok: false, reason: 'not_found' })
+      expect(out.ok).toBe(false)
+      if (out.ok) throw new Error('expected failure')
+      expect(out.error.httpStatus).toBe(404)
+      expect(out.error.message).toBe('Invite code not found')
       expect(record).not.toHaveBeenCalled()
     })
 
     it('returns already_used for a redeemed code and records no activity', async () => {
       const { deps, record } = makeDeps({ delete: async () => 'already_used' })
       const out = await deleteInviteCode(deps, { userId: 'u1', orgId: 'o1', id: 'ic-1' })
-      expect(out).toEqual({ ok: false, reason: 'already_used' })
+      expect(out.ok).toBe(false)
+      if (out.ok) throw new Error('expected failure')
+      expect(out.error.httpStatus).toBe(400)
+      expect(out.error.message).toBe('Cannot delete a used invite code')
       expect(record).not.toHaveBeenCalled()
     })
   })

--- a/server/usecases/site/invite-code.ts
+++ b/server/usecases/site/invite-code.ts
@@ -4,14 +4,21 @@
 // logging — so the http handlers only validate input, call these functions, and
 // serialize the result.
 
-import type { ActivityRepo, InviteCodeRecord, InviteRepo } from '../ports'
+import {
+  type ActivityRepo,
+  type AppError,
+  badRequest,
+  type InviteCodeRecord,
+  type InviteRepo,
+  notFound,
+} from '../ports'
 
 export type InviteCodeDeps = {
   invites: InviteRepo
   activity: ActivityRepo
 }
 
-export type DeleteInviteCodeOutcome = { ok: true } | { ok: false; reason: 'not_found' | 'already_used' }
+export type DeleteInviteCodeOutcome = { ok: true } | { ok: false; error: AppError }
 
 export function listInviteCodes(
   deps: Pick<InviteCodeDeps, 'invites'>,
@@ -51,8 +58,8 @@ export async function deleteInviteCode(
 ): Promise<DeleteInviteCodeOutcome> {
   const { userId, orgId, id } = params
   const result = await deps.invites.delete(id)
-  if (result === 'not_found') return { ok: false, reason: 'not_found' }
-  if (result === 'already_used') return { ok: false, reason: 'already_used' }
+  if (result === 'not_found') return { ok: false, error: notFound('Invite code not found') }
+  if (result === 'already_used') return { ok: false, error: badRequest('Cannot delete a used invite code') }
   await deps.activity.record({
     orgId,
     userId,

--- a/server/usecases/site/licensing-admin.test.ts
+++ b/server/usecases/site/licensing-admin.test.ts
@@ -12,17 +12,36 @@
 import { generateKeys, sign } from 'paseto-ts/v4'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { PUBLIC_KEYS } from '../../domain/license-keys'
-import type {
-  ActivityRepo,
-  CloudInstanceInfo,
-  InstanceRepo,
-  LicenseBindingRepo,
-  LicenseState,
-  LicensingCloudGateway,
-  PairingPollResponse,
-  PairingResponse,
+import {
+  type ActivityRepo,
+  AppError,
+  type CloudInstanceInfo,
+  type InstanceRepo,
+  type LicenseBindingRepo,
+  type LicenseState,
+  type LicensingCloudGateway,
+  type PairingPollResponse,
+  type PairingResponse,
 } from '../ports'
 import { initiatePairing, pollPairing, triggerRefresh, unbindLicense } from './licensing'
+
+// Asserts a rejected pairing carries the 502 INVALID_CERTIFICATE AppError with the
+// rejection reason (+ optional cloud-unbind failure) folded into metadata.
+function expectInvalidCertificate(
+  out: { ok: boolean } & Record<string, unknown>,
+  expected: { certificateReason: string; cloudUnbindError?: string },
+) {
+  expect(out.ok).toBe(false)
+  const error = (out as unknown as { error: AppError }).error
+  expect(error).toBeInstanceOf(AppError)
+  expect(error.httpStatus).toBe(502)
+  expect(error.message).toBe('Invalid certificate')
+  expect(error.meta.reason).toBe('INVALID_CERTIFICATE')
+  expect(error.meta.metadata).toEqual({
+    certificateReason: expected.certificateReason,
+    ...(expected.cloudUnbindError ? { cloudUnbindError: expected.cloudUnbindError } : {}),
+  })
+}
 
 const BASE_URL = 'https://cloud.zpan.space'
 const INSTANCE_ID = 'inst-1'
@@ -280,7 +299,7 @@ describe('pollPairing', () => {
 
     const out = await pollPairing(deps, params)
 
-    expect(out).toEqual({ ok: false, reason: 'signature', cloudUnbindError: null })
+    expectInvalidCertificate(out, { certificateReason: 'signature' })
     expect(cloud.unbindCloudLicense).toHaveBeenCalledWith(BASE_URL, 'cb-1', 'rt-secret')
     expect(createLicenseBinding).not.toHaveBeenCalled()
     expect(record).not.toHaveBeenCalled()
@@ -300,7 +319,7 @@ describe('pollPairing', () => {
 
     const out = await pollPairing(deps, params)
 
-    expect(out).toEqual({ ok: false, reason: 'instance', cloudUnbindError: null })
+    expectInvalidCertificate(out, { certificateReason: 'instance' })
   })
 
   it('reports no_certificate when the approval omits the cert (nothing to roll back)', async () => {
@@ -312,7 +331,7 @@ describe('pollPairing', () => {
     const out = await pollPairing(deps, params)
 
     // No binding.id on the response → rollback is a no-op (null).
-    expect(out).toEqual({ ok: false, reason: 'no_certificate', cloudUnbindError: null })
+    expectInvalidCertificate(out, { certificateReason: 'no_certificate' })
     expect(cloud.unbindCloudLicense).not.toHaveBeenCalled()
     expect(createLicenseBinding).not.toHaveBeenCalled()
   })
@@ -325,7 +344,7 @@ describe('pollPairing', () => {
 
     const out = await pollPairing(deps, params)
 
-    expect(out).toEqual({ ok: false, reason: 'incomplete_response', cloudUnbindError: null })
+    expectInvalidCertificate(out, { certificateReason: 'incomplete_response' })
   })
 
   it('captures the cloud-unbind failure message during rollback', async () => {
@@ -345,7 +364,7 @@ describe('pollPairing', () => {
 
     const out = await pollPairing(deps, params)
 
-    expect(out).toEqual({ ok: false, reason: 'signature', cloudUnbindError: 'cloud rejected unbind' })
+    expectInvalidCertificate(out, { certificateReason: 'signature', cloudUnbindError: 'cloud rejected unbind' })
   })
 })
 

--- a/server/usecases/site/licensing.ts
+++ b/server/usecases/site/licensing.ts
@@ -11,6 +11,7 @@ import { getTrustedPublicKeys } from '../../domain/license-keys'
 import { effectiveFeatures, hasFeature } from '../../domain/licensing'
 import {
   type ActivityRepo,
+  AppError,
   type CloudInstanceInfo,
   CloudInvalidResponseError,
   CloudNetworkError,
@@ -427,11 +428,20 @@ export interface PollPairingParams {
 export type PollPairingOutcome =
   | { ok: true; status: 'approved'; edition: LicenseEdition; cloudStoreId: string }
   | { ok: true; status: 'pending' | 'denied' | 'expired' }
-  | {
-      ok: false
-      reason: CertificateRejectionReason | 'incomplete_response' | 'no_certificate'
-      cloudUnbindError: string | null
-    }
+  | { ok: false; error: AppError }
+
+// A rejected pairing certificate always renders 502 INVALID_CERTIFICATE; the
+// specific rejection reason and any best-effort cloud-unbind failure ride along
+// as metadata for diagnostics.
+function invalidCertificate(
+  certificateReason: CertificateRejectionReason | 'incomplete_response' | 'no_certificate',
+  cloudUnbindError: string | null,
+): AppError {
+  return new AppError(502, 'Invalid certificate', {
+    reason: 'INVALID_CERTIFICATE',
+    metadata: { certificateReason, ...(cloudUnbindError ? { cloudUnbindError } : {}) },
+  })
+}
 
 // Polls a pairing code. On approval it verifies the returned certificate, and on
 // success persists the binding, best-effort confirms with the cloud, and records
@@ -458,7 +468,7 @@ export async function pollPairing(deps: PollPairingDeps, params: PollPairingPara
   if (!verification?.ok || !result.refreshToken || !result.binding?.storeId || !result.account) {
     const cloudUnbindError = await rollbackCloudBinding(deps.licensingCloud, baseUrl, result)
     const reason = verification ? (verification.ok ? 'incomplete_response' : verification.reason) : 'no_certificate'
-    return { ok: false, reason, cloudUnbindError }
+    return { ok: false, error: invalidCertificate(reason, cloudUnbindError) }
   }
 
   const assertion = verification.assertion

--- a/server/usecases/site/storage.test.ts
+++ b/server/usecases/site/storage.test.ts
@@ -3,6 +3,7 @@ import type { CreateStorageInput } from '@shared/schemas'
 import type { BindingState } from '@shared/types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ActivityRepo, LicenseBindingRepo, StorageRecord, StorageRepo } from '../ports'
+import { AppError } from '../ports'
 import { loadBindingState } from './licensing'
 import { createStorage, deleteStorage, getStorage, listStorages, type StorageDeps, updateStorage } from './storage'
 
@@ -85,11 +86,17 @@ describe('storage usecase', () => {
       edition(COMMUNITY)
       const { deps, record } = makeDeps({ count: async () => FREE_STORAGE_LIMIT })
       const out = await createStorage(deps, { userId: 'u1', orgId: 'o1', input: validInput })
-      expect(out).toEqual({
-        ok: false,
-        reason: 'feature_blocked',
-        block: { feature: 'storages_unlimited', currentCount: FREE_STORAGE_LIMIT, limit: FREE_STORAGE_LIMIT },
-      })
+      expect(out.ok).toBe(false)
+      if (!out.ok) {
+        expect(out.error).toBeInstanceOf(AppError)
+        expect(out.error.httpStatus).toBe(402)
+        expect(out.error.meta.reason).toBe('FEATURE_NOT_AVAILABLE')
+        expect(out.error.meta.metadata).toEqual({
+          feature: 'storages_unlimited',
+          currentCount: String(FREE_STORAGE_LIMIT),
+          limit: String(FREE_STORAGE_LIMIT),
+        })
+      }
       expect(record).not.toHaveBeenCalled()
     })
 
@@ -110,7 +117,13 @@ describe('storage usecase', () => {
         orgId: 'o1',
         input: { ...validInput, egressCreditBillingEnabled: true },
       })
-      expect(out).toEqual({ ok: false, reason: 'feature_blocked', block: { feature: 'quota_store' } })
+      expect(out.ok).toBe(false)
+      if (!out.ok) {
+        expect(out.error).toBeInstanceOf(AppError)
+        expect(out.error.httpStatus).toBe(402)
+        expect(out.error.meta.reason).toBe('FEATURE_NOT_AVAILABLE')
+        expect(out.error.meta.metadata).toEqual({ feature: 'quota_store' })
+      }
       expect(record).not.toHaveBeenCalled()
     })
 
@@ -142,7 +155,12 @@ describe('storage usecase', () => {
       edition(COMMUNITY)
       const { deps, record } = makeDeps({ update: async () => null })
       const out = await updateStorage(deps, { userId: 'u1', orgId: 'o1', id: 'x', input: { title: 'New' } })
-      expect(out).toEqual({ ok: false, reason: 'not_found' })
+      expect(out.ok).toBe(false)
+      if (!out.ok) {
+        expect(out.error).toBeInstanceOf(AppError)
+        expect(out.error.httpStatus).toBe(404)
+        expect(out.error.message).toBe('Storage not found')
+      }
       expect(record).not.toHaveBeenCalled()
     })
 
@@ -156,7 +174,13 @@ describe('storage usecase', () => {
         id: 'x',
         input: { egressCreditBillingEnabled: true },
       })
-      expect(out).toEqual({ ok: false, reason: 'feature_blocked', block: { feature: 'quota_store' } })
+      expect(out.ok).toBe(false)
+      if (!out.ok) {
+        expect(out.error).toBeInstanceOf(AppError)
+        expect(out.error.httpStatus).toBe(402)
+        expect(out.error.meta.reason).toBe('FEATURE_NOT_AVAILABLE')
+        expect(out.error.meta.metadata).toEqual({ feature: 'quota_store' })
+      }
       expect(update).not.toHaveBeenCalled()
     })
   })
@@ -175,14 +199,24 @@ describe('storage usecase', () => {
     it('returns not_found for a missing storage', async () => {
       const { deps, record } = makeDeps({ get: async () => null, delete: async () => 'not_found' })
       const out = await deleteStorage(deps, { userId: 'u1', orgId: 'o1', id: 'x' })
-      expect(out).toEqual({ ok: false, reason: 'not_found' })
+      expect(out.ok).toBe(false)
+      if (!out.ok) {
+        expect(out.error).toBeInstanceOf(AppError)
+        expect(out.error.httpStatus).toBe(404)
+        expect(out.error.message).toBe('Storage not found')
+      }
       expect(record).not.toHaveBeenCalled()
     })
 
     it('returns in_use when the storage is referenced', async () => {
       const { deps, record } = makeDeps({ get: async () => sampleStorage, delete: async () => 'in_use' })
       const out = await deleteStorage(deps, { userId: 'u1', orgId: 'o1', id: 'st-1' })
-      expect(out).toEqual({ ok: false, reason: 'in_use' })
+      expect(out.ok).toBe(false)
+      if (!out.ok) {
+        expect(out.error).toBeInstanceOf(AppError)
+        expect(out.error.httpStatus).toBe(409)
+        expect(out.error.message).toBe('Storage is referenced by existing files')
+      }
       expect(record).not.toHaveBeenCalled()
     })
   })

--- a/server/usecases/site/storage.ts
+++ b/server/usecases/site/storage.ts
@@ -2,6 +2,7 @@
 // /api/admin/storages routes — the Community storage-count limit, the
 // egress-credit-billing feature gate, and activity logging — so the http
 // handlers only validate input, call these functions, and serialize the result.
+// Expected failures come back as a returned AppError the handler throws.
 //
 // Not to be confused with storage-usage.ts, which is the reusable
 // quota-reservation operation consumed by the objects/matter flows. This file is
@@ -10,7 +11,16 @@
 import { FREE_STORAGE_LIMIT } from '@shared/constants'
 import type { CreateStorageInput, UpdateStorageInput } from '@shared/schemas'
 import { hasFeature } from '../../domain/licensing'
-import type { ActivityRepo, LicenseBindingRepo, StorageRecord, StorageRepo } from '../ports'
+import {
+  type ActivityRepo,
+  type AppError,
+  conflict,
+  featureBlocked,
+  type LicenseBindingRepo,
+  type StorageRecord,
+  type StorageRepo,
+  storageNotFound,
+} from '../ports'
 import { loadBindingState } from './licensing'
 
 export type StorageDeps = {
@@ -20,22 +30,28 @@ export type StorageDeps = {
 }
 
 // The license feature that gates a storage write, plus the payload its 402
-// carries. The http layer turns this into the `feature_not_available` body; the
-// decision of *whether* a feature is required lives here.
+// carries. The decision of *whether* a feature is required lives here; the error
+// factory below bakes the feature_not_available body + metadata.
 export type StorageFeatureBlock =
   | { feature: 'storages_unlimited'; currentCount: number; limit: number }
   | { feature: 'quota_store' }
 
-export type CreateStorageOutcome =
-  | { ok: true; storage: StorageRecord }
-  | { ok: false; reason: 'feature_blocked'; block: StorageFeatureBlock }
+export type CreateStorageOutcome = { ok: true; storage: StorageRecord } | { ok: false; error: AppError }
 
-export type UpdateStorageOutcome =
-  | { ok: true; storage: StorageRecord }
-  | { ok: false; reason: 'not_found' }
-  | { ok: false; reason: 'feature_blocked'; block: StorageFeatureBlock }
+export type UpdateStorageOutcome = { ok: true; storage: StorageRecord } | { ok: false; error: AppError }
 
-export type DeleteStorageOutcome = { ok: true } | { ok: false; reason: 'not_found' | 'in_use' }
+export type DeleteStorageOutcome = { ok: true } | { ok: false; error: AppError }
+
+// The 402 body for a blocked storage write — the same metadata the handler used
+// to assemble, now built once where the block is raised.
+function featureBlockError(block: StorageFeatureBlock): AppError {
+  const metadata: Record<string, string> = {
+    feature: block.feature,
+    ...('currentCount' in block ? { currentCount: String(block.currentCount) } : {}),
+    ...('limit' in block ? { limit: String(block.limit) } : {}),
+  }
+  return featureBlocked('Feature not available', { metadata })
+}
 
 // Egress-credit billing is a paid capability; turning it on requires quota_store.
 function enablesEgressCreditBilling(input: { egressCreditBillingEnabled?: boolean }): boolean {
@@ -62,12 +78,11 @@ export async function createStorage(
   if (!hasFeature('storages_unlimited', state) && total >= FREE_STORAGE_LIMIT) {
     return {
       ok: false,
-      reason: 'feature_blocked',
-      block: { feature: 'storages_unlimited', currentCount: total, limit: FREE_STORAGE_LIMIT },
+      error: featureBlockError({ feature: 'storages_unlimited', currentCount: total, limit: FREE_STORAGE_LIMIT }),
     }
   }
   if (enablesEgressCreditBilling(input) && !hasFeature('quota_store', state)) {
-    return { ok: false, reason: 'feature_blocked', block: { feature: 'quota_store' } }
+    return { ok: false, error: featureBlockError({ feature: 'quota_store' }) }
   }
   const storage = await deps.storages.create(input)
   await deps.activity.record({
@@ -92,10 +107,10 @@ export async function updateStorage(
     enablesEgressCreditBilling(input) &&
     !hasFeature('quota_store', await loadBindingState({ licenseBinding: deps.licenseBinding }))
   ) {
-    return { ok: false, reason: 'feature_blocked', block: { feature: 'quota_store' } }
+    return { ok: false, error: featureBlockError({ feature: 'quota_store' }) }
   }
   const storage = await deps.storages.update(id, input)
-  if (!storage) return { ok: false, reason: 'not_found' }
+  if (!storage) return { ok: false, error: storageNotFound() }
   await deps.activity.record({
     orgId,
     userId,
@@ -115,8 +130,8 @@ export async function deleteStorage(
   const { userId, orgId, id } = params
   const existing = await deps.storages.get(id)
   const result = await deps.storages.delete(id)
-  if (result === 'not_found') return { ok: false, reason: 'not_found' }
-  if (result === 'in_use') return { ok: false, reason: 'in_use' }
+  if (result === 'not_found') return { ok: false, error: storageNotFound() }
+  if (result === 'in_use') return { ok: false, error: conflict('Storage is referenced by existing files') }
   await deps.activity.record({
     orgId,
     userId,

--- a/server/usecases/site/system.test.ts
+++ b/server/usecases/site/system.test.ts
@@ -10,6 +10,7 @@ import type { BindingState } from '@shared/types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getAppVersion } from '../../version'
 import type { ActivityRepo, ChangelogProvider, InstanceRepo, SystemOption, SystemOptionsRepo } from '../ports'
+import { AppError } from '../ports'
 import { loadBindingState } from './licensing'
 import {
   deleteSystemOption,
@@ -132,9 +133,15 @@ describe('system usecase', () => {
   })
 
   describe('getSystemOption', () => {
-    it('returns not_found when the key is absent', async () => {
+    it('returns a 404 AppError when the key is absent', async () => {
       const { deps } = makeDeps({ get: async () => null })
-      expect(await getSystemOption(deps, { key: 'missing', isAdmin: true })).toEqual({ ok: false, reason: 'not_found' })
+      const out = await getSystemOption(deps, { key: 'missing', isAdmin: true })
+      expect(out.ok).toBe(false)
+      if (!out.ok) {
+        expect(out.error).toBeInstanceOf(AppError)
+        expect(out.error.httpStatus).toBe(404)
+        expect(out.error.message).toBe('Option not found')
+      }
     })
 
     it('returns the option to anyone when it is public', async () => {
@@ -145,10 +152,12 @@ describe('system usecase', () => {
 
     it('forbids a non-admin from reading a private option', async () => {
       const { deps } = makeDeps({ get: async () => option({ key: 'smtp_password', public: false }) })
-      expect(await getSystemOption(deps, { key: 'smtp_password', isAdmin: false })).toEqual({
-        ok: false,
-        reason: 'forbidden',
-      })
+      const out = await getSystemOption(deps, { key: 'smtp_password', isAdmin: false })
+      expect(out.ok).toBe(false)
+      if (!out.ok) {
+        expect(out.error).toBeInstanceOf(AppError)
+        expect(out.error.httpStatus).toBe(403)
+      }
     })
 
     it('lets an admin read a private option', async () => {
@@ -194,7 +203,13 @@ describe('system usecase', () => {
       const set = vi.fn(async () => {})
       const { deps, record } = makeDeps({ set })
       const out = await setSystemOption(deps, { ...base, key: 'auth_signup_mode', value: SignupMode.OPEN })
-      expect(out).toEqual({ ok: false, reason: 'feature_blocked', feature: 'open_registration' })
+      expect(out.ok).toBe(false)
+      if (!out.ok) {
+        expect(out.error).toBeInstanceOf(AppError)
+        expect(out.error.httpStatus).toBe(402)
+        expect(out.error.meta.reason).toBe('FEATURE_NOT_AVAILABLE')
+        expect(out.error.meta.metadata).toEqual({ feature: 'open_registration', upgradeUrl: '/settings/billing' })
+      }
       expect(set).not.toHaveBeenCalled()
       expect(record).not.toHaveBeenCalled()
     })
@@ -246,7 +261,10 @@ describe('system usecase', () => {
       const { deps } = makeDeps({ set, listByKeyLike: async () => [] })
       const out = await setSystemOption(deps, { ...base, key: CAPTCHA_ENABLED_KEY, value: 'true' })
       expect(out.ok).toBe(false)
-      expect(out).toMatchObject({ reason: 'invalid' })
+      if (!out.ok) {
+        expect(out.error).toBeInstanceOf(AppError)
+        expect(out.error.httpStatus).toBe(400)
+      }
       expect(set).not.toHaveBeenCalled()
     })
 
@@ -273,7 +291,8 @@ describe('system usecase', () => {
         ],
       })
       const out = await setSystemOption(deps, { ...base, key: CAPTCHA_MIN_SCORE_KEY, value: '5' })
-      expect(out).toMatchObject({ ok: false, reason: 'invalid' })
+      expect(out.ok).toBe(false)
+      if (!out.ok) expect(out.error.httpStatus).toBe(400)
       expect(set).not.toHaveBeenCalled()
     })
 
@@ -283,11 +302,12 @@ describe('system usecase', () => {
       const { deps } = makeDeps({ set })
       for (const value of ['0', '-1', '1.5', 'abc']) {
         const out = await setSystemOption(deps, { ...base, key: 'default_org_quota', value })
-        expect(out).toEqual({
-          ok: false,
-          reason: 'invalid',
-          message: 'Default organization quota must be a positive number',
-        })
+        expect(out.ok).toBe(false)
+        if (!out.ok) {
+          expect(out.error).toBeInstanceOf(AppError)
+          expect(out.error.httpStatus).toBe(400)
+          expect(out.error.message).toBe('Default organization quota must be a positive number')
+        }
       }
       expect(set).not.toHaveBeenCalled()
     })
@@ -323,7 +343,8 @@ describe('system usecase', () => {
       const { deps } = makeDeps({ set })
       for (const value of ['', '   ', '-1', '1.5', 'abc']) {
         const out = await setSystemOption(deps, { ...base, key: 'default_org_monthly_traffic_quota', value })
-        expect(out).toMatchObject({ ok: false, reason: 'invalid' })
+        expect(out.ok).toBe(false)
+        if (!out.ok) expect(out.error.httpStatus).toBe(400)
       }
       expect(set).not.toHaveBeenCalled()
     })

--- a/server/usecases/site/system.ts
+++ b/server/usecases/site/system.ts
@@ -3,7 +3,7 @@
 // check, system-option visibility rules, and the option-write pipeline (signup
 // Pro gate, captcha key visibility + validation, quota validation, persistence +
 // activity logging). The http handlers only parse input, call these functions,
-// and map the discriminated outcomes onto HTTP statuses.
+// and throw the returned AppError on failure.
 
 import {
   CAPTCHA_ENABLED_KEY,
@@ -19,7 +19,18 @@ import { readCaptchaConfig } from '../../domain/captcha'
 import { hasFeature } from '../../domain/licensing'
 import { originFromRequestUrl } from '../../domain/site-public-origin'
 import { getAppVersion } from '../../version'
-import type { ActivityRepo, ChangelogProvider, InstanceRepo, LicenseBindingRepo, SystemOptionsRepo } from '../ports'
+import {
+  type ActivityRepo,
+  type AppError,
+  badRequest,
+  type ChangelogProvider,
+  featureBlocked,
+  forbidden,
+  type InstanceRepo,
+  type LicenseBindingRepo,
+  notFound,
+  type SystemOptionsRepo,
+} from '../ports'
 import { loadCaptchaOptionValues } from './captcha'
 import { buildInstanceInfo, type runtimeInfo } from './instance-info'
 import { loadBindingState } from './licensing'
@@ -83,18 +94,15 @@ export async function listSystemOptions(
   return { items, total: items.length }
 }
 
-export type GetSystemOptionOutcome =
-  | { ok: true; option: SystemOptionView }
-  | { ok: false; reason: 'not_found' }
-  | { ok: false; reason: 'forbidden' }
+export type GetSystemOptionOutcome = { ok: true; option: SystemOptionView } | { ok: false; error: AppError }
 
 export async function getSystemOption(
   deps: Pick<SystemDeps, 'systemOptions'>,
   params: { key: string; isAdmin: boolean },
 ): Promise<GetSystemOptionOutcome> {
   const row = await deps.systemOptions.get(params.key)
-  if (!row) return { ok: false, reason: 'not_found' }
-  if (!row.public && !params.isAdmin) return { ok: false, reason: 'forbidden' }
+  if (!row) return { ok: false, error: notFound('Option not found') }
+  if (!row.public && !params.isAdmin) return { ok: false, error: forbidden() }
   return { ok: true, option: { key: row.key, value: row.value, public: row.public } }
 }
 
@@ -102,8 +110,13 @@ export async function getSystemOption(
 
 export type SetSystemOptionOutcome =
   | { ok: true; created: boolean; option: SystemOptionView }
-  | { ok: false; reason: 'feature_blocked'; feature: 'open_registration' }
-  | { ok: false; reason: 'invalid'; message: string }
+  | { ok: false; error: AppError }
+
+// Opening signup is a Pro capability; the 402 body points to billing.
+const signupFeatureBlock = () =>
+  featureBlocked('Feature not available', {
+    metadata: { feature: 'open_registration', upgradeUrl: '/settings/billing' },
+  })
 
 // Opening signup to the public is a Pro capability; setting auth_signup_mode to
 // `open` without the feature is blocked. Other modes/values pass freely.
@@ -174,16 +187,16 @@ export async function setSystemOption(
   const { userId, orgId, key } = params
 
   if (await signupModeBlocked(deps, key, params.value)) {
-    return { ok: false, reason: 'feature_blocked', feature: 'open_registration' }
+    return { ok: false, error: signupFeatureBlock() }
   }
 
   const isPublic = resolveCaptchaVisibility(key, params.public)
 
   const captchaError = await validateCaptchaOption(deps, key, params.value)
-  if (captchaError) return { ok: false, reason: 'invalid', message: captchaError.message }
+  if (captchaError) return { ok: false, error: badRequest(captchaError.message) }
 
   const { value, error: quotaError } = validateQuotaOption(key, params.value)
-  if (quotaError) return { ok: false, reason: 'invalid', message: quotaError }
+  if (quotaError) return { ok: false, error: badRequest(quotaError) }
 
   const existing = await deps.systemOptions.get(key)
   const nextPublic = !!(isPublic ?? existing?.public ?? false)

--- a/server/usecases/store/store.test.ts
+++ b/server/usecases/store/store.test.ts
@@ -1,7 +1,28 @@
 import type { CloudOrderQuotaChange } from '@shared/schemas'
 import type { CloudStoreTarget } from '@shared/types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { CloudStoreBinding, CloudStoreRepo, EffectiveQuota, LicensingCloudGateway, QuotaRepo } from '../ports'
+import {
+  AppError,
+  type CloudStoreBinding,
+  type CloudStoreRepo,
+  type EffectiveQuota,
+  type LicensingCloudGateway,
+  type QuotaRepo,
+} from '../ports'
+
+// Asserts a failed outcome carries the expected AppError (status / reason / message).
+function expectError(
+  out: { ok: boolean } & Record<string, unknown>,
+  expected: { httpStatus: number; reason?: string; message: string },
+) {
+  expect(out.ok).toBe(false)
+  const error = (out as unknown as { error: AppError }).error
+  expect(error).toBeInstanceOf(AppError)
+  expect(error.httpStatus).toBe(expected.httpStatus)
+  expect(error.meta.reason).toBe(expected.reason)
+  expect(error.message).toBe(expected.message)
+}
+
 import { verifyCloudEventToken } from '../site/licensing'
 import {
   type CloudStoreDeps,
@@ -181,25 +202,17 @@ describe('cloud-store usecase', () => {
 
     it('listPackages returns binding_missing when unbound', async () => {
       const { deps } = makeDeps({ binding: 'missing' })
-      expect(await listPackages(deps, CLOUD)).toEqual({
-        ok: false,
-        reason: 'binding_missing',
-        error: 'quota_store_binding_missing',
-      })
+      expectError(await listPackages(deps, CLOUD), { httpStatus: 403, message: 'quota_store_binding_missing' })
     })
 
     it('listPackages surfaces a cloud error', async () => {
       const { deps } = makeDeps({ responses: [fail(503, { error: 'cloud_down' })] })
-      expect(await listPackages(deps, CLOUD)).toEqual({ ok: false, reason: 'cloud_error', error: 'cloud_down' })
+      expectError(await listPackages(deps, CLOUD), { httpStatus: 502, message: 'cloud_down' })
     })
 
     it('listPackages surfaces a malformed cloud response', async () => {
       const { deps } = makeDeps({ responses: [ok({ nope: true })] })
-      expect(await listPackages(deps, CLOUD)).toEqual({
-        ok: false,
-        reason: 'cloud_error',
-        error: 'invalid_cloud_response',
-      })
+      expectError(await listPackages(deps, CLOUD), { httpStatus: 502, message: 'invalid_cloud_response' })
     })
 
     it('listTargets returns the accessible targets without a cloud call', async () => {
@@ -244,7 +257,7 @@ describe('cloud-store usecase', () => {
         origin: 'https://files.example',
         input: { packageId: 'pkg-1' },
       })
-      expect(out).toEqual({ ok: false, reason: 'binding_missing', error: 'quota_store_binding_missing' })
+      expectError(out, { httpStatus: 403, message: 'quota_store_binding_missing' })
     })
 
     it('returns price_missing when the requested priceId is not on the product', async () => {
@@ -255,7 +268,7 @@ describe('cloud-store usecase', () => {
         origin: 'https://files.example',
         input: { packageId: 'pkg-1', priceId: 'price-does-not-exist' },
       })
-      expect(out).toEqual({ ok: false, reason: 'price_missing' })
+      expectError(out, { httpStatus: 400, reason: 'PACKAGE_PRICE_MISSING', message: 'Package price missing' })
     })
 
     it('returns price_missing when the only USD price is metered', async () => {
@@ -276,7 +289,7 @@ describe('cloud-store usecase', () => {
         origin: 'https://files.example',
         input: { packageId: 'pkg-1' },
       })
-      expect(out).toEqual({ ok: false, reason: 'price_missing' })
+      expectError(out, { httpStatus: 400, reason: 'PACKAGE_PRICE_MISSING', message: 'Package price missing' })
     })
 
     it('rejects a recurring checkout when the workspace already has a subscription plan', async () => {
@@ -287,7 +300,7 @@ describe('cloud-store usecase', () => {
         origin: 'https://files.example',
         input: { packageId: 'pkg-1' },
       })
-      expect(out).toEqual({ ok: false, reason: 'workspace_plan_exists' })
+      expectError(out, { httpStatus: 409, reason: 'WORKSPACE_PLAN_EXISTS', message: 'Workspace plan already exists' })
     })
 
     it('surfaces a cloud error from order creation', async () => {
@@ -298,7 +311,7 @@ describe('cloud-store usecase', () => {
         origin: 'https://files.example',
         input: { packageId: 'pkg-1' },
       })
-      expect(out).toEqual({ ok: false, reason: 'cloud_error', error: 'cloud_down' })
+      expectError(out, { httpStatus: 502, message: 'cloud_down' })
     })
 
     it('allows a one-time (non-recurring) price without consulting quota', async () => {
@@ -321,7 +334,7 @@ describe('cloud-store usecase', () => {
     it('continueOrderPayment returns not_found for an empty orderId', async () => {
       const { deps } = makeDeps()
       const out = await continueOrderPayment(deps, CLOUD, { orgId: 'org-1', orderId: undefined, origin: 'o' })
-      expect(out).toEqual({ ok: false, reason: 'not_found' })
+      expectError(out, { httpStatus: 404, message: 'Order not found' })
     })
 
     it('continueOrderPayment rejects an order belonging to another org', async () => {
@@ -331,7 +344,7 @@ describe('cloud-store usecase', () => {
         orderId: 'order-1',
         origin: 'https://files.example',
       })
-      expect(out).toEqual({ ok: false, reason: 'forbidden' })
+      expectError(out, { httpStatus: 403, message: 'Forbidden' })
     })
 
     it('continueOrderPayment continues payment for an owned order', async () => {
@@ -351,7 +364,7 @@ describe('cloud-store usecase', () => {
         orderId: 'order-1',
         origin: 'https://files.example',
       })
-      expect(out).toEqual({ ok: false, reason: 'cloud_error', error: 'cloud_down' })
+      expectError(out, { httpStatus: 502, message: 'cloud_down' })
     })
 
     it('cancelOrder cancels an owned order', async () => {
@@ -364,7 +377,7 @@ describe('cloud-store usecase', () => {
     it('cancelOrder rejects another org order', async () => {
       const { deps } = makeDeps({ responses: [ok(order({ target: { orgId: 'org-other' } }))] })
       const out = await cancelOrder(deps, CLOUD, { orgId: 'org-1', orderId: 'order-1', status: 'canceled' })
-      expect(out).toEqual({ ok: false, reason: 'forbidden' })
+      expectError(out, { httpStatus: 403, message: 'Forbidden' })
     })
   })
 
@@ -400,7 +413,7 @@ describe('cloud-store usecase', () => {
       rejected()
       const { deps, processCloudOrderQuotaChange } = makeDeps()
       const out = await processDeliveryWebhook(deps, params(validEvent))
-      expect(out).toEqual({ ok: false, reason: 'invalid_token' })
+      expectError(out, { httpStatus: 401, reason: 'INVALID_EVENT_TOKEN', message: 'Invalid event token' })
       expect(processCloudOrderQuotaChange).not.toHaveBeenCalled()
     })
 
@@ -408,21 +421,21 @@ describe('cloud-store usecase', () => {
       verified('evt-1')
       const { deps } = makeDeps()
       const out = await processDeliveryWebhook(deps, params(null))
-      expect(out).toEqual({ ok: false, reason: 'invalid_payload' })
+      expectError(out, { httpStatus: 400, reason: 'INVALID_PAYLOAD', message: 'Invalid payload' })
     })
 
     it('rejects a body that fails the quota-change schema', async () => {
       verified('evt-1')
       const { deps } = makeDeps()
       const out = await processDeliveryWebhook(deps, params({ eventId: 'evt-1' }))
-      expect(out).toEqual({ ok: false, reason: 'invalid_payload' })
+      expectError(out, { httpStatus: 400, reason: 'INVALID_PAYLOAD', message: 'Invalid payload' })
     })
 
     it('rejects a body whose eventId differs from the token eventId', async () => {
       verified('evt-token')
       const { deps, processCloudOrderQuotaChange } = makeDeps()
       const out = await processDeliveryWebhook(deps, params(validEvent))
-      expect(out).toEqual({ ok: false, reason: 'invalid_token' })
+      expectError(out, { httpStatus: 401, reason: 'INVALID_EVENT_TOKEN', message: 'Invalid event token' })
       expect(processCloudOrderQuotaChange).not.toHaveBeenCalled()
     })
 
@@ -449,7 +462,7 @@ describe('cloud-store usecase', () => {
       verified('evt-1')
       const { deps } = makeDeps({ processThrows: new Error('webhook_payload_conflict') })
       const out = await processDeliveryWebhook(deps, params(validEvent))
-      expect(out).toEqual({ ok: false, reason: 'processing_failed', error: 'webhook_payload_conflict' })
+      expectError(out, { httpStatus: 400, message: 'webhook_payload_conflict' })
     })
 
     it('passes the bound license + payload hash to token verification', async () => {

--- a/server/usecases/store/store.ts
+++ b/server/usecases/store/store.ts
@@ -34,7 +34,17 @@ import {
   paymentCreateResponseSchema,
   productListResponseSchema,
 } from 'zpan-cloud-sdk'
-import type { CloudStoreRepo, LicensingCloudGateway, QuotaRepo } from '../ports'
+import {
+  AppError,
+  badGateway,
+  badRequest,
+  type CloudStoreRepo,
+  conflict,
+  forbidden,
+  type LicensingCloudGateway,
+  notFound,
+  type QuotaRepo,
+} from '../ports'
 import { verifyCloudEventToken } from '../site/licensing'
 
 // The Cloud commerce response schemas. Aliased to keep call sites readable; the
@@ -60,13 +70,10 @@ export type BoundCloudClient = { client: CloudClient; storeId: string }
 
 type CloudError = { error: string }
 
-// Storefront proxy outcomes. `binding_missing` → 403 (store not yet bound to
-// Cloud), `cloud_error` → 502 (the upstream Cloud request failed or returned a
-// malformed body). Each endpoint layers its own pre-cloud guards on top.
-export type StorefrontReadOutcome<T> =
-  | { ok: true; value: T }
-  | { ok: false; reason: 'binding_missing'; error: string }
-  | { ok: false; reason: 'cloud_error'; error: string }
+// Storefront proxy outcomes. An unbound store renders 403 (`forbidden`); an
+// upstream Cloud failure or malformed body renders 502 (`badGateway`). Each
+// endpoint layers its own pre-cloud guards on top.
+export type StorefrontReadOutcome<T> = { ok: true; value: T } | { ok: false; error: AppError }
 
 // ─── Cloud-proxy plumbing (port access) ──────────────────────────────────────
 
@@ -168,7 +175,7 @@ async function listDeliverables(
   deliverableType: 'zpan.plan' | 'zpan.credits',
 ): Promise<StorefrontReadOutcome<{ items: unknown[]; total: number }>> {
   const ready = await getStoreReadiness(deps)
-  if (!ready.ready) return { ok: false, reason: 'binding_missing', error: ready.error }
+  if (!ready.ready) return { ok: false, error: forbidden(ready.error) }
   const result = await cloudRequest(deps, cloudBaseUrl, async ({ client, storeId }) =>
     unwrapCloudResponse(
       await client.stores[':storeId'].products.$get({
@@ -178,7 +185,7 @@ async function listDeliverables(
       cloudPackageListResponseSchema,
     ),
   )
-  if (isCloudError(result)) return { ok: false, reason: 'cloud_error', error: result.error }
+  if (isCloudError(result)) return { ok: false, error: badGateway(result.error) }
   const items = result.items.filter((item) => item.metadata.deliverable.type === deliverableType)
   return { ok: true, value: { ...result, items, total: items.length } }
 }
@@ -196,7 +203,7 @@ export async function listTargets(
   userId: string,
 ): Promise<StorefrontReadOutcome<{ items: CloudStoreTarget[]; total: number }>> {
   const ready = await getStoreReadiness(deps)
-  if (!ready.ready) return { ok: false, reason: 'binding_missing', error: ready.error }
+  if (!ready.ready) return { ok: false, error: forbidden(ready.error) }
   const items = await deps.cloudStore.getAccessibleTargets(userId)
   return { ok: true, value: { items, total: items.length } }
 }
@@ -211,7 +218,7 @@ export async function getCreditBalance(
   orgId: string,
 ): Promise<StorefrontReadOutcome<unknown>> {
   const ready = await getStoreReadiness(deps)
-  if (!ready.ready) return { ok: false, reason: 'binding_missing', error: ready.error }
+  if (!ready.ready) return { ok: false, error: forbidden(ready.error) }
   const result = await cloudRequest(deps, cloudBaseUrl, async ({ client, storeId }) =>
     unwrapCloudResponse(
       await client.stores[':storeId']['credit-accounts'][':customerId'].balance.$get({
@@ -220,7 +227,7 @@ export async function getCreditBalance(
       cloudCreditBalanceResponseSchema,
     ),
   )
-  if (isCloudError(result)) return { ok: false, reason: 'cloud_error', error: result.error }
+  if (isCloudError(result)) return { ok: false, error: badGateway(result.error) }
   return { ok: true, value: result }
 }
 
@@ -230,7 +237,7 @@ export async function getCreditLedger(
   orgId: string,
 ): Promise<StorefrontReadOutcome<unknown>> {
   const ready = await getStoreReadiness(deps)
-  if (!ready.ready) return { ok: false, reason: 'binding_missing', error: ready.error }
+  if (!ready.ready) return { ok: false, error: forbidden(ready.error) }
   const result = await cloudRequest(deps, cloudBaseUrl, async ({ client, storeId }) =>
     unwrapCloudResponse(
       await client.stores[':storeId']['credit-accounts'][':customerId']['ledger-entries'].$get({
@@ -240,7 +247,7 @@ export async function getCreditLedger(
       cloudCreditLedgerResponseSchema,
     ),
   )
-  if (isCloudError(result)) return { ok: false, reason: 'cloud_error', error: result.error }
+  if (isCloudError(result)) return { ok: false, error: badGateway(result.error) }
   return { ok: true, value: result }
 }
 
@@ -250,7 +257,7 @@ export async function redeemGiftCard(
   params: { orgId: string; input: RedeemGiftCardInput },
 ): Promise<StorefrontReadOutcome<unknown>> {
   const ready = await getStoreReadiness(deps)
-  if (!ready.ready) return { ok: false, reason: 'binding_missing', error: ready.error }
+  if (!ready.ready) return { ok: false, error: forbidden(ready.error) }
   const result = await cloudRequest(deps, cloudBaseUrl, async ({ client, storeId }) =>
     unwrapCloudResponse(
       await client.stores[':storeId']['credit-accounts'][':customerId'].redemptions.$post({
@@ -260,7 +267,7 @@ export async function redeemGiftCard(
       redeemGiftCardResponseSchema,
     ),
   )
-  if (isCloudError(result)) return { ok: false, reason: 'cloud_error', error: result.error }
+  if (isCloudError(result)) return { ok: false, error: badGateway(result.error) }
   return { ok: true, value: result }
 }
 
@@ -270,14 +277,14 @@ export async function getDiscountQuote(
   input: DiscountQuoteInput,
 ): Promise<StorefrontReadOutcome<unknown>> {
   const ready = await getStoreReadiness(deps)
-  if (!ready.ready) return { ok: false, reason: 'binding_missing', error: ready.error }
+  if (!ready.ready) return { ok: false, error: forbidden(ready.error) }
   const result = await cloudRequest(deps, cloudBaseUrl, async ({ client, storeId }) =>
     unwrapCloudResponse(
       await client.stores[':storeId']['discount-quotes'].$post({ param: { storeId }, json: input }),
       cloudDiscountQuoteResponseSchema,
     ),
   )
-  if (isCloudError(result)) return { ok: false, reason: 'cloud_error', error: result.error }
+  if (isCloudError(result)) return { ok: false, error: badGateway(result.error) }
   return { ok: true, value: result }
 }
 
@@ -287,7 +294,7 @@ export async function createBillingPortalSession(
   params: { orgId: string; origin: string },
 ): Promise<StorefrontReadOutcome<unknown>> {
   const ready = await getStoreReadiness(deps)
-  if (!ready.ready) return { ok: false, reason: 'binding_missing', error: ready.error }
+  if (!ready.ready) return { ok: false, error: forbidden(ready.error) }
   const result = await cloudRequest(deps, cloudBaseUrl, async ({ client, storeId }) =>
     unwrapCloudResponse(
       await client.stores[':storeId'].billing['portal-sessions'].$post({
@@ -297,18 +304,13 @@ export async function createBillingPortalSession(
       cloudBillingPortalSessionResponseSchema,
     ),
   )
-  if (isCloudError(result)) return { ok: false, reason: 'cloud_error', error: result.error }
+  if (isCloudError(result)) return { ok: false, error: badGateway(result.error) }
   return { ok: true, value: result }
 }
 
 // ─── Checkout ────────────────────────────────────────────────────────────────
 
-export type CheckoutOutcome =
-  | { ok: true; value: unknown }
-  | { ok: false; reason: 'binding_missing'; error: string }
-  | { ok: false; reason: 'cloud_error'; error: string }
-  | { ok: false; reason: 'price_missing' }
-  | { ok: false; reason: 'workspace_plan_exists' }
+export type CheckoutOutcome = { ok: true; value: unknown } | { ok: false; error: AppError }
 
 const CHECKOUT_CURRENCY = 'usd'
 
@@ -322,7 +324,7 @@ export async function createCheckout(
   params: { userId: string; orgId: string; origin: string; input: CheckoutInput },
 ): Promise<CheckoutOutcome> {
   const ready = await getStoreReadiness(deps)
-  if (!ready.ready) return { ok: false, reason: 'binding_missing', error: ready.error }
+  if (!ready.ready) return { ok: false, error: forbidden(ready.error) }
   const { userId, orgId, origin, input } = params
 
   const product = await cloudRequest(deps, cloudBaseUrl, async ({ client, storeId }) =>
@@ -333,7 +335,7 @@ export async function createCheckout(
       cloudPackageResponseSchema,
     ),
   )
-  if (isCloudError(product)) return { ok: false, reason: 'cloud_error', error: product.error }
+  if (isCloudError(product)) return { ok: false, error: badGateway(product.error) }
 
   const price = input.priceId
     ? product.prices.find(
@@ -341,11 +343,12 @@ export async function createCheckout(
           item.id === input.priceId && item.currency === CHECKOUT_CURRENCY && item.recurring?.usageType !== 'metered',
       )
     : product.prices.find((item) => item.currency === CHECKOUT_CURRENCY && item.recurring?.usageType !== 'metered')
-  if (!price) return { ok: false, reason: 'price_missing' }
+  if (!price) return { ok: false, error: badRequest('Package price missing', 'PACKAGE_PRICE_MISSING') }
 
   if (price.recurring) {
     const quota = await deps.quota.getEffectiveQuota(orgId)
-    if (quota.currentPlan?.subscription) return { ok: false, reason: 'workspace_plan_exists' }
+    if (quota.currentPlan?.subscription)
+      return { ok: false, error: conflict('Workspace plan already exists', 'WORKSPACE_PLAN_EXISTS') }
   }
 
   const customerLabel = await deps.cloudStore.getCustomerLabel(userId, orgId)
@@ -363,7 +366,7 @@ export async function createCheckout(
       cloudOrderResponseSchema,
     ),
   )
-  if (isCloudError(order)) return { ok: false, reason: 'cloud_error', error: order.error }
+  if (isCloudError(order)) return { ok: false, error: badGateway(order.error) }
 
   const payment = await cloudRequest(deps, cloudBaseUrl, async ({ client, storeId }) =>
     unwrapCloudResponse(
@@ -378,7 +381,7 @@ export async function createCheckout(
       cloudCheckoutResponseSchema,
     ),
   )
-  if (isCloudError(payment)) return { ok: false, reason: 'cloud_error', error: payment.error }
+  if (isCloudError(payment)) return { ok: false, error: badGateway(payment.error) }
   return { ok: true, value: payment }
 }
 
@@ -387,11 +390,7 @@ export async function createCheckout(
 // The store-binding gate (403) is enforced by the handler before these run —
 // for the order routes the original checks binding before the org/orderId guards,
 // so the handler owns that ordering. These assume the store is bound.
-export type OrderActionOutcome =
-  | { ok: true; value: unknown }
-  | { ok: false; reason: 'cloud_error'; error: string }
-  | { ok: false; reason: 'not_found' }
-  | { ok: false; reason: 'forbidden' }
+export type OrderActionOutcome = { ok: true; value: unknown } | { ok: false; error: AppError }
 
 function fetchOrder(
   deps: Pick<CloudStoreDeps, 'cloudStore' | 'licensingCloud'>,
@@ -417,12 +416,12 @@ export async function continueOrderPayment(
   cloudBaseUrl: string,
   params: { orgId: string; orderId: string | undefined; origin: string },
 ): Promise<OrderActionOutcome> {
-  if (!params.orderId) return { ok: false, reason: 'not_found' }
+  if (!params.orderId) return { ok: false, error: notFound('Order not found') }
   const orderId = params.orderId
 
   const order = await fetchOrder(deps, cloudBaseUrl, orderId)
-  if (isCloudError(order)) return { ok: false, reason: 'cloud_error', error: order.error }
-  if (!orderBelongsToTarget(order.target, params.orgId)) return { ok: false, reason: 'forbidden' }
+  if (isCloudError(order)) return { ok: false, error: badGateway(order.error) }
+  if (!orderBelongsToTarget(order.target, params.orgId)) return { ok: false, error: forbidden() }
 
   const result = await cloudRequest(deps, cloudBaseUrl, async ({ client, storeId }) =>
     unwrapCloudResponse(
@@ -433,7 +432,7 @@ export async function continueOrderPayment(
       cloudCheckoutResponseSchema,
     ),
   )
-  if (isCloudError(result)) return { ok: false, reason: 'cloud_error', error: result.error }
+  if (isCloudError(result)) return { ok: false, error: badGateway(result.error) }
   return { ok: true, value: result }
 }
 
@@ -442,12 +441,12 @@ export async function cancelOrder(
   cloudBaseUrl: string,
   params: { orgId: string; orderId: string | undefined; status: 'canceled' },
 ): Promise<OrderActionOutcome> {
-  if (!params.orderId) return { ok: false, reason: 'not_found' }
+  if (!params.orderId) return { ok: false, error: notFound('Order not found') }
   const orderId = params.orderId
 
   const order = await fetchOrder(deps, cloudBaseUrl, orderId)
-  if (isCloudError(order)) return { ok: false, reason: 'cloud_error', error: order.error }
-  if (!orderBelongsToTarget(order.target, params.orgId)) return { ok: false, reason: 'forbidden' }
+  if (isCloudError(order)) return { ok: false, error: badGateway(order.error) }
+  if (!orderBelongsToTarget(order.target, params.orgId)) return { ok: false, error: forbidden() }
 
   const result = await cloudRequest(deps, cloudBaseUrl, async ({ client, storeId }) =>
     unwrapCloudResponse(
@@ -458,21 +457,19 @@ export async function cancelOrder(
       cloudOrderResponseSchema,
     ),
   )
-  if (isCloudError(result)) return { ok: false, reason: 'cloud_error', error: result.error }
+  if (isCloudError(result)) return { ok: false, error: badGateway(result.error) }
   return { ok: true, value: result }
 }
 
 // ─── Delivery webhook ────────────────────────────────────────────────────────
 
-// Why a cloud-delivery webhook was rejected. `invalid_token` (401) means the
-// signed event token failed verification or its eventId did not match the body;
-// `invalid_payload` (400) means the body was not valid JSON or not a quota-change
-// event; `processing_failed` (400) carries the fulfillment error message.
-export type WebhookOutcome =
-  | { ok: true; duplicate: boolean; eventId: string }
-  | { ok: false; reason: 'invalid_token' }
-  | { ok: false; reason: 'invalid_payload' }
-  | { ok: false; reason: 'processing_failed'; error: string }
+// Why a cloud-delivery webhook was rejected. A failed/mismatched event token
+// renders 401 (`INVALID_EVENT_TOKEN`); a non-JSON or non-quota-change body renders
+// 400 (`INVALID_PAYLOAD`); a fulfillment failure renders 400 carrying the error
+// message.
+export type WebhookOutcome = { ok: true; duplicate: boolean; eventId: string } | { ok: false; error: AppError }
+
+const invalidEventToken = () => new AppError(401, 'Invalid event token', { reason: 'INVALID_EVENT_TOKEN' })
 
 // Full webhook decision over the already-read request. Reads the binding, verifies
 // the event token, validates the parsed body, cross-checks the body eventId
@@ -494,12 +491,12 @@ export async function processDeliveryWebhook(
     boundLicenseId: binding.boundLicenseId,
     payloadHash: params.payloadHash,
   })
-  if (!eventAuth) return { ok: false, reason: 'invalid_token' }
+  if (!eventAuth) return { ok: false, error: invalidEventToken() }
 
-  if (!params.body) return { ok: false, reason: 'invalid_payload' }
+  if (!params.body) return { ok: false, error: badRequest('Invalid payload', 'INVALID_PAYLOAD') }
   const parsed = cloudOrderQuotaChangeSchema.safeParse(params.body)
-  if (!parsed.success) return { ok: false, reason: 'invalid_payload' }
-  if (parsed.data.eventId !== eventAuth.eventId) return { ok: false, reason: 'invalid_token' }
+  if (!parsed.success) return { ok: false, error: badRequest('Invalid payload', 'INVALID_PAYLOAD') }
+  if (parsed.data.eventId !== eventAuth.eventId) return { ok: false, error: invalidEventToken() }
 
   try {
     const result = await deps.cloudStore.processCloudOrderQuotaChange(
@@ -509,6 +506,6 @@ export async function processDeliveryWebhook(
     )
     return { ok: true, duplicate: result.duplicate, eventId: result.eventId }
   } catch (error) {
-    return { ok: false, reason: 'processing_failed', error: (error as Error).message }
+    return { ok: false, error: badRequest((error as Error).message) }
   }
 }


### PR DESCRIPTION
## What

Collapses the two parallel error conventions onto one typed mechanism.

- **Usecases** return typed `AppError` values via factories (`notFound()`, `quotaExceeded()`, `featureBlocked()`, …) instead of `{ ok: false, reason: 'string' }`.
- **Handlers** do `throw result.error` — no per-handler `switch`, no hand-written status codes, no magic-string reasons.
- **`jsonError`** (renamed from `renderError`) is the single place that renders any error to an AIP-193 body + access-log line, in `app.onError`/accessLog.

## Why

`outcomeError` + the `OUTCOME` string→code table lived in parallel with the `mapDomainError` type→code table, and 67 inline `apiError(c, <status>, …)` sites hand-wrote the status at each call site — exactly the drift that left the same `quota_exceeded` at **400** in one handler and **422** everywhere else. Now status + AIP-193 reason live once, in the factory.

## Notable

- New `server/usecases/ports/app-error.ts`: `AppError` + factories. Also carries optional response headers (`Retry-After`) via a `rateLimited()` factory.
- **Deleted:** `apiError`, `outcomeError`, the `OUTCOME` table, and the dead `ApiError` class.
- Control-flow outcomes a handler *branches* on (e.g. `deleteObject` `not_trashed`) stay discriminated reasons; internal shared sub-usecases (traffic-metering, licensing internals) keep string reasons, mapped at the public boundary.
- Go OpenAPI client regenerated (saveShare gained a 422 response).

## Breaking

`POST /shares/{token}/objects` quota rejection now returns **422** (was an inconsistent 400). Every other quota path already returned 422.

## Verification (local)

- typecheck (server + src) ✅ · biome ✅ · lint:http ✅ · lint:arch ✅
- server unit+integration **4395/4395** ✅ · cloudflare **57/57** ✅
- OpenAPI Go client regenerated, `go build` exit 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)