### PR TITLE
ci: publish :dev and :nightly docker images from main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,54 @@ jobs:
         if: always()
         run: docker compose -f docker-compose.yml down -v
 
+  docker-dev:
+    name: Docker dev image
+    runs-on: ubuntu-latest
+    needs: [check, docker-smoke]
+    # Publish the bleeding-edge `:dev` image only for green pushes to main on the
+    # canonical repo — never on PRs or forks. `:latest` stays pinned to releases.
+    if: github.repository == 'saltbo/zpan' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Build & push server image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            APP_VERSION=dev
+            APP_COMMIT=${{ github.sha }}
+          tags: ghcr.io/${{ github.repository }}:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build & push CLI image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          target: cli
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            APP_VERSION=dev
+            APP_COMMIT=${{ github.sha }}
+          tags: ghcr.io/${{ github.repository }}:dev-cli
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   cf-deploy-dry-run:
     name: CF deploy dry-run
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -1,0 +1,56 @@
+name: Docker Nightly
+
+# A genuine daily rebuild of main's HEAD. Unlike `:dev` (which only rebuilds when
+# code lands), this runs on a schedule with no cache so it picks up base-image and
+# OS security updates (node/debian, aria2, qbittorrent-nox) even on quiet days.
+# Scheduled runs only fire on the default branch, so this always tracks main.
+on:
+  schedule:
+    - cron: '27 3 * * *' # 03:27 UTC daily — minute offset dodges GitHub's congested top-of-hour scheduling
+  workflow_dispatch:
+
+jobs:
+  nightly:
+    name: Nightly image
+    runs-on: ubuntu-latest
+    if: github.repository == 'saltbo/zpan'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Build & push server image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          pull: true
+          no-cache: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            APP_VERSION=nightly
+            APP_COMMIT=${{ github.sha }}
+          tags: ghcr.io/${{ github.repository }}:nightly
+
+      - name: Build & push CLI image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          target: cli
+          push: true
+          pull: true
+          no-cache: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            APP_VERSION=nightly
+            APP_COMMIT=${{ github.sha }}
+          tags: ghcr.io/${{ github.repository }}:nightly-cli

--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -2,6 +2,18 @@
 
 ZPan ships as a single Docker image. By default it uses an embedded SQLite database (`better-sqlite3`). For production multi-replica deployments you can opt into [Turso](https://turso.tech) (libSQL) as a shared remote database.
 
+## Image tags
+
+Images are published to `ghcr.io/saltbo/zpan`. A CLI-only variant (downloader) is published under the matching `-cli` suffix.
+
+| Tag | Built from | When | Use for |
+| --- | --- | --- | --- |
+| `latest`, `2.6.1`, `2.6`, `2` | release tags (`v*`) | on every release | **production** — stable, version-pinned |
+| `dev` | `main` HEAD | every push to `main` (after CI passes) | trying the newest code as soon as it lands |
+| `nightly` | `main` HEAD | daily, full no-cache rebuild | newest code **plus** fresh base-image/OS security patches |
+
+`dev` and `nightly` are moving, unreviewed tags — do not pin production to them. Pulling without a tag (`ghcr.io/saltbo/zpan`) resolves to `latest`.
+
 ## Default: local SQLite
 
 No extra configuration needed. Mount a volume so the database survives container restarts:


### PR DESCRIPTION
## Problem

Docker images were only built on release tags (`v*`), so there was no published image tracking the latest code on `main`.

## Change

| Tag | Source | When | Use |
| --- | --- | --- | --- |
| `latest` / semver | release tags | on release | production (unchanged) |
| `dev` | main HEAD | every green push to main | try newest code as it lands |
| `nightly` | main HEAD | daily no-cache rebuild | newest code + fresh base-image/OS security patches |

- **`ci.yml`**: new `docker-dev` job — pushes `:dev`/`:dev-cli`, gated on `check` + `docker-smoke`, only on pushes to `main` of the canonical repo (skipped on PRs/forks).
- **`docker-nightly.yml`** (new): `schedule` (03:27 UTC, minute offset to dodge GitHub's congested top-of-hour scheduling) + `workflow_dispatch`. Full `no-cache`/`pull` rebuild so upstream `node`/`debian`/`aria2`/`qbittorrent-nox` patches land daily even without code changes.
- **`docs/deploy/docker.md`**: documents the tag scheme.

`:latest` stays pinned to releases. `:dev`/`:nightly` are moving, unreviewed tags — not for production.

## Notes

- `nightly` publishes without a pre-publish runtime health check (multi-arch builds can't `--load` then smoke). A failing base image fails the build (nothing pushed), but runtime regressions from base-image drift wouldn't be caught before publish.
- `actionlint` clean on both workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)