### PR TITLE
refactor(branding): store logo + favicon as base64 data URIs (drop public bucket)

### DIFF
--- a/cmd/internal/openapi/client.gen.go
+++ b/cmd/internal/openapi/client.gen.go
@@ -25018,7 +25018,6 @@ type UpdateBrandingResponse struct {
 	JSON413      *Error
 	JSON415      *Error
 	JSON422      *Error
-	JSON503      *Error
 }
 
 // Status returns HTTPResponse.Status
@@ -39411,13 +39410,6 @@ func ParseUpdateBrandingResponse(rsp *http.Response) (*UpdateBrandingResponse, e
 			return nil, err
 		}
 		response.JSON422 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
-		var dest Error
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON503 = &dest
 
 	}
 

--- a/server/http/site/branding.integration.test.ts
+++ b/server/http/site/branding.integration.test.ts
@@ -1,22 +1,11 @@
-import { sql } from 'drizzle-orm'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import type { BrandingConfig } from '../../../shared/types'
-import { S3Service } from '../../adapters/gateways/s3.js'
 import { adminHeaders, authedHeaders, createTestApp, seedProLicense as seedProLicenseRow } from '../../test/setup.js'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-const NOW = Date.now()
-
 async function seedProLicense(db: Awaited<ReturnType<typeof createTestApp>>['db']) {
   await seedProLicenseRow(db)
-}
-
-async function seedPublicStorage(db: Awaited<ReturnType<typeof createTestApp>>['db']) {
-  await db.run(sql`
-    INSERT INTO storages (id, title, mode, bucket, endpoint, region, access_key, secret_key, file_path, custom_host, capacity, used, status, created_at, updated_at)
-    VALUES ('branding-storage', 'Public', 'public', 'test-bucket', 'https://s3.example.com', 'us-east-1', 'key', 'secret', '', '', 0, 0, 'active', ${NOW}, ${NOW})
-  `)
 }
 
 async function seedBrandingOption(db: Awaited<ReturnType<typeof createTestApp>>['db'], key: string, value: string) {
@@ -64,6 +53,18 @@ describe('GET /api/site/branding', () => {
     expect(body.hide_powered_by).toBe(true)
   })
 
+  it('still returns a legacy absolute-URL logo/favicon unchanged [spec: branding/legacy-url-compat]', async () => {
+    const { app, db } = await createTestApp()
+    await seedBrandingOption(db, 'branding_logo_url', 'https://cdn.example.com/_system/branding/logo.svg')
+    await seedBrandingOption(db, 'branding_favicon_url', 'https://cdn.example.com/_system/branding/favicon.png')
+
+    const res = await app.request('/api/site/branding')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as BrandingConfig
+    expect(body.logo_url).toBe('https://cdn.example.com/_system/branding/logo.svg')
+    expect(body.favicon_url).toBe('https://cdn.example.com/_system/branding/favicon.png')
+  })
+
   it('returns stored built-in theme values when set', async () => {
     const { app, db } = await createTestApp()
     await seedBrandingOption(db, 'branding_theme_mode', 'preset')
@@ -109,15 +110,6 @@ describe('GET /api/site/branding', () => {
 // ─── PUT /api/site/branding ──────────────────────────────────────────────────
 
 describe('PUT /api/site/branding', () => {
-  beforeEach(() => {
-    vi.spyOn(S3Service.prototype, 'putObject').mockResolvedValue(16)
-    vi.spyOn(S3Service.prototype, 'getPublicUrl').mockReturnValue('https://cdn.example.com/logo.png')
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
   it('returns 401 without auth', async () => {
     const { app } = await createTestApp()
     const res = await app.request('/api/site/branding', { method: 'PUT' })
@@ -268,28 +260,50 @@ describe('PUT /api/site/branding', () => {
     expect(res.status).toBe(422)
   })
 
-  it('uploads logo file to S3 and stores URL [spec: branding/logo-upload]', async () => {
+  it('stores an uploaded logo as a data URI — no public storage required [spec: branding/logo-upload]', async () => {
     const { app, db } = await createTestApp()
     const headers = await adminHeaders(app)
     await seedProLicense(db)
-    await seedPublicStorage(db)
+    // Intentionally no storage seeded — branding must not depend on mode='public' storage.
 
-    const logoFile = new File(['<svg></svg>'], 'logo.svg', { type: 'image/svg+xml' })
+    const svg = '<svg></svg>'
+    const logoFile = new File([svg], 'logo.svg', { type: 'image/svg+xml' })
     const form = new FormData()
     form.set('logo', logoFile)
 
     const res = await app.request('/api/site/branding', { method: 'PUT', headers, body: form })
     expect(res.status).toBe(200)
     const body = (await res.json()) as { logo_url: string }
-    expect(body.logo_url).toBe('https://cdn.example.com/logo.png')
-    expect(S3Service.prototype.putObject).toHaveBeenCalledTimes(1)
+    const expected = `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`
+    expect(body.logo_url).toBe(expected)
+
+    // GET reflects the same data URI.
+    const getRes = await app.request('/api/site/branding')
+    const getBody = (await getRes.json()) as BrandingConfig
+    expect(getBody.logo_url).toBe(expected)
+  })
+
+  it('stores an uploaded favicon as a data URI [spec: branding/favicon-upload]', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+    await seedProLicense(db)
+
+    const bytes = new Uint8Array([1, 2, 3, 4, 5])
+    const faviconFile = new File([bytes], 'favicon.ico', { type: 'image/x-icon' })
+    const form = new FormData()
+    form.set('favicon', faviconFile)
+
+    const res = await app.request('/api/site/branding', { method: 'PUT', headers, body: form })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { favicon_url: string }
+    const expected = `data:image/x-icon;base64,${Buffer.from(bytes).toString('base64')}`
+    expect(body.favicon_url).toBe(expected)
   })
 
   it('returns 400 for invalid logo MIME type [spec: branding/logo-mime]', async () => {
     const { app, db } = await createTestApp()
     const headers = await adminHeaders(app)
     await seedProLicense(db)
-    await seedPublicStorage(db)
 
     const badFile = new File(['data'], 'malware.exe', { type: 'application/octet-stream' })
     const form = new FormData()
@@ -299,15 +313,12 @@ describe('PUT /api/site/branding', () => {
     expect(res.status).toBe(400)
   })
 
-  it('returns 413 for logo file exceeding 2MB [spec: branding/logo-size]', async () => {
+  it('returns 413 for a logo exceeding 256 KB [spec: branding/logo-size]', async () => {
     const { app, db } = await createTestApp()
     const headers = await adminHeaders(app)
     await seedProLicense(db)
-    await seedPublicStorage(db)
 
-    // 2MB + 1 byte
-    const bigData = new Uint8Array(2 * 1024 * 1024 + 1)
-    const bigFile = new File([bigData], 'big.png', { type: 'image/png' })
+    const bigFile = new File([new Uint8Array(256 * 1024 + 1)], 'big.png', { type: 'image/png' })
     const form = new FormData()
     form.set('logo', bigFile)
 
@@ -315,18 +326,18 @@ describe('PUT /api/site/branding', () => {
     expect(res.status).toBe(413)
   })
 
-  it('returns 503 when no public storage is configured [spec: branding/logo-needs-storage]', async () => {
+  it('returns 413 for a favicon exceeding 64 KB [spec: branding/favicon-size]', async () => {
     const { app, db } = await createTestApp()
     const headers = await adminHeaders(app)
     await seedProLicense(db)
-    // No storage seeded — selectStorage will throw
 
-    const logoFile = new File(['<svg></svg>'], 'logo.svg', { type: 'image/svg+xml' })
+    // Under the 256 KB logo cap, but over the 64 KB favicon cap — proves per-field limits.
+    const bigFile = new File([new Uint8Array(64 * 1024 + 1)], 'big.png', { type: 'image/png' })
     const form = new FormData()
-    form.set('logo', logoFile)
+    form.set('favicon', bigFile)
 
     const res = await app.request('/api/site/branding', { method: 'PUT', headers, body: form })
-    expect(res.status).toBe(503)
+    expect(res.status).toBe(413)
   })
 })
 

--- a/server/http/site/branding.ts
+++ b/server/http/site/branding.ts
@@ -3,7 +3,7 @@ import { type BrandingField, type BrandingThemeMode, isBrandingThemePresetId } f
 import { requireAdmin } from '../../middleware/auth'
 import type { Env } from '../../middleware/platform'
 import { requireFeature } from '../../middleware/require-feature'
-import { AppError, badRequest, noStorage, payloadTooLarge, unsupportedMediaType } from '../../usecases/ports'
+import { AppError, badRequest, payloadTooLarge, unsupportedMediaType } from '../../usecases/ports'
 import { applyBrandingUpdate, readBranding, resetBranding, type ThemeUpdate } from '../../usecases/site/branding'
 import { errorResponse, jsonContent } from '../openapi'
 
@@ -114,7 +114,6 @@ const updateRoute = createRoute({
     413: errorResponse('File too large'),
     415: errorResponse('Expected multipart/form-data'),
     422: errorResponse('Invalid theme or wordmark'),
-    503: errorResponse('No public storage configured'),
   },
 })
 
@@ -167,7 +166,6 @@ export const brandingAdmin = new OpenAPIHono<Env>()
       theme: themeUpdate.values,
     })
     if (!result.ok) {
-      if (result.status === 503) throw noStorage(result.error)
       if (result.status === 413) throw payloadTooLarge(result.error)
       throw badRequest(result.error)
     }

--- a/server/usecases/site/branding.test.ts
+++ b/server/usecases/site/branding.test.ts
@@ -1,11 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { ActivityRepo, S3Gateway, StorageRecord, StorageRepo, SystemOptionsRepo } from '../ports'
+import type { ActivityRepo, SystemOptionsRepo } from '../ports'
 import {
   applyBrandingUpdate,
   BRANDING_KEYS,
   type BrandingDeps,
   type BrandingUpdateInput,
-  MAX_BRANDING_FILE_SIZE,
+  MAX_FAVICON_SIZE,
+  MAX_LOGO_SIZE,
   readBranding,
   resetBranding,
   resetBrandingTheme,
@@ -13,19 +14,7 @@ import {
   uploadBrandingImage,
 } from './branding'
 
-const sampleStorage = {
-  id: 'st-1',
-  title: 'Public',
-  mode: 'public',
-  bucket: 'b',
-  endpoint: 'https://s3.example.com',
-  region: 'us-east-1',
-  accessKey: 'k',
-  secretKey: 's',
-  customHost: null,
-} as unknown as StorageRecord
-
-function makeDeps(overrides: { options?: Map<string, string>; storages?: Partial<StorageRepo> } = {}) {
+function makeDeps(overrides: { options?: Map<string, string> } = {}) {
   const store = overrides.options ?? new Map<string, string>()
 
   const set = vi.fn(async (key: string, value: string, _isPublic: boolean) => {
@@ -37,18 +26,11 @@ function makeDeps(overrides: { options?: Map<string, string>; storages?: Partial
   const listByKeyLike = vi.fn(async (_pattern: string) => [...store].map(([key, value]) => ({ key, value })))
   const systemOptions = { set, delete: del, listByKeyLike } as unknown as SystemOptionsRepo
 
-  const select = vi.fn(async (_mode: 'private' | 'public') => sampleStorage)
-  const storages = { select, ...overrides.storages } as unknown as StorageRepo
-
-  const putObject = vi.fn(async () => 16)
-  const getPublicUrl = vi.fn(() => 'https://cdn.example.com/logo.png')
-  const s3 = { putObject, getPublicUrl } as unknown as S3Gateway
-
   const record = vi.fn(async () => {})
   const activity = { record } as unknown as ActivityRepo
 
-  const deps: BrandingDeps = { s3, storages, systemOptions, activity }
-  return { deps, store, set, del, listByKeyLike, select, putObject, getPublicUrl, record }
+  const deps: BrandingDeps = { systemOptions, activity }
+  return { deps, store, set, del, listByKeyLike, record }
 }
 
 function baseUpdate(over: Partial<BrandingUpdateInput> = {}): BrandingUpdateInput {
@@ -65,6 +47,9 @@ function baseUpdate(over: Partial<BrandingUpdateInput> = {}): BrandingUpdateInpu
 }
 
 const imageFile = (type = 'image/png', size = 10) => new File([new Uint8Array(size)], 'f', { type }) as unknown as File
+const imageFileFrom = (type: string, bytes: Uint8Array<ArrayBuffer>) =>
+  new File([bytes], 'f', { type }) as unknown as File
+const dataUri = (type: string, bytes: Uint8Array) => `data:${type};base64,${Buffer.from(bytes).toString('base64')}`
 
 beforeEach(() => vi.clearAllMocks())
 
@@ -168,10 +153,10 @@ describe('readBranding', () => {
 
 describe('uploadBrandingImage', () => {
   it('rejects an invalid logo MIME with 400', async () => {
-    const { deps, putObject } = makeDeps()
+    const { deps, set } = makeDeps()
     const res = await uploadBrandingImage(deps, 'logo', imageFile('application/octet-stream'))
     expect(res).toEqual({ ok: false, status: 400, error: expect.stringContaining('Invalid file type for logo') })
-    expect(putObject).not.toHaveBeenCalled()
+    expect(set).not.toHaveBeenCalled()
   })
 
   it('rejects an invalid favicon MIME with 400 listing favicon mimes', async () => {
@@ -186,37 +171,49 @@ describe('uploadBrandingImage', () => {
     expect(res.ok).toBe(true)
   })
 
-  it('rejects a file larger than the max with 413', async () => {
-    const { deps, putObject } = makeDeps()
-    const big = imageFile('image/png', MAX_BRANDING_FILE_SIZE + 1)
+  it('rejects a logo larger than 256 KB with 413 naming the limit', async () => {
+    const { deps, set } = makeDeps()
+    const big = imageFile('image/png', MAX_LOGO_SIZE + 1)
     const res = await uploadBrandingImage(deps, 'logo', big)
-    expect(res).toEqual({ ok: false, status: 413, error: 'File too large. Max 2 MiB.' })
-    expect(putObject).not.toHaveBeenCalled()
+    expect(res).toEqual({ ok: false, status: 413, error: 'Logo too large. Max 256 KB.' })
+    expect(set).not.toHaveBeenCalled()
   })
 
-  it('returns 503 when no public storage is configured', async () => {
-    const select = vi.fn(async () => {
-      throw new Error('no public storage')
+  it('rejects a favicon larger than 64 KB with 413 naming the limit', async () => {
+    const { deps, set } = makeDeps()
+    const big = imageFile('image/png', MAX_FAVICON_SIZE + 1)
+    const res = await uploadBrandingImage(deps, 'favicon', big)
+    expect(res).toEqual({ ok: false, status: 413, error: 'Favicon too large. Max 64 KB.' })
+    expect(set).not.toHaveBeenCalled()
+  })
+
+  it('applies per-field caps: a 128 KB file is fine for a logo but too large for a favicon', async () => {
+    const { deps } = makeDeps()
+    const size = 128 * 1024
+    expect((await uploadBrandingImage(deps, 'logo', imageFile('image/png', size))).ok).toBe(true)
+    expect(await uploadBrandingImage(deps, 'favicon', imageFile('image/png', size))).toMatchObject({
+      ok: false,
+      status: 413,
     })
-    const { deps } = makeDeps({ storages: { select } })
-    const res = await uploadBrandingImage(deps, 'logo', imageFile('image/png'))
-    expect(res).toEqual({ ok: false, status: 503, error: 'No public storage configured' })
   })
 
-  it('uploads, names the key from the mime ext, stores the public URL, and returns it', async () => {
-    const { deps, store, putObject, getPublicUrl, set, select } = makeDeps()
-    const res = await uploadBrandingImage(deps, 'logo', imageFile('image/svg+xml'))
-    expect(res).toEqual({ ok: true, url: 'https://cdn.example.com/logo.png' })
-    expect(select).toHaveBeenCalledWith('public')
-    expect(putObject).toHaveBeenCalledWith(
-      sampleStorage,
-      '_system/branding/logo.svg',
-      expect.any(Uint8Array),
-      'image/svg+xml',
-    )
-    expect(getPublicUrl).toHaveBeenCalledWith(sampleStorage, '_system/branding/logo.svg')
-    expect(set).toHaveBeenCalledWith(BRANDING_KEYS.logo, 'https://cdn.example.com/logo.png', true)
-    expect(store.get(BRANDING_KEYS.logo)).toBe('https://cdn.example.com/logo.png')
+  it('encodes the logo as a data URI matching the uploaded bytes, stores it, and returns it', async () => {
+    const { deps, store, set } = makeDeps()
+    const bytes = new Uint8Array([0x3c, 0x73, 0x76, 0x67, 0x3e]) // "<svg>"
+    const res = await uploadBrandingImage(deps, 'logo', imageFileFrom('image/svg+xml', bytes))
+    const expected = dataUri('image/svg+xml', bytes)
+    expect(res).toEqual({ ok: true, url: expected })
+    expect(set).toHaveBeenCalledWith(BRANDING_KEYS.logo, expected, true)
+    expect(store.get(BRANDING_KEYS.logo)).toBe(expected)
+  })
+
+  it('encodes a favicon as a data URI carrying its own mime type', async () => {
+    const { deps, store } = makeDeps()
+    const bytes = new Uint8Array([1, 2, 3, 4, 5, 6, 7])
+    const res = await uploadBrandingImage(deps, 'favicon', imageFileFrom('image/x-icon', bytes))
+    const expected = dataUri('image/x-icon', bytes)
+    expect(res).toEqual({ ok: true, url: expected })
+    expect(store.get(BRANDING_KEYS.favicon)).toBe(expected)
   })
 })
 
@@ -287,51 +284,55 @@ describe('applyBrandingUpdate', () => {
     )
   })
 
-  it('uploads logo then favicon and lists both as changed', async () => {
-    const { deps, putObject, record } = makeDeps()
+  it('stores logo then favicon as data URIs and lists both as changed', async () => {
+    const { deps, store, record } = makeDeps()
+    const logoBytes = new Uint8Array([10, 20, 30])
+    const faviconBytes = new Uint8Array([40, 50, 60, 70])
     const out = await applyBrandingUpdate(
       deps,
-      baseUpdate({ logoFile: imageFile('image/png'), faviconFile: imageFile('image/x-icon') }),
+      baseUpdate({
+        logoFile: imageFileFrom('image/png', logoBytes),
+        faviconFile: imageFileFrom('image/x-icon', faviconBytes),
+      }),
     )
     expect(out.ok).toBe(true)
-    expect(putObject).toHaveBeenCalledTimes(2)
+    expect(store.get(BRANDING_KEYS.logo)).toBe(dataUri('image/png', logoBytes))
+    expect(store.get(BRANDING_KEYS.favicon)).toBe(dataUri('image/x-icon', faviconBytes))
     expect(record).toHaveBeenCalledWith(expect.objectContaining({ metadata: { fields: ['logo', 'favicon'] } }))
   })
 
   it('short-circuits on a logo upload failure without touching favicon or recording activity', async () => {
-    const { deps, putObject, record } = makeDeps()
+    const { deps, store, record } = makeDeps()
     const out = await applyBrandingUpdate(
       deps,
       baseUpdate({ logoFile: imageFile('application/pdf'), faviconFile: imageFile('image/png') }),
     )
     expect(out).toEqual({ ok: false, status: 400, error: expect.stringContaining('Invalid file type for logo') })
-    expect(putObject).not.toHaveBeenCalled()
+    expect(store.has(BRANDING_KEYS.logo)).toBe(false)
+    expect(store.has(BRANDING_KEYS.favicon)).toBe(false)
     expect(record).not.toHaveBeenCalled()
   })
 
-  it('propagates a 503 storage failure from the favicon upload after the logo succeeded', async () => {
-    let calls = 0
-    const select = vi.fn(async () => {
-      calls += 1
-      if (calls === 2) throw new Error('gone') // logo ok, favicon fails
-      return sampleStorage
-    })
-    const { deps, record } = makeDeps({ storages: { select } })
+  it('propagates a 413 from the favicon upload after the logo succeeded', async () => {
+    const { deps, store, record } = makeDeps()
     const out = await applyBrandingUpdate(
       deps,
-      baseUpdate({ logoFile: imageFile('image/png'), faviconFile: imageFile('image/png') }),
+      baseUpdate({
+        logoFile: imageFile('image/png'),
+        faviconFile: imageFile('image/png', MAX_FAVICON_SIZE + 1),
+      }),
     )
-    expect(out).toEqual({ ok: false, status: 503, error: 'No public storage configured' })
+    expect(out).toEqual({ ok: false, status: 413, error: 'Favicon too large. Max 64 KB.' })
+    expect(store.has(BRANDING_KEYS.favicon)).toBe(false)
     expect(record).not.toHaveBeenCalled()
   })
 
   it('does not record an audit event when nothing changed', async () => {
-    const { deps, record, set, putObject } = makeDeps()
+    const { deps, record, set } = makeDeps()
     const out = await applyBrandingUpdate(deps, baseUpdate())
     expect(out.ok).toBe(true)
     expect(record).not.toHaveBeenCalled()
     expect(set).not.toHaveBeenCalled()
-    expect(putObject).not.toHaveBeenCalled()
   })
 
   it('records the full changed-field list across files, scalars, and theme', async () => {

--- a/server/usecases/site/branding.ts
+++ b/server/usecases/site/branding.ts
@@ -5,19 +5,19 @@ import {
   type BrandingThemeMode,
   isBrandingThemePresetId,
 } from '@shared/types'
-import { mimeToExt } from '../../lib/mime-utils'
-import type { ActivityRepo, S3Gateway, StorageRecord, StorageRepo, SystemOptionsRepo } from '../ports'
+import type { ActivityRepo, SystemOptionsRepo } from '../ports'
 
 export type BrandingDeps = {
-  s3: S3Gateway
-  storages: StorageRepo
   systemOptions: SystemOptionsRepo
   activity: ActivityRepo
 }
 
 const LOGO_MIMES = ['image/png', 'image/jpeg', 'image/webp', 'image/svg+xml'] as const
 const FAVICON_MIMES = ['image/png', 'image/x-icon', 'image/vnd.microsoft.icon', 'image/svg+xml'] as const
-export const MAX_BRANDING_FILE_SIZE = 2 * 1024 * 1024 // 2 MiB
+// Caps apply to the RAW uploaded bytes. Base64 inflates ~33%, but GET
+// /api/site/branding is public + 5-min cached so the stored payload stays small.
+export const MAX_LOGO_SIZE = 256 * 1024 // 256 KB
+export const MAX_FAVICON_SIZE = 64 * 1024 // 64 KB
 
 export const BRANDING_KEYS = {
   logo: 'branding_logo_url',
@@ -46,7 +46,7 @@ const THEME_KEYS = [
 export type ThemeField = (typeof THEME_KEYS)[number]
 export type ThemeUpdate = Partial<Record<ThemeField, string>>
 
-export type BrandingUploadResult = { ok: true; url: string } | { ok: false; status: 400 | 413 | 503; error: string }
+export type BrandingUploadResult = { ok: true; url: string } | { ok: false; status: 400 | 413; error: string }
 
 // The parsed, already-validated PUT payload. Multipart parsing, theme/color
 // validation, and the wordmark-length check are http concerns; this usecase
@@ -63,11 +63,11 @@ export type BrandingUpdateInput = {
 }
 
 // On an image-upload failure the handler maps `status`/`error` straight to its
-// response (400 invalid type, 413 too large, 503 no public storage). On success
-// the freshly-read config is returned for serialization.
+// response (400 invalid type, 413 too large). On success the freshly-read config
+// is returned for serialization.
 export type BrandingUpdateOutcome =
   | { ok: true; config: BrandingConfig }
-  | { ok: false; status: 400 | 413 | 503; error: string }
+  | { ok: false; status: 400 | 413; error: string }
 
 export async function readBranding(deps: Pick<BrandingDeps, 'systemOptions'>): Promise<BrandingConfig> {
   const keys = Object.values(BRANDING_KEYS)
@@ -167,8 +167,11 @@ export async function resetBranding(
   })
 }
 
+// Encodes the uploaded file as a `data:` URI and stores it in the branding
+// system option. No S3 / public storage is involved — the data URI is served
+// inline by the public, cached GET /api/site/branding.
 export async function uploadBrandingImage(
-  deps: Pick<BrandingDeps, 's3' | 'storages' | 'systemOptions'>,
+  deps: Pick<BrandingDeps, 'systemOptions'>,
   field: 'logo' | 'favicon',
   file: File,
 ): Promise<BrandingUploadResult> {
@@ -176,22 +179,14 @@ export async function uploadBrandingImage(
   if (!(allowedMimes as readonly string[]).includes(file.type)) {
     return { ok: false, status: 400, error: `Invalid file type for ${field}. Allowed: ${allowedMimes.join(', ')}` }
   }
-  if (file.size > MAX_BRANDING_FILE_SIZE) {
-    return { ok: false, status: 413, error: 'File too large. Max 2 MiB.' }
+  const maxSize = field === 'logo' ? MAX_LOGO_SIZE : MAX_FAVICON_SIZE
+  if (file.size > maxSize) {
+    const label = field === 'logo' ? 'Logo' : 'Favicon'
+    return { ok: false, status: 413, error: `${label} too large. Max ${maxSize / 1024} KB.` }
   }
 
-  let storage: StorageRecord
-  try {
-    storage = await deps.storages.select('public')
-  } catch {
-    return { ok: false, status: 503, error: 'No public storage configured' }
-  }
-
-  const ext = mimeToExt(file.type)
-  const key = `_system/branding/${field}.${ext}`
   const bytes = new Uint8Array(await file.arrayBuffer())
-  await deps.s3.putObject(storage, key, bytes, file.type)
-  const url = deps.s3.getPublicUrl(storage, key)
+  const url = `data:${file.type};base64,${Buffer.from(bytes).toString('base64')}`
 
   await deps.systemOptions.set(BRANDING_KEYS[field], url, true)
   return { ok: true, url }

--- a/spec/branding.feature
+++ b/spec/branding.feature
@@ -20,6 +20,12 @@ Feature: Branding
     When the public branding is requested
     Then the stored values are returned
 
+  @branding/legacy-url-compat @api
+  Scenario: Legacy absolute-URL logo and favicon are still served
+    Given stored branding with absolute-URL logo and favicon
+    When the public branding is requested
+    Then the absolute URLs are returned unchanged
+
   @branding/custom-theme @api
   Scenario: Custom theme colors are served
     Given stored custom theme colors
@@ -69,10 +75,16 @@ Feature: Branding
     Then the API responds 422 and the stored theme is unchanged
 
   @branding/logo-upload @api
-  Scenario: A logo is uploaded to S3
-    Given an admin with Pro and a public storage
+  Scenario: A logo is stored as a data URI
+    Given an admin with Pro and no public storage
     When they upload a valid logo
-    Then it is stored to S3 and its URL recorded
+    Then it is stored as a base64 data URI and returned unchanged
+
+  @branding/favicon-upload @api
+  Scenario: A favicon is stored as a data URI
+    Given an admin with Pro
+    When they upload a valid favicon
+    Then it is stored as a base64 data URI carrying its mime type
 
   @branding/logo-mime @api
   Scenario: Logo type is validated
@@ -83,14 +95,14 @@ Feature: Branding
   @branding/logo-size @api
   Scenario: Logo size is limited
     Given an admin with Pro
-    When they upload a logo larger than 2MB
+    When they upload a logo larger than 256KB
     Then the API responds 413
 
-  @branding/logo-needs-storage @api
-  Scenario: Logo upload needs a public storage
-    Given no public storage
-    When an admin uploads a logo
-    Then the API responds 503
+  @branding/favicon-size @api
+  Scenario: Favicon size is limited
+    Given an admin with Pro
+    When they upload a favicon larger than 64KB
+    Then the API responds 413
 
   @branding/admin-only @api
   Scenario: Only admins update branding

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -3478,8 +3478,9 @@ describe('api', () => {
     })
 
     it('resolves with stored branding values', async () => {
+      const logoDataUri = 'data:image/svg+xml;base64,PHN2Zz48L3N2Zz4='
       const payload = {
-        logo_url: 'https://cdn.example.com/logo.svg',
+        logo_url: logoDataUri,
         favicon_url: null,
         wordmark_text: 'MyCloud',
         hide_powered_by: true,
@@ -3489,7 +3490,7 @@ describe('api', () => {
 
       const result = await getBranding()
 
-      expect(result.logo_url).toBe('https://cdn.example.com/logo.svg')
+      expect(result.logo_url).toBe(logoDataUri)
       expect(result.wordmark_text).toBe('MyCloud')
       expect(result.hide_powered_by).toBe(true)
     })
@@ -3560,7 +3561,7 @@ describe('api', () => {
 
     it('includes only logo file fields in FormData when provided', async () => {
       const payload = {
-        logo_url: 'https://cdn/logo.png',
+        logo_url: 'data:image/png;base64,cG5nLWRhdGE=',
         favicon_url: null,
         wordmark_text: null,
         hide_powered_by: false,


### PR DESCRIPTION
## Goal

Store the site logo and favicon as base64 `data:` URIs in `systemOptions` instead of uploading them to a public S3 bucket, removing branding's dependency on `mode='public'` storage. (#456 Part 1 only.)

## Changes

- **`server/usecases/site/branding.ts`** — `uploadBrandingImage` now encodes the raw file bytes as `data:${file.type};base64,…` and stores that in the `branding_logo_url` / `branding_favicon_url` system option. Dropped `select('public')`, `s3.putObject`, `s3.getPublicUrl`, and removed `s3` + `storages` from `BrandingDeps`. The single 2 MiB `MAX_BRANDING_FILE_SIZE` is replaced by per-field raw-byte caps `MAX_LOGO_SIZE = 256 KB` and `MAX_FAVICON_SIZE = 64 KB`. The ok:false `status` union narrows from `400|413|503` to `400|413`.
- **`server/http/site/branding.ts`** — removed the `503` response from the `updateBranding` route, the `if (result.status === 503)` branch, and the now-unused `noStorage` import. `operationId: 'updateBranding'` unchanged.
- **`cmd/internal/openapi/client.gen.go`** — regenerated via `pnpm openapi:client`; only diff is dropping `JSON503` from `UpdateBrandingResponse` / its parse case.
- **Tests** — unit + integration branding tests reworked: no S3 mocks; assert stored values are `data:<mime>;base64,<…>` URIs matching the uploaded bytes; per-field 413 caps (logo > 256 KB, favicon > 64 KB); kept bad-MIME → 400; removed the 503 test; added a legacy absolute-URL backward-compat GET test. `spec/branding.feature` updated to match. `src/lib/api.test.ts` mock values switched to data URIs (cosmetic).

## Behavior notes

- Uploads now succeed even when **no `mode='public'` storage** exists (no 503).
- Size caps apply to raw upload bytes; base64 inflates ~33%, and `GET /api/site/branding` is public + 5-min cached (React Query `staleTime`), so the inline payload stays small.
- `GET` shape unchanged (`logo_url`/`favicon_url` stay `string | null`); legacy absolute-URL values keep being returned and rendering as-is. No DB migration, no backfill, old `_system/branding/*` objects left intact.
- Out of scope (#456 Parts 2–3): avatar/team-logo upload, `storages.mode`, `StorageRepo.select`.

## Verification (all gates green from raw output)

`typecheck`, `lint` (biome, 646 files), `lint:arch`, `lint:http`, `lint:spec` (417 scenarios), `openapi:client:check`, unit + integration (4367 tests), Cloudflare (59 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)