### PR TITLE
fix(downloads): settle stale downloaders' canceling/pausing tasks

### DIFF
--- a/server/adapters/repos/download-task.ts
+++ b/server/adapters/repos/download-task.ts
@@ -238,5 +238,26 @@ export function createDownloadTaskRepo(db: Database): DownloadTaskRepo {
         .set({ status: 'queued', assignedDownloaderId: null, assignedAt: null, runtime: null, updatedAt: now })
         .where(and(inArray(downloadTasks.assignedDownloaderId, downloaderIds), inArray(downloadTasks.status, statuses)))
     },
+
+    async resolveControlAssignedToMany(downloaderIds, now) {
+      if (downloaderIds.length === 0) return
+      // A canceling task whose downloader vanished is effectively canceled.
+      await db
+        .update(downloadTasks)
+        .set({
+          status: 'canceled',
+          assignedDownloaderId: null,
+          assignedAt: null,
+          runtime: null,
+          finishedAt: now,
+          updatedAt: now,
+        })
+        .where(and(inArray(downloadTasks.assignedDownloaderId, downloaderIds), eq(downloadTasks.status, 'canceling')))
+      // A pausing task whose downloader vanished settles to paused (resumable).
+      await db
+        .update(downloadTasks)
+        .set({ status: 'paused', assignedDownloaderId: null, assignedAt: null, runtime: null, updatedAt: now })
+        .where(and(inArray(downloadTasks.assignedDownloaderId, downloaderIds), eq(downloadTasks.status, 'pausing')))
+    },
   }
 }

--- a/server/http/downloads/download-tasks.integration.test.ts
+++ b/server/http/downloads/download-tasks.integration.test.ts
@@ -351,6 +351,54 @@ describe('Download tasks API integration', () => {
     expect(listed?.status).toBe('offline')
   })
 
+  it('settles a stale downloader’s canceling task to canceled [spec: download-tasks/stale-resolves-canceling]', async () => {
+    const { app, db } = await createTestApp({ DOWNLOAD_TOKEN_SECRET: 'test-download-token-secret' })
+    await insertStorage(db)
+    const admin = await adminHeaders(app)
+    const downloader = await registerDownloaderThroughDeviceLogin(app, 'stale-cancel-downloader', admin)
+    expect(
+      await app.request('/api/downloads/downloaders/me/heartbeats', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${downloader.token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...heartbeat, currentTasks: 0 }),
+      }),
+    ).toHaveProperty('status', 200)
+
+    const user = await authedHeaders(app, 'stale-cancel-user@example.com')
+    const createRes = await app.request('/api/downloads/tasks', {
+      method: 'POST',
+      headers: { ...user, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source: { type: 'http', uri: 'https://example.com/stale-cancel.bin' }, targetFolder: '' }),
+    })
+    expect(createRes.status).toBe(201)
+    const task = (await createRes.json()) as DownloadTask
+    expect(task.status.assignment?.downloaderId).toBe(downloader.downloader.id)
+
+    // Cancel while assigned → canceling, waiting for the downloader to ack.
+    const cancelRes = await app.request(`/api/downloads/tasks/${task.id}/status`, {
+      method: 'PUT',
+      headers: { ...user, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'canceled' }),
+    })
+    expect(cancelRes.status).toBe(200)
+    await expect(cancelRes.json()).resolves.toMatchObject({ status: { state: 'canceling' } })
+
+    // The downloader goes offline before it can ack.
+    const staleHeartbeatAt = Date.now() - 60_000
+    await db.run(sql`
+      UPDATE downloaders
+      SET last_heartbeat_at = ${staleHeartbeatAt}, updated_at = ${staleHeartbeatAt}
+      WHERE id = ${downloader.downloader.id}
+    `)
+
+    // Stale recovery (triggered here by the admin list) must settle it, not leave it stuck.
+    expect((await app.request('/api/downloads/downloaders', { headers: admin })).status).toBe(200)
+
+    const taskRes = await app.request(`/api/downloads/tasks/${task.id}`, { headers: user })
+    expect(taskRes.status).toBe(200)
+    await expect(taskRes.json()).resolves.toMatchObject({ status: { state: 'canceled', assignment: null } })
+  })
+
   it('reassigns unfinished tasks from stale downloaders on live heartbeat [spec: download-tasks/reassign-on-heartbeat]', async () => {
     const { app, db } = await createTestApp({ DOWNLOAD_TOKEN_SECRET: 'test-download-token-secret' })
     await insertStorage(db)

--- a/server/usecases/downloads/downloads.ts
+++ b/server/usecases/downloads/downloads.ts
@@ -491,6 +491,9 @@ async function recoverStaleDownloaderAssignments(deps: DownloadsDeps): Promise<v
   const staleIds = await deps.downloaders.listStaleIds(leaseCutoff)
   if (staleIds.length === 0) return
   await deps.downloadTasks.requeueAssignedToMany(staleIds, STALE_REQUEUE_STATUSES, now)
+  // canceling/pausing tasks must settle terminally, not requeue — their owner is
+  // gone, so no downloader will ever ack the transition otherwise.
+  await deps.downloadTasks.resolveControlAssignedToMany(staleIds, now)
   await deps.downloaders.markStaleOffline(staleIds, now)
 }
 

--- a/server/usecases/ports/downloads.ts
+++ b/server/usecases/ports/downloads.ts
@@ -186,6 +186,8 @@ export interface DownloadTaskRepo {
   requeueAssignedTo(downloaderId: string, statuses: string[], now: Date): Promise<void>
   /** Re-queue in-flight tasks held by stale downloaders. */
   requeueAssignedToMany(downloaderIds: string[], statuses: string[], now: Date): Promise<void>
+  /** Resolve control states (canceling→canceled, pausing→paused) held by stale downloaders. */
+  resolveControlAssignedToMany(downloaderIds: string[], now: Date): Promise<void>
 }
 
 export interface UpdateDownloadTaskFields {


### PR DESCRIPTION
Fixes tasks getting stuck in `canceling` forever.

## Root cause
When a downloader goes offline (stale lease) while holding a `canceling` task, `recoverStaleDownloaderAssignments` only requeues `STALE_REQUEUE_STATUSES = [assigned, downloading, uploading, interrupted]`. `canceling`/`pausing` aren't in that set, so the task is never resolved — and since its owning downloader is gone, no live downloader will ever ack the transition. It sits in `canceling` indefinitely (observed on a production node where a task had been stuck for a long time, owned by an offline downloader).

Note: the *delete-downloader* path already requeues `canceling` (`DELETE_DOWNLOADER_REQUEUE_STATUSES`), but the *stale/offline* path did not.

## Fix
`recoverStaleDownloaderAssignments` now also settles control states for stale downloaders, instead of requeuing them (requeue would re-run work the user asked to stop):
- `canceling → canceled` (terminal; clears assignment, sets `finishedAt`)
- `pausing → paused` (resumable; clears assignment)

Adds the `resolveControlAssignedToMany` repo method. This runs on the existing recovery triggers (create task / list downloaders / assign queue), so it **auto-clears already-stuck tasks** on the next sweep and prevents recurrence — no manual DB edit needed.

## Verification
- `pnpm typecheck` clean
- New integration test (`stale-resolves-canceling`): a stale downloader's `canceling` task settles to `canceled` once recovery runs
- Full `download-tasks` integration suite green (24/24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)