### PR TITLE
fix(downloader): give seeding its own concurrency budget and recycle orphan seeds

### DIFF
--- a/cmd/internal/config/config.go
+++ b/cmd/internal/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	SeedDuration          time.Duration
 	SeedCacheLimit        int64
 	SeedRatio             float64
+	SeedMaxConcurrent     int
 	Aria2Configured       bool
 	QBittorrentConfigured bool
 }
@@ -59,6 +60,7 @@ func Defaults(v *viper.Viper) {
 	v.SetDefault("downloader.seed.duration", "1h")
 	v.SetDefault("downloader.seed.cache_limit", "10GB")
 	v.SetDefault("downloader.seed.ratio", 0)
+	v.SetDefault("downloader.seed.max_concurrent", 10)
 }
 
 func Load(v *viper.Viper) (Config, error) {
@@ -110,6 +112,7 @@ func Load(v *viper.Viper) (Config, error) {
 		SeedDuration:       seedDuration,
 		SeedCacheLimit:     seedCacheLimit,
 		SeedRatio:          v.GetFloat64("downloader.seed.ratio"),
+		SeedMaxConcurrent:  v.GetInt("downloader.seed.max_concurrent"),
 		Aria2Configured: aria2Configured &&
 			(v.GetString("downloader.aria2.url") != DefaultAria2URL || v.GetString("downloader.aria2.secret") != ""),
 		QBittorrentConfigured: qbittorrentConfigured &&
@@ -138,6 +141,9 @@ func Load(v *viper.Viper) (Config, error) {
 	if cfg.SeedRatio < 0 {
 		return Config{}, errors.New("downloader.seed.ratio must not be negative")
 	}
+	if cfg.SeedMaxConcurrent < 0 {
+		return Config{}, errors.New("downloader.seed.max_concurrent must not be negative")
+	}
 	return cfg, nil
 }
 
@@ -160,6 +166,7 @@ func WriteDefaultConfig(path string, serverURL string) error {
 		SeedDuration:       time.Hour,
 		SeedCacheLimit:     10_000_000_000,
 		SeedRatio:          0,
+		SeedMaxConcurrent:  10,
 	}
 	return createConfigFile(path, defaultConfigYAML(cfg))
 }
@@ -216,6 +223,7 @@ func configYAML(cfg Config, includeRuntimeHints bool) string {
 	fmt.Fprintf(&b, "    duration: %s\n", yamlString(formatDuration(cfg.SeedDuration, "1h")))
 	fmt.Fprintf(&b, "    cache_limit: %s\n", yamlString(formatSeedCacheLimit(cfg.SeedCacheLimit)))
 	fmt.Fprintf(&b, "    ratio: %s\n", strconv.FormatFloat(cfg.SeedRatio, 'f', -1, 64))
+	fmt.Fprintf(&b, "    max_concurrent: %d\n", nonZero(cfg.SeedMaxConcurrent, 10))
 	if shouldWriteAria2Config(cfg) {
 		b.WriteString("  aria2:\n")
 		fmt.Fprintf(&b, "    url: %s\n", yamlString(nonEmpty(cfg.Aria2URL, DefaultAria2URL)))

--- a/cmd/internal/config/config_test.go
+++ b/cmd/internal/config/config_test.go
@@ -19,6 +19,7 @@ func TestLoadParsesSeedPolicy(t *testing.T) {
 	v.Set("downloader.seed.duration", "30m")
 	v.Set("downloader.seed.cache_limit", "10GB")
 	v.Set("downloader.seed.ratio", 1.5)
+	v.Set("downloader.seed.max_concurrent", 7)
 
 	cfg, err := Load(v)
 	if err != nil {
@@ -26,6 +27,9 @@ func TestLoadParsesSeedPolicy(t *testing.T) {
 	}
 	if !cfg.SeedEnabled {
 		t.Fatal("expected seed policy to be enabled")
+	}
+	if cfg.SeedMaxConcurrent != 7 {
+		t.Fatalf("expected seed max_concurrent 7, got %d", cfg.SeedMaxConcurrent)
 	}
 	if cfg.SeedDuration != 30*time.Minute {
 		t.Fatalf("expected seed duration 30m, got %s", cfg.SeedDuration)
@@ -57,6 +61,9 @@ func TestLoadUsesSafeSeedDefaults(t *testing.T) {
 	}
 	if cfg.SeedCacheLimit != 10_000_000_000 {
 		t.Fatalf("expected default seed cache limit 10GB, got %d", cfg.SeedCacheLimit)
+	}
+	if cfg.SeedMaxConcurrent != 10 {
+		t.Fatalf("expected default seed max_concurrent 10, got %d", cfg.SeedMaxConcurrent)
 	}
 	if cfg.Token != "" {
 		t.Fatalf("expected missing token to be accepted for device login bootstrap, got %q", cfg.Token)
@@ -119,6 +126,7 @@ func TestLoadRejectsInvalidSeedPolicy(t *testing.T) {
 		{name: "duration", key: "downloader.seed.duration", value: "-1s"},
 		{name: "cache limit", key: "downloader.seed.cache_limit", value: "-1GB"},
 		{name: "ratio", key: "downloader.seed.ratio", value: "-1"},
+		{name: "max concurrent", key: "downloader.seed.max_concurrent", value: "-1"},
 	}
 
 	for _, tt := range tests {

--- a/cmd/internal/engine/aria2.go
+++ b/cmd/internal/engine/aria2.go
@@ -23,13 +23,32 @@ import (
 )
 
 type Aria2 struct {
-	URL        string
-	Secret     string
-	Dir        string
-	StateDir   string
-	ListenPort int
-	RetainSeed bool
-	GeoIP      PeerGeoIPResolver
+	URL                    string
+	Secret                 string
+	Dir                    string
+	StateDir               string
+	ListenPort             int
+	MaxConcurrentDownloads int
+	RetainSeed             bool
+	SeedDuration           time.Duration
+	SeedRatio              float64
+	GeoIP                  PeerGeoIPResolver
+}
+
+// aria2 measures --seed-time in minutes. A zero seed duration means "seed
+// indefinitely", which we approximate with a very large value rather than 0
+// (aria2 treats --seed-time=0 as "do not seed at all").
+const aria2SeedForeverMinutes = 1000000
+
+func aria2SeedTimeMinutes(d time.Duration) uint {
+	if d <= 0 {
+		return aria2SeedForeverMinutes
+	}
+	minutes := uint(d.Minutes())
+	if minutes == 0 {
+		return 1
+	}
+	return minutes
 }
 
 var aria2StatusKeys = []string{
@@ -87,6 +106,12 @@ func (a Aria2) startArgs(rpcPort string) ([]string, error) {
 		"--allow-overwrite=true",
 		"--auto-file-renaming=false",
 		"--listen-port=" + listenPortString(a.ListenPort),
+	}
+	if a.MaxConcurrentDownloads > 0 {
+		// Retained seeds count as active downloads in aria2, so this budget must
+		// exceed the worker's download concurrency or seeding would starve new
+		// downloads. The worker caps real download concurrency itself.
+		args = append(args, "--max-concurrent-downloads="+strconv.Itoa(a.MaxConcurrentDownloads))
 	}
 	if a.StateDir != "" {
 		sessionPath := filepath.Join(a.StateDir, "aria2.session")
@@ -246,6 +271,37 @@ func (a Aria2) RestoreSeed(ctx context.Context, ref SeedRef) (*Seed, error) {
 	}, nil
 }
 
+func (a Aria2) ListSeeds(ctx context.Context) ([]Seed, error) {
+	aria, err := a.client(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer aria.Close()
+	statuses, err := a.taskStatuses(ctx, &aria)
+	if err != nil {
+		return nil, err
+	}
+	var seeds []Seed
+	for _, status := range statuses {
+		if !isAria2SeedStatus(status) {
+			continue
+		}
+		path := aria2StatusTaskDir(status, "")
+		if path == "" {
+			continue
+		}
+		seeds = append(seeds, Seed{
+			Engine:   "aria2",
+			ID:       status.GID,
+			InfoHash: strings.ToLower(status.InfoHash),
+			Path:     path,
+			Snapshot: a.seedSnapshot(status.GID),
+			Cleanup:  a.cleanupSeed(status.GID, path),
+		})
+	}
+	return seeds, nil
+}
+
 func (a Aria2) InspectTask(ctx context.Context, task client.DownloadTask) (TaskSnapshot, bool, error) {
 	if task.SourceType() == "http" {
 		return HTTP{Dir: a.Dir}.InspectTask(ctx, task)
@@ -302,7 +358,10 @@ func (a Aria2) Download(ctx context.Context, task client.DownloadTask, progress 
 		AutoFileRenaming: false,
 	}
 	if a.RetainSeed && task.SourceType() != "http" {
-		options.SeedTime = 1000000
+		// Let aria2 stop seeding on its own after the configured window so a seed
+		// can never outlive its retention even if the worker loses track of it.
+		options.SeedTime = aria2SeedTimeMinutes(a.SeedDuration)
+		options.SeedRatio = float32(a.SeedRatio)
 	}
 	if task.Name() != "" && task.SourceType() == "http" {
 		options.GID = aria2TaskGID(task.ID)

--- a/cmd/internal/engine/engine.go
+++ b/cmd/internal/engine/engine.go
@@ -79,6 +79,13 @@ type SeedRestorer interface {
 	RestoreSeed(ctx context.Context, ref SeedRef) (*Seed, error)
 }
 
+// SeedLister enumerates every torrent the engine is currently seeding,
+// including ones the worker is no longer tracking. The worker uses this to
+// reconcile orphaned seeds so they cannot occupy runtime slots forever.
+type SeedLister interface {
+	ListSeeds(ctx context.Context) ([]Seed, error)
+}
+
 type SessionSaver interface {
 	SaveSession(ctx context.Context) error
 }

--- a/cmd/internal/engine/engine_test.go
+++ b/cmd/internal/engine/engine_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Braurbeki/arigo"
 	qbittorrent "github.com/autobrr/go-qbittorrent"
@@ -148,6 +149,36 @@ func TestAria2StartArgsForceSaveCompletedSeeds(t *testing.T) {
 		if !strings.Contains(joined, expected) {
 			t.Fatalf("expected aria2 args to contain %q, got %v", expected, args)
 		}
+	}
+}
+
+func TestAria2StartArgsSetsMaxConcurrentDownloads(t *testing.T) {
+	args, err := (Aria2{Dir: t.TempDir(), MaxConcurrentDownloads: 25}).startArgs("6800")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(strings.Join(args, "\n"), "--max-concurrent-downloads=25") {
+		t.Fatalf("expected aria2 args to set max-concurrent-downloads, got %v", args)
+	}
+
+	zeroArgs, err := (Aria2{Dir: t.TempDir()}).startArgs("6800")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(strings.Join(zeroArgs, "\n"), "--max-concurrent-downloads") {
+		t.Fatalf("expected no max-concurrent-downloads flag when unset, got %v", zeroArgs)
+	}
+}
+
+func TestAria2SeedTimeMinutes(t *testing.T) {
+	if got := aria2SeedTimeMinutes(time.Hour); got != 60 {
+		t.Fatalf("expected 1h to map to 60 minutes, got %d", got)
+	}
+	if got := aria2SeedTimeMinutes(0); got != aria2SeedForeverMinutes {
+		t.Fatalf("expected zero duration to seed indefinitely, got %d", got)
+	}
+	if got := aria2SeedTimeMinutes(30 * time.Second); got != 1 {
+		t.Fatalf("expected sub-minute duration to round up to 1, got %d", got)
 	}
 }
 

--- a/cmd/internal/worker/engines.go
+++ b/cmd/internal/worker/engines.go
@@ -168,9 +168,32 @@ func explicitlyConfiguredExternalEngine(cfg config.Config, geoIP engine.PeerGeoI
 
 func externalEngines(cfg config.Config, geoIP engine.PeerGeoIPResolver) []engine.Engine {
 	return []engine.Engine{
-		engine.Aria2{URL: cfg.Aria2URL, Secret: cfg.Aria2Secret, Dir: cfg.DownloadDir, StateDir: cfg.StateDir, ListenPort: cfg.BTListenPort, RetainSeed: cfg.SeedEnabled, GeoIP: geoIP},
+		engine.Aria2{
+			URL:                    cfg.Aria2URL,
+			Secret:                 cfg.Aria2Secret,
+			Dir:                    cfg.DownloadDir,
+			StateDir:               cfg.StateDir,
+			ListenPort:             cfg.BTListenPort,
+			MaxConcurrentDownloads: aria2MaxConcurrentDownloads(cfg),
+			RetainSeed:             cfg.SeedEnabled,
+			SeedDuration:           cfg.SeedDuration,
+			SeedRatio:              cfg.SeedRatio,
+			GeoIP:                  geoIP,
+		},
 		engine.QBittorrent{URL: cfg.QBittorrentURL, Username: cfg.QBittorrentUser, Password: cfg.QBittorrentPass, Dir: cfg.DownloadDir, StateDir: cfg.StateDir, ListenPort: cfg.BTListenPort, RetainSeed: cfg.SeedEnabled, GeoIP: geoIP},
 	}
+}
+
+// aria2MaxConcurrentDownloads keeps download and seeding concurrency separate.
+// max_concurrent_tasks is the worker's download budget; retained seeds (which
+// aria2 counts as active downloads) get their own budget on top so they never
+// consume a download slot.
+func aria2MaxConcurrentDownloads(cfg config.Config) int {
+	limit := cfg.MaxConcurrentTasks
+	if cfg.SeedEnabled {
+		limit += cfg.SeedMaxConcurrent
+	}
+	return limit
 }
 
 func waitForEngine(ctx context.Context, downloader engine.Engine) error {

--- a/cmd/internal/worker/seeds.go
+++ b/cmd/internal/worker/seeds.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -356,6 +357,88 @@ func (w *Worker) retainedSeedSnapshot() []retainedSeed {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return append([]retainedSeed(nil), w.retainedSeeds...)
+}
+
+func (w *Worker) runningTaskIDs() map[string]struct{} {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	ids := make(map[string]struct{}, len(w.running))
+	for id := range w.running {
+		ids[id] = struct{}{}
+	}
+	return ids
+}
+
+// reconcileEngineSeeds adopts torrents the engine is still seeding but the
+// worker no longer tracks (orphans left behind by restarts or ledger drift),
+// so the normal time/ratio/cache cleanup applies to them instead of letting
+// them seed forever and hold runtime slots. Tasks still mid-flight (running or
+// already tracked) are skipped so reconciliation never races their cleanup.
+func (w *Worker) reconcileEngineSeeds(ctx context.Context) {
+	if !w.cfg.SeedEnabled {
+		return
+	}
+	lister, ok := w.engine.(engine.SeedLister)
+	if !ok {
+		return
+	}
+	seeds, err := lister.ListSeeds(ctx)
+	if err != nil {
+		w.logger.Warn("failed to list engine seeds for reconciliation", "error", err)
+		return
+	}
+	tracked := map[string]struct{}{}
+	for _, seed := range w.retainedSeedSnapshot() {
+		tracked[seed.taskID] = struct{}{}
+	}
+	running := w.runningTaskIDs()
+	now := time.Now()
+	var adopted []retainedSeed
+	for _, seed := range seeds {
+		taskID := filepath.Base(seed.Path)
+		if taskID == "" || taskID == "." || taskID == string(filepath.Separator) {
+			continue
+		}
+		if _, ok := tracked[taskID]; ok {
+			continue
+		}
+		if _, ok := running[taskID]; ok {
+			continue
+		}
+		size, err := directorySize(seed.Path)
+		if err != nil {
+			w.logger.Warn("failed to size adopted seed", "task_id", taskID, "path", seed.Path, "error", err)
+			continue
+		}
+		adoptedSeed := retainedSeed{
+			taskID:     taskID,
+			engine:     seed.Engine,
+			seedID:     seed.ID,
+			infoHash:   strings.ToLower(seed.InfoHash),
+			path:       seed.Path,
+			size:       size,
+			downloaded: size,
+			retainedAt: now,
+			snapshot:   seed.Snapshot,
+			cleanup:    seed.Cleanup,
+		}
+		if w.cfg.SeedDuration > 0 {
+			adoptedSeed.expiresAt = now.Add(w.cfg.SeedDuration)
+		}
+		adopted = append(adopted, adoptedSeed)
+		tracked[taskID] = struct{}{}
+		if err := w.upsertSeedLedger(adoptedSeed, size); err != nil {
+			w.logger.Warn("failed to persist adopted seed", "task_id", taskID, "error", err)
+		}
+	}
+	if len(adopted) == 0 {
+		return
+	}
+	w.mu.Lock()
+	w.retainedSeeds = append(w.retainedSeeds, adopted...)
+	count := len(w.retainedSeeds)
+	w.mu.Unlock()
+	w.logger.Info("adopted untracked engine seeds for managed expiry", "count", len(adopted), "retained_seeds", count)
 }
 
 func (w *Worker) cleanupRetainedSeed(ctx context.Context, seed retainedSeed, reason string) {

--- a/cmd/internal/worker/worker.go
+++ b/cmd/internal/worker/worker.go
@@ -140,6 +140,7 @@ func (w *Worker) Run(ctx context.Context) error {
 	w.logger.Info("downloader engine check passed", "engine", w.cfg.Engine)
 	w.logger.Info("downloader started", "engine", w.cfg.Engine)
 	w.restoreRetainedSeeds(runCtx)
+	w.reconcileEngineSeeds(runCtx)
 	ticker := time.NewTicker(w.cfg.PollInterval)
 	defer ticker.Stop()
 	seedCleanupTicker := time.NewTicker(time.Minute)
@@ -170,6 +171,7 @@ func (w *Worker) Run(ctx context.Context) error {
 			w.cleanupRetainedSeeds(runCtx)
 		case <-seedReportTicker.C:
 			w.restoreRetainedSeeds(runCtx)
+			w.reconcileEngineSeeds(runCtx)
 			w.reportRetainedSeeds(runCtx)
 		}
 	}

--- a/cmd/internal/worker/worker_test.go
+++ b/cmd/internal/worker/worker_test.go
@@ -70,6 +70,62 @@ func TestWatchEngineProcessQuietOnDeliberateStop(t *testing.T) {
 	}
 }
 
+func TestReconcileEngineSeedsAdoptsUntrackedOrphans(t *testing.T) {
+	root := t.TempDir()
+	orphanDir := filepath.Join(root, "orphan-task")
+	if err := os.MkdirAll(orphanDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(orphanDir, "file.bin"), make([]byte, 1024), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	trackedDir := filepath.Join(root, "tracked-task")
+	runningDir := filepath.Join(root, "running-task")
+	for _, dir := range []string{trackedDir, runningDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	eng := &recordingEngine{listSeeds: []engine.Seed{
+		{Engine: "aria2", ID: "g1", InfoHash: "AAAA", Path: orphanDir},
+		{Engine: "aria2", ID: "g2", InfoHash: "BBBB", Path: trackedDir},
+		{Engine: "aria2", ID: "g3", InfoHash: "CCCC", Path: runningDir},
+	}}
+	w := NewWithAPI(config.Config{SeedEnabled: true, SeedDuration: time.Hour}, &recordingAPI{})
+	w.logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	w.engine = eng
+	w.retainedSeeds = []retainedSeed{{taskID: "tracked-task"}}
+	w.running["running-task"] = func(error) {}
+
+	w.reconcileEngineSeeds(context.Background())
+
+	got := map[string]retainedSeed{}
+	trackedCount := 0
+	for _, seed := range w.retainedSeedSnapshot() {
+		got[seed.taskID] = seed
+		if seed.taskID == "tracked-task" {
+			trackedCount++
+		}
+	}
+	orphan, adopted := got["orphan-task"]
+	if !adopted {
+		t.Fatal("expected the untracked orphan seed to be adopted")
+	}
+	if orphan.expiresAt.IsZero() {
+		t.Fatal("expected the adopted orphan to receive an expiry")
+	}
+	if orphan.size != 1024 {
+		t.Fatalf("expected adopted orphan size 1024, got %d", orphan.size)
+	}
+	if _, ok := got["running-task"]; ok {
+		t.Fatal("expected the in-flight running task to be skipped, not adopted")
+	}
+	if trackedCount != 1 {
+		t.Fatalf("expected the already-tracked seed to stay single, got %d", trackedCount)
+	}
+}
+
 func TestHeartbeatReportsAggregateTransferSpeeds(t *testing.T) {
 	w := NewWithAPI(config.Config{Engine: "auto", MaxConcurrentTasks: 5}, &recordingAPI{})
 
@@ -1215,10 +1271,12 @@ type recordingEngine struct {
 	inspectPanic   any
 	taskFound      bool
 	restoreSeed    *engine.Seed
+	listSeeds      []engine.Seed
 	downloadCalls  int
 	resetCalls     int
 	inspectCalls   int
 	restoreCalls   int
+	listSeedsCalls int
 }
 
 func (e *recordingEngine) Name() string {
@@ -1247,6 +1305,11 @@ func (e *recordingEngine) InspectTask(context.Context, client.DownloadTask) (eng
 func (e *recordingEngine) RestoreSeed(context.Context, engine.SeedRef) (*engine.Seed, error) {
 	e.restoreCalls++
 	return e.restoreSeed, nil
+}
+
+func (e *recordingEngine) ListSeeds(context.Context) ([]engine.Seed, error) {
+	e.listSeedsCalls++
+	return e.listSeeds, nil
 }
 
 func (e *recordingEngine) ResetTask(context.Context, client.DownloadTask) error {


### PR DESCRIPTION
Follow-up to #461. Two coupled bugs starved aria2 downloads on a long-running node (found while debugging a VPS where downloads silently stopped with no error).

## Root cause
aria2 counts **seeding** torrents as active downloads, so retained seeds were consuming the shared `--max-concurrent-downloads` budget (default 5). Once enough completed torrents were seeding, new downloads sat in aria2's `waiting` queue forever — no error, just starved. Worse, aria2 was told `SeedTime=1000000` (~694 days), so it never stopped seeding on its own; the worker was the sole authority, and any drift between aria2's session and the worker's ledger (across restarts) left torrents seeding **forever**, holding slots + disk, never expired.

## Fixes
**1. Separate download vs seed concurrency.** `max_concurrent_tasks` is the *download* budget only. Seeding now gets its own budget via a new **Downloader-local** config `downloader.seed.max_concurrent` (default 10) — local like the other seed settings, not server-driven. aria2's `--max-concurrent-downloads` = `max_concurrent_tasks + seed.max_concurrent`, so seeds can never take a download slot. The worker still caps real download concurrency itself.

**2. aria2 self-stops seeding.** `SeedTime` is now the configured `seed_duration` (+ `seed-ratio`) instead of ~694 days, so aria2 stops seeding on its own even if the worker loses track.

**3. Orphan-seed reconciliation.** On startup and periodically, the worker enumerates what the engine is actually seeding (new `SeedLister` / aria2 `ListSeeds`) and adopts any torrent it no longer tracks into the ledger with an expiry — skipping in-flight (`running`) and already-tracked tasks — so normal time/ratio/cache cleanup applies instead of leaking.

## Verification
- `go build`/`vet`/`gofmt` clean; `go test ./...` green; worker+engine green under `-race`
- New tests: config default/parse/validation for `seed.max_concurrent`; aria2 `--max-concurrent-downloads` arg; `SeedTime` minute mapping; orphan adoption (skips running/tracked)
- Diagnosed live on the affected node: raising the limit immediately unblocked a queued magnet (0 → 32 MB/s); the orphan seeds matched torrents missing from the ledger

🤖 Generated with [Claude Code](https://claude.com/claude-code)