### PR TITLE
fix(downloader): drive stop-control from the task poll, make reporting pure

### DIFF
--- a/cmd/internal/client/client.go
+++ b/cmd/internal/client/client.go
@@ -312,8 +312,9 @@ func (c *Client) AssignedTasks(ctx context.Context) ([]DownloadTask, error) {
 
 func (c *Client) AssignedControlTasks(ctx context.Context) ([]DownloadTask, error) {
 	return c.assignedTasks(ctx, []openapi.ListDownloadTasksParamsStatus{
-		openapi.ListDownloadTasksParamsStatus("pausing"),
-		openapi.ListDownloadTasksParamsStatus("canceling"),
+		openapi.ListDownloadTasksParamsStatusPausing,
+		openapi.ListDownloadTasksParamsStatusCanceling,
+		openapi.ListDownloadTasksParamsStatusSuspended,
 	})
 }
 

--- a/cmd/internal/client/client_test.go
+++ b/cmd/internal/client/client_test.go
@@ -86,6 +86,25 @@ func TestAssignedTasksFetchesRunnableStatuses(t *testing.T) {
 	}
 }
 
+func TestAssignedControlTasksFetchesControlStatuses(t *testing.T) {
+	var statuses []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		statuses = append(statuses, r.URL.Query().Get("status"))
+		_ = json.NewEncoder(w).Encode(Page[DownloadTask]{Items: []DownloadTask{}})
+	}))
+	defer server.Close()
+
+	if _, err := mustClient(t, server.URL, "token").AssignedControlTasks(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(statuses)
+	expected := []string{"canceling", "pausing", "suspended"}
+	if !reflect.DeepEqual(statuses, expected) {
+		t.Fatalf("expected control statuses %v, got %v", expected, statuses)
+	}
+}
+
 func TestSeedingTasksFiltersCompletedSeedingPhase(t *testing.T) {
 	var status string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/internal/worker/worker.go
+++ b/cmd/internal/worker/worker.go
@@ -24,9 +24,9 @@ import (
 const Version = "0.1.0"
 const maxTaskErrorMessageLength = 1000
 
-var errBillingPaused = errors.New("billing paused")
 var errTaskPausing = errors.New("task pausing")
 var errTaskCanceling = errors.New("task canceling")
+var errTaskSuspended = errors.New("task suspended")
 var errEngineExited = errors.New("managed downloader engine exited")
 
 type taskWorkStage int
@@ -255,36 +255,30 @@ func (w *Worker) downloadThenUpload(
 	currentDetail *client.DownloadTaskRuntime,
 ) {
 	if _, err := w.updateTask(ctx, task.ID, client.TaskPatch{Status: "downloading"}); err != nil {
-		log.Error("failed to mark task downloading", "error", err)
-		if w.resolveControlledTaskUpdate(ctx, task.ID, err, log) {
-			return
-		}
+		log.Warn("failed to mark task downloading", "error", err)
 	}
 
 	var lastProgressLog time.Time
+	// Progress reporting is pure telemetry: it never decides whether to stop.
+	// Control transitions (pause/cancel/suspend) arrive through the task poll
+	// and cancel this context; a failed report just gets logged and retried.
 	result, err := w.engine.Download(ctx, task, func(downloaded int64, total *int64, bps int64, detail *client.DownloadTaskRuntime) error {
 		w.setTaskTransferSpeed(task.ID, transferSpeeds{downloadBps: bps})
 		detail = withDownloadRuntime(detail, downloaded, total, bps)
 		if detail != nil {
 			currentDetail = detail
 		}
-		_, updateErr := w.updateTask(ctx, task.ID, client.TaskPatch{
+		if _, updateErr := w.updateTask(ctx, task.ID, client.TaskPatch{
 			Progress: downloadProgressPatch(downloaded, total, bps),
 			Runtime:  detail,
-		})
-		if updateErr != nil && strings.Contains(updateErr.Error(), "insufficient_credits") {
-			log.Warn("task paused by billing", "downloaded_bytes", downloaded, "total_bytes", optionalInt64(total), "bps", bps)
-			return errBillingPaused
-		}
-		if updateErr != nil {
-			log.Error("failed to report task progress", "downloaded_bytes", downloaded, "total_bytes", optionalInt64(total), "bps", bps, "error", updateErr)
-			return updateErr
+		}); updateErr != nil {
+			log.Warn("failed to report task progress", "downloaded_bytes", downloaded, "total_bytes", optionalInt64(total), "bps", bps, "error", updateErr)
 		}
 		if time.Since(lastProgressLog) >= 10*time.Second {
 			log.Debug("task download progress", "downloaded_bytes", downloaded, "total_bytes", optionalInt64(total), "bps", bps)
 			lastProgressLog = time.Now()
 		}
-		return updateErr
+		return nil
 	})
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
@@ -302,6 +296,12 @@ func (w *Worker) downloadThenUpload(
 				log.Info("task canceled by control action")
 				return
 			}
+			if errors.Is(context.Cause(ctx), errTaskSuspended) {
+				// The server already moved the task to suspended (billing); the
+				// poll told us to stop. Don't touch its status.
+				log.Info("task stopped because it was suspended")
+				return
+			}
 			zero := int64(0)
 			downloaded, total := downloadCheckpoint(currentDetail)
 			if _, updateErr := w.updateTask(context.WithoutCancel(ctx), task.ID, client.TaskPatch{
@@ -312,17 +312,6 @@ func (w *Worker) downloadThenUpload(
 				log.Error("failed to mark task interrupted after shutdown", "error", updateErr)
 			}
 			log.Info("task stopped by context cancellation")
-			return
-		}
-		if isControlledTaskUpdateError(err) {
-			if w.resolveControlledTaskUpdate(context.WithoutCancel(ctx), task.ID, err, log) {
-				return
-			}
-			log.Info("task stopped because server state no longer accepts progress", "error", err)
-			return
-		}
-		if errors.Is(err, errBillingPaused) {
-			log.Warn("task stopped because credits are insufficient")
 			return
 		}
 		msg := taskErrorMessage(err)
@@ -772,12 +761,15 @@ func (w *Worker) cancelRunning(task client.DownloadTask) bool {
 	if cancel == nil {
 		return false
 	}
-	w.taskLogger(task).Info("canceling running task from server state", "status", task.State())
-	if task.State() == "pausing" {
+	w.taskLogger(task).Info("stopping running task from server state", "status", task.State())
+	switch task.State() {
+	case "pausing":
 		cancel(errTaskPausing)
-		return true
+	case "suspended":
+		cancel(errTaskSuspended)
+	default:
+		cancel(errTaskCanceling)
 	}
-	cancel(errTaskCanceling)
 	return true
 }
 
@@ -821,31 +813,6 @@ func (w *Worker) heartbeat() client.Heartbeat {
 		UploadBps:          speeds.uploadBps,
 		FreeDiskBytes:      0,
 	}
-}
-
-func (w *Worker) resolveControlledTaskUpdate(ctx context.Context, taskID string, err error, log *slog.Logger) bool {
-	message := err.Error()
-	if strings.Contains(message, "Task is pausing") {
-		if _, updateErr := w.updateTask(ctx, taskID, client.TaskPatch{Status: "paused"}); updateErr != nil {
-			log.Error("failed to mark task paused", "error", updateErr)
-		}
-		return true
-	}
-	if strings.Contains(message, "Task is canceling") {
-		if _, updateErr := w.updateTask(ctx, taskID, client.TaskPatch{Status: "canceled"}); updateErr != nil {
-			log.Error("failed to mark task canceled", "error", updateErr)
-		}
-		return true
-	}
-	return strings.Contains(message, "Task is paused") || strings.Contains(message, "Task is canceled")
-}
-
-func isControlledTaskUpdateError(err error) bool {
-	message := err.Error()
-	return strings.Contains(message, "Task is pausing") ||
-		strings.Contains(message, "Task is paused") ||
-		strings.Contains(message, "Task is canceling") ||
-		strings.Contains(message, "Task is canceled")
 }
 
 func (w *Worker) currentTasks() int {

--- a/cmd/internal/worker/worker_test.go
+++ b/cmd/internal/worker/worker_test.go
@@ -20,6 +20,36 @@ import (
 	"github.com/saltbo/zpan/internal/engine"
 )
 
+func TestCancelRunningUsesCauseForControlState(t *testing.T) {
+	cases := []struct {
+		state string
+		want  error
+	}{
+		{"pausing", errTaskPausing},
+		{"canceling", errTaskCanceling},
+		{"suspended", errTaskSuspended},
+	}
+	for _, tc := range cases {
+		t.Run(tc.state, func(t *testing.T) {
+			w := NewWithAPI(config.Config{MaxConcurrentTasks: 5}, &recordingAPI{})
+			w.logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+			taskCtx, ok := w.startTask(context.Background(), "task-1")
+			if !ok {
+				t.Fatal("expected to start task")
+			}
+			defer w.finish("task-1")
+
+			if !w.cancelRunning(clientTaskWithStatus("task-1", tc.state)) {
+				t.Fatal("expected cancelRunning to act on a running task")
+			}
+			<-taskCtx.Done()
+			if cause := context.Cause(taskCtx); !errors.Is(cause, tc.want) {
+				t.Fatalf("expected cancel cause %v, got %v", tc.want, cause)
+			}
+		})
+	}
+}
+
 func TestWatchEngineProcessFatalOnUnexpectedExit(t *testing.T) {
 	w := NewWithAPI(config.Config{}, nil)
 	w.logger = slog.New(slog.NewTextHandler(io.Discard, nil))


### PR DESCRIPTION
Fixes the "Suspended but still downloading" bug and removes the brittle error-string control logic the report path relied on (per design discussion).

## The bug
When remote-download credits run out, the server sets `status=suspended` and returns **200** (it catches the billing error). The worker's only stop-detection was `strings.Contains(updateErr.Error(), "insufficient_credits")` on the progress-report response — but there's no error (200), and the worker discarded the returned task. So the task kept downloading while the dashboard showed Suspended.

More broadly, the whole worker↔server control contract rode on string-matching the error **body** (the client can't even parse the structured `google.rpc.Status`, so it greps the raw JSON), e.g. `"Task is pausing"`.

## The fix (worker-only, polling model — no DO, no push)
Stop-control now flows **only** through the task poll; reporting is pure telemetry.

- `AssignedControlTasks` also queries `suspended`. When the poll sees a running task is `suspended`, `cancelRunning` cancels the download with a new `errTaskSuspended` cause and **leaves the server-owned `suspended` status untouched**.
- The `mark-downloading` update and the progress callback now just report — a failed report is logged, never acted on (`return nil`). No more control/billing judgment in the report path.
- Deleted `errBillingPaused`, the `insufficient_credits` match, and `isControlledTaskUpdateError`/`resolveControlledTaskUpdate`. pause/cancel already flowed through the poll; this was a redundant, brittle second path.

No server change needed: `status=suspended` is already a pollable status and the server keeps `assignedDownloaderId` on suspended tasks.

## Verification
- `go build`/`vet`/`gofmt` clean; `go test ./...` green; worker+client green under `-race`
- New tests: `cancelRunning` maps pausing/canceling/suspended → the right cancel cause; `AssignedControlTasks` queries `pausing|canceling|suspended`

🤖 Generated with [Claude Code](https://claude.com/claude-code)