### PR TITLE
refactor(api)!: collapse polymorphic GET responses to one monomorphic schema (#449)

### DIFF
--- a/cmd/internal/openapi/client.gen.go
+++ b/cmd/internal/openapi/client.gen.go
@@ -237,21 +237,6 @@ func (e ImageHostingConfigDomainStatus) Valid() bool {
 	}
 }
 
-// Defines values for ImageHostingConfigResponse1Enabled.
-const (
-	ImageHostingConfigResponse1EnabledFalse ImageHostingConfigResponse1Enabled = false
-)
-
-// Valid indicates whether the value is a known member of the ImageHostingConfigResponse1Enabled enum.
-func (e ImageHostingConfigResponse1Enabled) Valid() bool {
-	switch e {
-	case ImageHostingConfigResponse1EnabledFalse:
-		return true
-	default:
-		return false
-	}
-}
-
 // Defines values for ChangeEmail200JSONResponseBodyMessage.
 const (
 	ChangeEmail200JSONResponseBodyMessageEmailUpdated          ChangeEmail200JSONResponseBodyMessage = "Email updated"
@@ -389,13 +374,13 @@ func (e PostApiAuthOauth2Link200JSONResponseBodyRedirect) Valid() bool {
 
 // Defines values for SignInEmail200JSONResponseBodyRedirect.
 const (
-	SignInEmail200JSONResponseBodyRedirectFalse SignInEmail200JSONResponseBodyRedirect = false
+	False SignInEmail200JSONResponseBodyRedirect = false
 )
 
 // Valid indicates whether the value is a known member of the SignInEmail200JSONResponseBodyRedirect enum.
 func (e SignInEmail200JSONResponseBodyRedirect) Valid() bool {
 	switch e {
-	case SignInEmail200JSONResponseBodyRedirectFalse:
+	case False:
 		return true
 	default:
 		return false
@@ -1354,28 +1339,25 @@ type AuditEventPage struct {
 	Total    int          `json:"total"`
 }
 
-// AuthProviderConfig defines model for AuthProviderConfig.
-type AuthProviderConfig struct {
+// AuthProvider defines model for AuthProvider.
+type AuthProvider struct {
 	ClientId     string    `json:"clientId"`
-	ClientSecret string    `json:"clientSecret"`
-	DiscoveryUrl *string   `json:"discoveryUrl,omitempty"`
+	ClientSecret *string   `json:"clientSecret"`
+	DiscoveryUrl *string   `json:"discoveryUrl"`
 	Enabled      bool      `json:"enabled"`
+	Icon         string    `json:"icon"`
+	Name         string    `json:"name"`
 	ProviderId   string    `json:"providerId"`
-	Scopes       *[]string `json:"scopes,omitempty"`
+	Scopes       *[]string `json:"scopes"`
 	Type         string    `json:"type"`
 }
 
 // AuthProviderList defines model for AuthProviderList.
 type AuthProviderList struct {
-	Items    []AuthProviderList_Items_Item `json:"items"`
-	Page     int                           `json:"page"`
-	PageSize int                           `json:"pageSize"`
-	Total    int                           `json:"total"`
-}
-
-// AuthProviderList_Items_Item defines model for AuthProviderList.items.Item.
-type AuthProviderList_Items_Item struct {
-	union json.RawMessage
+	Items    []AuthProvider `json:"items"`
+	Page     int            `json:"page"`
+	PageSize int            `json:"pageSize"`
+	Total    int            `json:"total"`
 }
 
 // BackgroundJob defines model for BackgroundJob.
@@ -1729,7 +1711,7 @@ type ImageHosting struct {
 
 // ImageHostingConfig defines model for ImageHostingConfig.
 type ImageHostingConfig struct {
-	CreatedAt       int     `json:"createdAt"`
+	CreatedAt       *int    `json:"createdAt"`
 	CustomDomain    *string `json:"customDomain"`
 	DnsInstructions *struct {
 		Name       string `json:"name"`
@@ -1744,19 +1726,6 @@ type ImageHostingConfig struct {
 
 // ImageHostingConfigDomainStatus defines model for ImageHostingConfig.DomainStatus.
 type ImageHostingConfigDomainStatus string
-
-// ImageHostingConfigResponse defines model for ImageHostingConfigResponse.
-type ImageHostingConfigResponse struct {
-	union json.RawMessage
-}
-
-// ImageHostingConfigResponse1 defines model for .
-type ImageHostingConfigResponse1 struct {
-	Enabled ImageHostingConfigResponse1Enabled `json:"enabled"`
-}
-
-// ImageHostingConfigResponse1Enabled defines model for ImageHostingConfigResponse.1.Enabled.
-type ImageHostingConfigResponse1Enabled bool
 
 // ImageHostingDraft defines model for ImageHostingDraft.
 type ImageHostingDraft struct {
@@ -1907,14 +1876,6 @@ type PendingInvitation struct {
 	ExpiresAt *string `json:"expiresAt"`
 	Id        string  `json:"id"`
 	Role      string  `json:"role"`
-}
-
-// PublicAuthProvider defines model for PublicAuthProvider.
-type PublicAuthProvider struct {
-	Icon       string `json:"icon"`
-	Name       string `json:"name"`
-	ProviderId string `json:"providerId"`
-	Type       string `json:"type"`
 }
 
 // PublicProfile defines model for PublicProfile.
@@ -3998,130 +3959,6 @@ type GrantUserEntitlementJSONRequestBody GrantUserEntitlementJSONBody
 
 // UpdateUserEntitlementJSONRequestBody defines body for UpdateUserEntitlement for application/json ContentType.
 type UpdateUserEntitlementJSONRequestBody UpdateUserEntitlementJSONBody
-
-// AsAuthProviderConfig returns the union data inside the AuthProviderList_Items_Item as a AuthProviderConfig
-func (t AuthProviderList_Items_Item) AsAuthProviderConfig() (AuthProviderConfig, error) {
-	var body AuthProviderConfig
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromAuthProviderConfig overwrites any union data inside the AuthProviderList_Items_Item as the provided AuthProviderConfig
-func (t *AuthProviderList_Items_Item) FromAuthProviderConfig(v AuthProviderConfig) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeAuthProviderConfig performs a merge with any union data inside the AuthProviderList_Items_Item, using the provided AuthProviderConfig
-func (t *AuthProviderList_Items_Item) MergeAuthProviderConfig(v AuthProviderConfig) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-// AsPublicAuthProvider returns the union data inside the AuthProviderList_Items_Item as a PublicAuthProvider
-func (t AuthProviderList_Items_Item) AsPublicAuthProvider() (PublicAuthProvider, error) {
-	var body PublicAuthProvider
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromPublicAuthProvider overwrites any union data inside the AuthProviderList_Items_Item as the provided PublicAuthProvider
-func (t *AuthProviderList_Items_Item) FromPublicAuthProvider(v PublicAuthProvider) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergePublicAuthProvider performs a merge with any union data inside the AuthProviderList_Items_Item, using the provided PublicAuthProvider
-func (t *AuthProviderList_Items_Item) MergePublicAuthProvider(v PublicAuthProvider) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-func (t AuthProviderList_Items_Item) MarshalJSON() ([]byte, error) {
-	b, err := t.union.MarshalJSON()
-	return b, err
-}
-
-func (t *AuthProviderList_Items_Item) UnmarshalJSON(b []byte) error {
-	err := t.union.UnmarshalJSON(b)
-	return err
-}
-
-// AsImageHostingConfig returns the union data inside the ImageHostingConfigResponse as a ImageHostingConfig
-func (t ImageHostingConfigResponse) AsImageHostingConfig() (ImageHostingConfig, error) {
-	var body ImageHostingConfig
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromImageHostingConfig overwrites any union data inside the ImageHostingConfigResponse as the provided ImageHostingConfig
-func (t *ImageHostingConfigResponse) FromImageHostingConfig(v ImageHostingConfig) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeImageHostingConfig performs a merge with any union data inside the ImageHostingConfigResponse, using the provided ImageHostingConfig
-func (t *ImageHostingConfigResponse) MergeImageHostingConfig(v ImageHostingConfig) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-// AsImageHostingConfigResponse1 returns the union data inside the ImageHostingConfigResponse as a ImageHostingConfigResponse1
-func (t ImageHostingConfigResponse) AsImageHostingConfigResponse1() (ImageHostingConfigResponse1, error) {
-	var body ImageHostingConfigResponse1
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromImageHostingConfigResponse1 overwrites any union data inside the ImageHostingConfigResponse as the provided ImageHostingConfigResponse1
-func (t *ImageHostingConfigResponse) FromImageHostingConfigResponse1(v ImageHostingConfigResponse1) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeImageHostingConfigResponse1 performs a merge with any union data inside the ImageHostingConfigResponse, using the provided ImageHostingConfigResponse1
-func (t *ImageHostingConfigResponse) MergeImageHostingConfigResponse1(v ImageHostingConfigResponse1) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-func (t ImageHostingConfigResponse) MarshalJSON() ([]byte, error) {
-	b, err := t.union.MarshalJSON()
-	return b, err
-}
-
-func (t *ImageHostingConfigResponse) UnmarshalJSON(b []byte) error {
-	err := t.union.UnmarshalJSON(b)
-	return err
-}
 
 // AsCreateBackgroundJobJSONBody0 returns the union data inside the CreateBackgroundJobJSONBody as a CreateBackgroundJobJSONBody0
 func (t CreateBackgroundJobJSONBody) AsCreateBackgroundJobJSONBody0() (CreateBackgroundJobJSONBody0, error) {
@@ -23854,7 +23691,7 @@ func (r DeleteImageHostingConfigResponse) ContentType() string {
 type GetImageHostingConfigResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ImageHostingConfigResponse
+	JSON200      *ImageHostingConfig
 	JSON401      *Error
 }
 
@@ -25114,7 +24951,7 @@ func (r DeleteAuthProviderResponse) ContentType() string {
 type UpsertAuthProviderResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *AuthProviderConfig
+	JSON200      *AuthProvider
 	JSON400      *Error
 	JSON402      *Error
 }
@@ -37941,7 +37778,7 @@ func ParseGetImageHostingConfigResponse(rsp *http.Response) (*GetImageHostingCon
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ImageHostingConfigResponse
+		var dest ImageHostingConfig
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -39475,7 +39312,7 @@ func ParseUpsertAuthProviderResponse(rsp *http.Response) (*UpsertAuthProviderRes
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest AuthProviderConfig
+		var dest AuthProvider
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/server/http/image-hosting/config.integration.test.ts
+++ b/server/http/image-hosting/config.integration.test.ts
@@ -230,7 +230,7 @@ describe('/api/image-hosting/config — role enforcement', () => {
 // ─── GET ───────────────────────────────────────────────────────────────────────
 
 describe('GET /api/image-hosting/config', () => {
-  it('returns { enabled: false } when no config row exists [spec: image-hosting-config/default-disabled]', async () => {
+  it('returns the full disabled shape when no config row exists [spec: image-hosting-config/default-disabled]', async () => {
     const { app, db } = await createTestApp()
     const { headers, userId } = await signUpAndGetHeaders(app, `get-no-config-${nanoid()}@example.com`)
     const orgId = await insertOrg(db)
@@ -239,8 +239,17 @@ describe('GET /api/image-hosting/config', () => {
 
     const res = await app.request('/api/image-hosting/config', { headers: { Cookie: updatedCookies } })
     expect(res.status).toBe(200)
-    const body = (await res.json()) as { enabled: boolean }
-    expect(body.enabled).toBe(false)
+    const body = await res.json()
+    // One monomorphic shape: enabled false carries every other field as null/none.
+    expect(body).toEqual({
+      enabled: false,
+      customDomain: null,
+      domainVerifiedAt: null,
+      domainStatus: 'none',
+      dnsInstructions: null,
+      refererAllowlist: null,
+      createdAt: null,
+    })
   })
 
   it('returns domainStatus=none and null dnsInstructions when no customDomain set [spec: image-hosting-config/no-domain]', async () => {

--- a/server/http/image-hosting/config.ts
+++ b/server/http/image-hosting/config.ts
@@ -12,6 +12,8 @@ import {
 import { unauthorized } from '../../usecases/ports'
 import { errorResponse, jsonBody, jsonContent } from '../openapi'
 
+// One monomorphic shape for every state: not-configured carries `enabled: false`
+// with every other field null, configured carries `enabled: true` with values.
 const ihostConfigSchema = z
   .object({
     enabled: z.boolean(),
@@ -20,14 +22,9 @@ const ihostConfigSchema = z
     domainStatus: z.enum(['none', 'pending', 'verified']),
     dnsInstructions: z.object({ recordType: z.string(), name: z.string(), target: z.string() }).nullable(),
     refererAllowlist: z.array(z.string()).nullable(),
-    createdAt: z.number().int(),
+    createdAt: z.number().int().nullable(),
   })
   .openapi('ImageHostingConfig')
-
-// GET returns the full config when configured, or just `{ enabled: false }`.
-const ihostConfigResponseSchema = z
-  .union([ihostConfigSchema, z.object({ enabled: z.literal(false) })])
-  .openapi('ImageHostingConfigResponse')
 
 function toUnixMs(d: Date | null | undefined): number | null {
   if (!d) return null
@@ -41,10 +38,22 @@ function buildResponse(
     domainVerifiedAt: Date | null
     refererAllowlist: string | null
     createdAt: Date
-  },
+  } | null,
   cnameTarget: string,
   isCfConfigured: boolean,
 ): IhostConfigResponse {
+  if (!row) {
+    return {
+      enabled: false,
+      customDomain: null,
+      domainVerifiedAt: null,
+      domainStatus: 'none',
+      dnsInstructions: null,
+      refererAllowlist: null,
+      createdAt: null,
+    }
+  }
+
   const verifiedAtMs = toUnixMs(row.domainVerifiedAt)
 
   let domainStatus: IhostConfigResponse['domainStatus'] = 'none'
@@ -87,7 +96,7 @@ const getRoute = createRoute({
   method: 'get',
   path: '/',
   responses: {
-    200: jsonContent(ihostConfigResponseSchema, 'Image-hosting config'),
+    200: jsonContent(ihostConfigSchema, 'Image-hosting config'),
     401: errorResponse('Unauthorized'),
   },
 })
@@ -130,7 +139,6 @@ const ihostConfig = app
     if (!orgId) throw unauthorized()
     const { isCfConfigured, cnameTarget, cf } = cfFrom(c)
     const row = await getImageHostingConfig(c.get('deps'), orgId, cf)
-    if (!row) return c.json({ enabled: false as const }, 200)
     return c.json(buildResponse(row, cnameTarget, isCfConfigured), 200)
   })
   .openapi(putRoute, async (c) => {

--- a/server/http/site/auth-providers.integration.test.ts
+++ b/server/http/site/auth-providers.integration.test.ts
@@ -54,7 +54,7 @@ describe('Auth Providers — public list', () => {
     expect(body.items[0].providerId).toBe('github')
   })
 
-  it('does not include clientSecret in public response [spec: auth-providers/public-no-secret]', async () => {
+  it('nulls clientSecret in public response [spec: auth-providers/public-no-secret]', async () => {
     const { app } = await createTestApp()
     const admin = await adminHeaders(app)
 
@@ -62,7 +62,7 @@ describe('Auth Providers — public list', () => {
 
     const res = await app.request('/api/site/auth-providers')
     const body = (await res.json()) as { items: Array<Record<string, unknown>> }
-    expect(body.items[0]).not.toHaveProperty('clientSecret')
+    expect(body.items[0].clientSecret).toBeNull()
   })
 
   it('returns display name and icon from provider metadata [spec: auth-providers/metadata]', async () => {
@@ -114,7 +114,7 @@ describe('Auth Providers — admin list', () => {
     expect(res.status).toBe(200)
     const body = (await res.json()) as { items: Array<Record<string, unknown>> }
     expect(body.items).toHaveLength(1)
-    expect(body.items[0]).not.toHaveProperty('clientSecret')
+    expect(body.items[0].clientSecret).toBeNull()
   })
 
   it('serves the public (secret-free) list to non-admin users [spec: auth-providers/admin-only]', async () => {
@@ -133,7 +133,7 @@ describe('Auth Providers — admin list', () => {
     expect(res.status).toBe(200)
     const body = (await res.json()) as { items: Array<Record<string, unknown>> }
     expect(body.items).toHaveLength(1)
-    expect(body.items[0]).not.toHaveProperty('clientSecret')
+    expect(body.items[0].clientSecret).toBeNull()
   })
 
   it('returns empty items when no providers are configured', async () => {

--- a/server/http/site/auth-providers.ts
+++ b/server/http/site/auth-providers.ts
@@ -2,41 +2,27 @@ import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
 import { pageSchema } from '@shared/schemas'
 import { requireAdmin } from '../../middleware/auth'
 import type { Env } from '../../middleware/platform'
-import {
-  deleteAuthProvider,
-  listAuthProviders,
-  listPublicAuthProviders,
-  upsertAuthProvider,
-} from '../../usecases/site/auth-provider'
+import { deleteAuthProvider, listAuthProviders, upsertAuthProvider } from '../../usecases/site/auth-provider'
 import { errorResponse, jsonBody, jsonContent } from '../openapi'
 
-const maskedProviderConfigSchema = z
+// One monomorphic schema for every caller. Role changes values only — admin gets a
+// masked `clientSecret`, front-of-house gets `clientSecret: null` (and the enabled-only
+// list). clientId/discoveryUrl/scopes are not secrets, so they are exposed to everyone.
+const authProviderSchema = z
   .object({
     providerId: z.string(),
     type: z.string(),
-    clientId: z.string(),
-    clientSecret: z.string(),
     enabled: z.boolean(),
-    discoveryUrl: z.string().optional(),
-    scopes: z.array(z.string()).optional(),
-  })
-  .openapi('AuthProviderConfig')
-
-const publicProviderSchema = z
-  .object({
-    providerId: z.string(),
-    type: z.string(),
     name: z.string(),
     icon: z.string(),
+    clientId: z.string(),
+    discoveryUrl: z.string().nullable(),
+    scopes: z.array(z.string()).nullable(),
+    clientSecret: z.string().nullable(),
   })
-  .openapi('PublicAuthProvider')
+  .openapi('AuthProvider')
 
-// GET / returns the admin config list (with masked secrets) to admins, or the
-// public display list to anonymous/login callers — hence the union.
-const authProviderListSchema = pageSchema(
-  z.union([maskedProviderConfigSchema, publicProviderSchema]),
-  'AuthProviderList',
-)
+const authProviderListSchema = pageSchema(authProviderSchema, 'AuthProviderList')
 
 const upsertSchema = z.object({
   type: z.enum(['builtin', 'oidc']),
@@ -65,7 +51,7 @@ const upsertRoute = createRoute({
   middleware: [requireAdmin] as const,
   request: { params: z.object({ providerId: z.string() }), ...jsonBody(upsertSchema) },
   responses: {
-    200: jsonContent(maskedProviderConfigSchema, 'Upserted auth provider'),
+    200: jsonContent(authProviderSchema, 'Upserted auth provider'),
     400: errorResponse('Invalid provider'),
     402: errorResponse('Feature not available'),
   },
@@ -89,10 +75,7 @@ const deleteProviderRoute = createRoute({
 // anonymous/login callers, and the full config to admins; writes are admin-only.
 export const authProviders = new OpenAPIHono<Env>()
   .openapi(listRoute, async (c) => {
-    const { items } =
-      c.get('userRole') === 'admin'
-        ? await listAuthProviders(c.get('deps'))
-        : await listPublicAuthProviders(c.get('deps'))
+    const { items } = await listAuthProviders(c.get('deps'), { isAdmin: c.get('userRole') === 'admin' })
     return c.json({ items, total: items.length, page: 1, pageSize: items.length }, 200)
   })
   .openapi(upsertRoute, async (c) => {

--- a/server/usecases/site/auth-provider.test.ts
+++ b/server/usecases/site/auth-provider.test.ts
@@ -6,7 +6,6 @@ import {
   type AuthProviderDeps,
   deleteAuthProvider,
   listAuthProviders,
-  listPublicAuthProviders,
   type UpsertProviderInput,
   upsertAuthProvider,
 } from './auth-provider'
@@ -66,28 +65,57 @@ function makeDeps(systemOptions: Partial<SystemOptionsRepo> = {}) {
 beforeEach(() => vi.clearAllMocks())
 
 describe('auth-provider usecase', () => {
-  describe('listPublicAuthProviders', () => {
-    it('returns only enabled providers with metadata, no secrets', async () => {
+  describe('listAuthProviders — front-of-house (isAdmin: false)', () => {
+    it('returns only enabled providers with metadata and a null secret', async () => {
       const { deps } = makeDeps({
         listByKeyLike: async () => [
           row({ providerId: 'github', type: 'builtin', clientId: 'a', clientSecret: 's', enabled: true }),
           row({ providerId: 'google', type: 'builtin', clientId: 'b', clientSecret: 's', enabled: false }),
         ],
       })
-      const out = await listPublicAuthProviders(deps)
-      expect(out.items).toEqual([{ providerId: 'github', type: 'builtin', name: 'GitHub', icon: 'github' }])
-      expect(out.items[0]).not.toHaveProperty('clientSecret')
+      const out = await listAuthProviders(deps, { isAdmin: false })
+      expect(out.items).toEqual([
+        {
+          providerId: 'github',
+          type: 'builtin',
+          enabled: true,
+          name: 'GitHub',
+          icon: 'github',
+          clientId: 'a',
+          discoveryUrl: null,
+          scopes: null,
+          clientSecret: null,
+        },
+      ])
     })
 
     it('falls back to providerId for name and icon of an unknown OIDC provider', async () => {
       const { deps } = makeDeps({
         listByKeyLike: async () => [
-          row({ providerId: 'my-custom-oidc', type: 'oidc', clientId: 'a', clientSecret: 's', enabled: true }),
+          row({
+            providerId: 'my-custom-oidc',
+            type: 'oidc',
+            clientId: 'a',
+            clientSecret: 's',
+            enabled: true,
+            discoveryUrl: 'https://accounts.example.com/.well-known/openid-configuration',
+            scopes: ['openid'],
+          }),
         ],
       })
-      const out = await listPublicAuthProviders(deps)
+      const out = await listAuthProviders(deps, { isAdmin: false })
       expect(out.items).toEqual([
-        { providerId: 'my-custom-oidc', type: 'oidc', name: 'my-custom-oidc', icon: 'my-custom-oidc' },
+        {
+          providerId: 'my-custom-oidc',
+          type: 'oidc',
+          enabled: true,
+          name: 'my-custom-oidc',
+          icon: 'my-custom-oidc',
+          clientId: 'a',
+          discoveryUrl: 'https://accounts.example.com/.well-known/openid-configuration',
+          scopes: ['openid'],
+          clientSecret: null,
+        },
       ])
     })
 
@@ -95,16 +123,16 @@ describe('auth-provider usecase', () => {
       const { deps } = makeDeps({
         listByKeyLike: async () => [{ key: 'oauth_provider_bad', value: 'not-json' }],
       })
-      expect(await listPublicAuthProviders(deps)).toEqual({ items: [] })
+      expect(await listAuthProviders(deps, { isAdmin: false })).toEqual({ items: [] })
     })
 
     it('returns empty when nothing is configured', async () => {
       const { deps } = makeDeps()
-      expect(await listPublicAuthProviders(deps)).toEqual({ items: [] })
+      expect(await listAuthProviders(deps, { isAdmin: false })).toEqual({ items: [] })
     })
   })
 
-  describe('listAuthProviders', () => {
+  describe('listAuthProviders — admin (isAdmin: true)', () => {
     it('returns all configs, enabled or not, with masked secrets', async () => {
       const { deps } = makeDeps({
         listByKeyLike: async () => [
@@ -118,7 +146,7 @@ describe('auth-provider usecase', () => {
           row({ providerId: 'google', type: 'builtin', clientId: 'b', clientSecret: 's', enabled: false }),
         ],
       })
-      const out = await listAuthProviders(deps)
+      const out = await listAuthProviders(deps, { isAdmin: true })
       expect(out.items).toHaveLength(2)
       expect(out.items[0].clientSecret).toMatch(/^\*+alue$/)
       expect(out.items[0].clientSecret).not.toBe('super-secret-value')
@@ -130,7 +158,7 @@ describe('auth-provider usecase', () => {
           row({ providerId: 'github', type: 'builtin', clientId: 'a', clientSecret: 'abc', enabled: true }),
         ],
       })
-      const out = await listAuthProviders(deps)
+      const out = await listAuthProviders(deps, { isAdmin: true })
       expect(out.items[0].clientSecret).toBe('****')
     })
 
@@ -138,7 +166,7 @@ describe('auth-provider usecase', () => {
       const { deps } = makeDeps({
         listByKeyLike: async () => [{ key: 'oauth_provider_bad', value: '{' }],
       })
-      expect(await listAuthProviders(deps)).toEqual({ items: [] })
+      expect(await listAuthProviders(deps, { isAdmin: true })).toEqual({ items: [] })
     })
   })
 

--- a/server/usecases/site/auth-provider.ts
+++ b/server/usecases/site/auth-provider.ts
@@ -19,6 +19,7 @@ import {
   type OAuthProviderType,
   parseProviderConfig,
 } from '@shared/oauth-providers'
+import type { AuthProvider } from '@shared/types'
 import { hasFeature } from '../../domain/licensing'
 import { type AppError, badRequest, featureBlocked, type LicenseBindingRepo, type SystemOptionsRepo } from '../ports'
 import { loadBindingState } from './licensing'
@@ -37,20 +38,23 @@ function maskSecret(secret: string): string {
   return `${'*'.repeat(secret.length - 4)}${secret.slice(-4)}`
 }
 
-// A stored config with its clientSecret masked — the shape the admin routes
-// return (list items and the upsert response body).
-export type MaskedProviderConfig = Omit<OAuthProviderConfig, 'clientSecret'> & { clientSecret: string }
-
-function maskConfig(config: OAuthProviderConfig): MaskedProviderConfig {
-  return { ...config, clientSecret: maskSecret(config.clientSecret) }
-}
-
-// A login-page button: just the public-safe display fields, never secrets.
-export type PublicProvider = {
-  providerId: string
-  type: OAuthProviderType
-  name: string
-  icon: string
+// Map a stored config to the one monomorphic AuthProvider shape every caller sees.
+// Role changes values only: admin gets a masked clientSecret, front-of-house gets null.
+// name/icon come from the static OAuthProviderMeta registry (providerId fallback);
+// clientId/discoveryUrl/scopes are not secrets, so they are exposed to everyone.
+function toAuthProvider(config: OAuthProviderConfig, isAdmin: boolean): AuthProvider {
+  const meta = OAuthProviderMeta[config.providerId]
+  return {
+    providerId: config.providerId,
+    type: config.type,
+    enabled: config.enabled,
+    name: meta?.name ?? config.providerId,
+    icon: meta?.icon ?? config.providerId,
+    clientId: config.clientId,
+    discoveryUrl: config.discoveryUrl ?? null,
+    scopes: config.scopes ?? null,
+    clientSecret: isAdmin ? maskSecret(config.clientSecret) : null,
+  }
 }
 
 // `invalid_id` / `unknown_builtin` / `missing_discovery` are 400 validations;
@@ -64,45 +68,25 @@ export type UpsertProviderInput = {
   scopes?: string[]
 }
 
-export type UpsertProviderOutcome = { ok: true; config: MaskedProviderConfig } | { ok: false; error: AppError }
+export type UpsertProviderOutcome = { ok: true; config: AuthProvider } | { ok: false; error: AppError }
 
 export type DeleteProviderOutcome = { ok: true } | { ok: false; error: AppError }
 
 const INVALID_PROVIDER_ID_MESSAGE = 'Provider ID must contain only lowercase letters, numbers, and hyphens'
 
-// Public: enabled providers only, no secrets (for login page buttons).
-export async function listPublicAuthProviders(
-  deps: Pick<AuthProviderDeps, 'systemOptions'>,
-): Promise<{ items: PublicProvider[] }> {
-  const rows = await deps.systemOptions.listByKeyLike(OAUTH_PROVIDER_KEY_PATTERN)
-  const items = rows
-    .map((r) => {
-      const config = parseProviderConfig(r.value)
-      if (!config?.enabled) return null
-      const meta = OAuthProviderMeta[config.providerId]
-      return {
-        providerId: config.providerId,
-        type: config.type,
-        name: meta?.name ?? config.providerId,
-        icon: meta?.icon ?? config.providerId,
-      }
-    })
-    .filter((item) => item !== null)
-  return { items }
-}
-
-// Admin: full CRUD with secrets masked — every stored config, enabled or not.
+// One list, one shape. Admin sees every stored config with a masked secret;
+// front-of-house sees the enabled-only subset with `clientSecret: null` — a content
+// difference (mask / null / filter), never a shape difference.
 export async function listAuthProviders(
   deps: Pick<AuthProviderDeps, 'systemOptions'>,
-): Promise<{ items: MaskedProviderConfig[] }> {
+  { isAdmin }: { isAdmin: boolean },
+): Promise<{ items: AuthProvider[] }> {
   const rows = await deps.systemOptions.listByKeyLike(OAUTH_PROVIDER_KEY_PATTERN)
   const items = rows
-    .map((r) => {
-      const config = parseProviderConfig(r.value)
-      if (!config) return null
-      return maskConfig(config)
-    })
-    .filter((item) => item !== null)
+    .map((r) => parseProviderConfig(r.value))
+    .filter((config) => config !== null)
+    .filter((config) => isAdmin || config.enabled)
+    .map((config) => toAuthProvider(config, isAdmin))
   return { items }
 }
 
@@ -148,7 +132,7 @@ export async function upsertAuthProvider(
     await deps.systemOptions.set(key, value, false)
   }
 
-  return { ok: true, config: maskConfig(config) }
+  return { ok: true, config: toAuthProvider(config, true) }
 }
 
 export async function deleteAuthProvider(

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -182,11 +182,18 @@ export interface SystemOption {
   public: boolean
 }
 
+// One monomorphic shape for every caller. Role changes values only: admin sees a
+// masked `clientSecret`, front-of-house sees `clientSecret: null` (and the enabled-only list).
 export interface AuthProvider {
   providerId: string
   type: string
+  enabled: boolean
   name: string
   icon: string
+  clientId: string
+  discoveryUrl: string | null
+  scopes: string[] | null
+  clientSecret: string | null
 }
 
 export interface PaginatedResponse<T> {
@@ -537,7 +544,7 @@ export interface IhostConfigResponse {
   domainStatus: 'none' | 'pending' | 'verified'
   dnsInstructions: { recordType: string; name: string; target: string } | null
   refererAllowlist: string[] | null
-  createdAt: number
+  createdAt: number | null
 }
 
 export type ImageHostingStatus = 'draft' | 'active'

--- a/src/components/admin/oauth-providers-section.tsx
+++ b/src/components/admin/oauth-providers-section.tsx
@@ -1,4 +1,5 @@
-import { BUILTIN_PROVIDER_IDS, type OAuthProviderConfig, OAuthProviderMeta } from '@shared/oauth-providers'
+import { BUILTIN_PROVIDER_IDS, OAuthProviderMeta } from '@shared/oauth-providers'
+import type { AuthProvider } from '@shared/types'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -18,7 +19,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
-import { deleteAuthProvider, listAdminAuthProviders, upsertAuthProvider } from '@/lib/api'
+import { deleteAuthProvider, listAuthProviders, upsertAuthProvider } from '@/lib/api'
 
 const providersQueryKey = ['admin', 'auth-providers'] as const
 
@@ -74,7 +75,7 @@ export function OAuthProvidersSection() {
 
   const { data, isLoading } = useQuery({
     queryKey: providersQueryKey,
-    queryFn: listAdminAuthProviders,
+    queryFn: listAuthProviders,
   })
 
   const upsertMutation = useMutation({
@@ -119,12 +120,12 @@ export function OAuthProvidersSection() {
     setDialogOpen(true)
   }
 
-  const openEdit = (p: OAuthProviderConfig) => {
+  const openEdit = (p: AuthProvider) => {
     setForm({
-      type: p.type,
+      type: p.type as ProviderType,
       providerId: p.providerId,
       clientId: p.clientId,
-      clientSecret: p.clientSecret,
+      clientSecret: p.clientSecret ?? '',
       enabled: p.enabled,
       discoveryUrl: p.discoveryUrl ?? '',
       scopes: p.scopes?.join(', ') ?? '',

--- a/src/components/oauth-buttons.test.ts
+++ b/src/components/oauth-buttons.test.ts
@@ -19,9 +19,24 @@ function shouldRender(isLoading: boolean, providers: AuthProvider[]): boolean {
   return !isLoading && providers.length > 0
 }
 
+// Front-of-house provider shape: display fields populated, secrets nulled.
+function makeProvider(providerId: string, name: string): AuthProvider {
+  return {
+    providerId,
+    type: 'builtin',
+    enabled: true,
+    name,
+    icon: providerId,
+    clientId: '',
+    discoveryUrl: null,
+    scopes: null,
+    clientSecret: null,
+  }
+}
+
 describe('OAuthButtons — render visibility logic', () => {
   it('returns false (renders null) when loading', () => {
-    const providers: AuthProvider[] = [{ providerId: 'github', type: 'oauth', name: 'GitHub', icon: '' }]
+    const providers: AuthProvider[] = [makeProvider('github', 'GitHub')]
 
     expect(shouldRender(true, providers)).toBe(false)
   })
@@ -35,16 +50,13 @@ describe('OAuthButtons — render visibility logic', () => {
   })
 
   it('returns true (renders buttons) when not loading and providers exist', () => {
-    const providers: AuthProvider[] = [{ providerId: 'github', type: 'oauth', name: 'GitHub', icon: '' }]
+    const providers: AuthProvider[] = [makeProvider('github', 'GitHub')]
 
     expect(shouldRender(false, providers)).toBe(true)
   })
 
   it('returns true when multiple providers are present', () => {
-    const providers: AuthProvider[] = [
-      { providerId: 'github', type: 'oauth', name: 'GitHub', icon: '' },
-      { providerId: 'google', type: 'oauth', name: 'Google', icon: '' },
-    ]
+    const providers: AuthProvider[] = [makeProvider('github', 'GitHub'), makeProvider('google', 'Google')]
 
     expect(shouldRender(false, providers)).toBe(true)
   })
@@ -53,10 +65,6 @@ describe('OAuthButtons — render visibility logic', () => {
 // ---------------------------------------------------------------------------
 // Provider data contract — shape expected from listAuthProviders
 // ---------------------------------------------------------------------------
-
-function makeProvider(providerId: string, name: string): AuthProvider {
-  return { providerId, type: 'oauth', name, icon: providerId }
-}
 
 describe('OAuthButtons — provider data contract', () => {
   it('provider has a providerId field used as the key and social sign-in provider', () => {

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -66,7 +66,6 @@ import {
   listActiveAnnouncements,
   listAdminAnnouncements,
   listAdminAuditLogs,
-  listAdminAuthProviders,
   listAnnouncements,
   listAuthProviders,
   listBackgroundJobs,
@@ -2568,16 +2567,26 @@ describe('api', () => {
       expect(url).toContain('/api/image-hosting/config')
     })
 
-    it('returns null when feature is not enabled', async () => {
-      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(null))
+    it('returns the disabled shape when feature is not enabled', async () => {
+      const disabled = {
+        enabled: false,
+        customDomain: null,
+        domainVerifiedAt: null,
+        domainStatus: 'none',
+        dnsInstructions: null,
+        refererAllowlist: null,
+        createdAt: null,
+      }
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(disabled))
 
       const result = await getIhostConfig()
 
-      expect(result).toBeNull()
+      expect(result).toEqual(disabled)
+      expect(result.enabled).toBe(false)
     })
 
     it('passes credentials: include', async () => {
-      vi.mocked(fetch).mockResolvedValueOnce(makeResponse(null))
+      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ enabled: false }))
 
       await getIhostConfig()
 
@@ -3797,16 +3806,6 @@ describe('api', () => {
   })
 
   describe('admin auth providers api', () => {
-    it('lists admin auth providers', async () => {
-      vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ items: [] }))
-
-      await listAdminAuthProviders()
-
-      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
-      expect(url).toBe('/api/site/auth-providers')
-      expect(init.method).toBe('GET')
-    })
-
     it('upserts an auth provider', async () => {
       const data = { enabled: true, clientId: 'cid', clientSecret: 'secret' }
       vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ providerId: 'google', ...data }))
@@ -3832,7 +3831,7 @@ describe('api', () => {
     it('throws ApiError on failure', async () => {
       vi.mocked(fetch).mockResolvedValueOnce(makeResponse({ error: 'forbidden' }, false, 403))
 
-      await expect(listAdminAuthProviders()).rejects.toThrow('forbidden')
+      await expect(upsertAuthProvider('google', {} as never)).rejects.toThrow('forbidden')
     })
   })
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -642,12 +642,8 @@ export function listAuthProviders() {
   return unwrap<{ items: AuthProvider[] }>(authProviders.index.$get())
 }
 
-export function listAdminAuthProviders() {
-  return unwrap<{ items: OAuthProviderConfig[] }>(authProviders.index.$get())
-}
-
 export function upsertAuthProvider(providerId: string, data: Omit<OAuthProviderConfig, 'providerId'>) {
-  return unwrap<OAuthProviderConfig>(authProviders[':providerId'].$put({ param: { providerId }, json: data }))
+  return unwrap<AuthProvider>(authProviders[':providerId'].$put({ param: { providerId }, json: data }))
 }
 
 export function deleteAuthProvider(providerId: string) {
@@ -942,7 +938,7 @@ export function saveShareToDrive(token: string, data: SaveShareInput) {
 export type { IhostConfigResponse }
 
 export function getIhostConfig() {
-  return unwrap<IhostConfigResponse | null>(ihostConfigApi.index.$get())
+  return unwrap<IhostConfigResponse>(ihostConfigApi.index.$get())
 }
 
 export function enableIhostFeature() {


### PR DESCRIPTION
Resolves #449 (split from #443 item #2). Enforces the API principle: **every endpoint exposes one monomorphic schema** — role/state changes field *values* (mask / null / filter), never the *shape*. Pre-SDK breaking change.

## image-hosting/config
- Dropped the `ImageHostingConfig | { enabled: false }` union. `GET /image-hosting/config` always returns the full `ImageHostingConfig` shape carrying `enabled`; not-configured → `enabled: false` with every other field `null` (`createdAt` is now nullable; `domainStatus` keeps its existing `'none'` sentinel since it's an enum).
- `buildResponse` is made **total over `row | null`** — the single producer of the shape; the GET handler loses its branch.
- `getIhostConfig()` no longer returns `| null`.

## auth-providers
- Collapsed the admin-config (masked) vs public-display union into **one** `AuthProvider` schema: `providerId, type, enabled, name, icon, clientId, discoveryUrl, scopes, clientSecret`.
- **Same endpoint, no path split.** Role changes one value only, server-enforced: admin → masked `clientSecret`; front-of-house → `clientSecret: null` + enabled-only list. `clientId`/`discoveryUrl`/`scopes` are not secrets (visible in the OAuth redirect), so they're exposed to everyone.
- The two list usecases collapse into `listAuthProviders(deps, { isAdmin })`. The PUT response and the merged frontend wrapper adopt the same schema; `AuthProviderConfig`/`PublicAuthProvider` deleted.

## Generated / consumers
- Regenerated the Go client — union types removed (`ImageHostingConfigResponse`, `AuthProviderConfig`, `PublicAuthProvider` gone; `AuthProvider`/`ImageHostingConfig` singular). operationIds unchanged.
- Expanded shared `AuthProvider` type; merged `listAuthProviders`/`listAdminAuthProviders` into one wrapper; updated admin section + all affected tests.

## Verification
- `pnpm typecheck` (raw tsc), `pnpm test` (4362), `pnpm test:cf` (59), biome, `lint:http`/`lint:arch`/`lint:spec`, `go build ./...`, `pnpm openapi:client:check` — all green locally.
- Integration tests exercise the real Hono app end-to-end for both endpoints: ihost disabled shape asserted exactly; auth-providers anon (`clientSecret: null`, enabled-only) vs admin (masked, all).
- Preview verification to follow on the CF Workers preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)