### PR TITLE
chore(deps): bump nodemailer 8→9.0.1 & undici 7.24.8→7.28.0 (security)

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "lucide-react": "^0.577.0",
     "nanoid": "^5.1.11",
     "next-themes": "^0.4.6",
-    "nodemailer": "^8.0.9",
+    "nodemailer": "^9.0.1",
     "paseto-ts": "^2.0.6",
     "pdfjs-dist": "^5.6.205",
     "posthog-node": "^5.36.4",
@@ -161,7 +161,7 @@
       "@vitest/snapshot": "4.1.4",
       "@vitest/spy": "4.1.4",
       "@vitest/utils": "4.1.4",
-      "undici": "7.24.8"
+      "undici": "7.28.0"
     },
     "onlyBuiltDependencies": [
       "@swc/core",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ overrides:
   '@vitest/snapshot': 4.1.4
   '@vitest/spy': 4.1.4
   '@vitest/utils': 4.1.4
-  undici: 7.24.8
+  undici: 7.28.0
 
 importers:
 
@@ -116,8 +116,8 @@ importers:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       nodemailer:
-        specifier: ^8.0.9
-        version: 8.0.9
+        specifier: ^9.0.1
+        version: 9.0.1
       paseto-ts:
         specifier: ^2.0.6
         version: 2.0.6
@@ -4793,8 +4793,8 @@ packages:
     resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
     engines: {node: '>=18'}
 
-  nodemailer@8.0.9:
-    resolution: {integrity: sha512-5ofa7BUN8+C+Hckh5V2GjeeOGRQBx0CJQA6KxrvuZfC8iU4/q7sLn8XrtEEhJkjV6HdyIiQs7Bba6bTao8JhkA==}
+  nodemailer@9.0.1:
+    resolution: {integrity: sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==}
     engines: {node: '>=6.0.0'}
 
   normalize-path@3.0.0:
@@ -5516,8 +5516,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.24.8:
-    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -9692,7 +9692,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.24.8
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -10213,7 +10213,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 7.24.8
+      undici: 7.28.0
       workerd: 1.20260526.1
       ws: 8.20.1
       youch: 4.1.0-beta.10
@@ -10280,7 +10280,7 @@ snapshots:
 
   node-releases@2.0.46: {}
 
-  nodemailer@8.0.9: {}
+  nodemailer@9.0.1: {}
 
   normalize-path@3.0.0: {}
 
@@ -11175,7 +11175,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.24.8: {}
+  undici@7.28.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:


### PR DESCRIPTION
Resolves the open Dependabot security alerts for the two **high**-severity packages. Supersedes #458 (this branch runs full CI with secrets, which a Dependabot-authored PR can't).

## Alerts cleared

| Package | Severity | Change |
|---|---|---|
| nodemailer | high | `8.0.9` → `9.0.1` (direct dep) |
| undici | high×3 / med×2 / low×2 | override `7.24.8` → `7.28.0` (transitive) |

### nodemailer
The advisory: the message-level `raw` option bypassed `disableFileAccess`/`disableUrlAccess` (arbitrary file read + SSRF). Our email gateway (`server/adapters/gateways/email.ts`) only sends `html` over an SMTP transport — no `raw`, no remote attachment fetching, no OAuth2/proxy — so **neither the vuln nor the 9.0 TLS-cert-validation breaking change affects us**.

### undici
The `pnpm.overrides` entry pinned undici at `7.24.8` (a leftover dedup pin from the pnpm migration, not a real constraint). Bumped to `7.28.0`; all consumers (jsdom / vitest / better-auth / miniflare / wrangler) accept `^7`, so it dedups to a single patched version. Clears 7 alerts in one move.

## Verification
- ✅ `pnpm typecheck`
- ✅ `pnpm test` — 4347 unit/integration passed
- ✅ `pnpm test:cf` — 59 CF Workers passed
- ✅ `pnpm build` — production vite build green

## Not in this PR: esbuild (low)
The remaining alert (esbuild `<0.28.1`, **low**) is *"arbitrary file read when running esbuild's dev server on Windows."* The vulnerable `0.27.x` is pulled transitively by vite 7 / tsup / drizzle-kit / the CF vite plugins — all **dev/build tooling that uses esbuild as a library and never invokes its `serve` dev server**, and we develop/deploy on macOS/Linux/Workers. The clean upgrade path is vite 8, which swaps the bundler from esbuild to **rolldown** — a disproportionate migration for a low-severity, dev-only, not-in-deploy-path alert. Recommend dismissing it (dev dependency / not in use) or folding it into a separate vite-8 evaluation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)