### PR TITLE
fix(security): resolve all 23 CodeQL code-scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ env:
   E2E_CLOUD_PRO_EMAIL: ${{ secrets.E2E_CLOUD_PRO_EMAIL }}
   E2E_CLOUD_PRO_PASSWORD: ${{ secrets.E2E_CLOUD_PRO_PASSWORD }}
 
+# Least-privilege default; jobs that need more (e.g. packages: write) opt in per-job.
+permissions:
+  contents: read
+
 jobs:
   downloader:
     name: Downloader (Go)

--- a/.github/workflows/deploy-aws-lambda.yml
+++ b/.github/workflows/deploy-aws-lambda.yml
@@ -16,6 +16,9 @@ concurrency:
   group: deploy-aws-lambda
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -36,6 +36,9 @@ concurrency:
   group: deploy-azure
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -28,6 +28,9 @@ concurrency:
   group: deploy-cloud-run
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -16,6 +16,9 @@ concurrency:
   group: deploy-cloudflare
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy

--- a/.github/workflows/deploy-netlify.yml
+++ b/.github/workflows/deploy-netlify.yml
@@ -16,6 +16,9 @@ concurrency:
   group: deploy-netlify
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -16,6 +16,9 @@ concurrency:
   group: deploy-vercel
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,9 @@ concurrency:
   group: deploy-dispatch
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   detect:
     name: Detect configured platforms

--- a/scripts/s3-mock.mjs
+++ b/scripts/s3-mock.mjs
@@ -16,8 +16,9 @@ const server = createServer(async (req, res) => {
   try {
     await handleRequest(req, res)
   } catch (error) {
+    console.error('[s3-mock] request failed:', error)
     res.writeHead(500, { 'Content-Type': 'text/plain' })
-    res.end(error instanceof Error ? error.message : String(error))
+    res.end('Internal Server Error')
   }
 })
 

--- a/server/adapters/providers/changelog.test.ts
+++ b/server/adapters/providers/changelog.test.ts
@@ -15,7 +15,9 @@ function markdownResponse(body: string, ok = true, status = 200): Response {
 function stubFetch(opts: { release: () => Response; changelog: () => Response }) {
   vi.stubGlobal(
     'fetch',
-    vi.fn(async (url: string) => (String(url).includes('api.github.com') ? opts.release() : opts.changelog())),
+    vi.fn(async (url: string) =>
+      new URL(String(url)).hostname === 'api.github.com' ? opts.release() : opts.changelog(),
+    ),
   )
 }
 

--- a/server/http/site/system.integration.test.ts
+++ b/server/http/site/system.integration.test.ts
@@ -151,7 +151,7 @@ describe('System API — options CRUD', () => {
       vi.stubGlobal(
         'fetch',
         vi.fn(async (url: string) =>
-          String(url).includes('api.github.com')
+          new URL(String(url)).hostname === 'api.github.com'
             ? ({ ok: true, status: 200, json: async () => ({ tag_name: 'v2.8.0' }) } as unknown as Response)
             : ({ ok: true, status: 200, text: async () => markdown } as unknown as Response),
         ),

--- a/src/components/files/dialogs/share-dialog.tsx
+++ b/src/components/files/dialogs/share-dialog.tsx
@@ -34,7 +34,8 @@ export const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 export function genPassword(): string {
   const chars = 'ABCDEFGHJKMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789'
-  return Array.from({ length: 12 }, () => chars[Math.floor(Math.random() * chars.length)]).join('')
+  const values = crypto.getRandomValues(new Uint32Array(12))
+  return Array.from(values, (v) => chars[v % chars.length]).join('')
 }
 
 export function addDays(n: number): string {


### PR DESCRIPTION
Clears every open CodeQL alert on the repo (23 total).

## Changes

### `actions/missing-workflow-permissions` — 19 alerts (medium)
Added a top-level least-privilege `permissions: contents: read` to `ci.yml` and all 7 deploy workflows (`deploy.yml`, `deploy-cloudflare`, `deploy-vercel`, `deploy-netlify`, `deploy-azure`, `deploy-cloud-run`, `deploy-aws-lambda`).

Verified each is safe at `read`:
- The only CI job needing `packages: write` (the `:dev` image publish) already declares its own per-job block — untouched.
- Every deploy authenticates via **static secrets** (AWS access keys, `AZURE_CREDENTIALS`, CF/Vercel/Netlify tokens) — **no OIDC / `id-token`, no repo writes** — so checkout-only `contents: read` suffices.
- `release.yml` / `docker-nightly.yml` already had per-job permissions (no alerts) — untouched.

### `js/insecure-randomness` — 1 alert (high)
`genPassword()` generated share passwords with `Math.random()`. Switched to `crypto.getRandomValues()` over the same unambiguous alphabet. Length (12), charset, uniqueness, and the "no `IOl01`" property are all preserved (existing `genPassword` tests still pass).

### `js/incomplete-url-substring-sanitization` — 2 alerts (high)
Two **test** fetch stubs routed on `String(url).includes('api.github.com')`. Tightened to `new URL(url).hostname === 'api.github.com'` — precise host match, no longer flagged.

### `js/stack-trace-exposure` — 1 alert (medium)
The E2E S3 mock (`scripts/s3-mock.mjs`, 127.0.0.1 test-only) echoed `error.message` in 500 responses. Now logs server-side and returns a generic body.

## Verification
- ✅ `pnpm typecheck`
- ✅ share-dialog / changelog / system.integration tests pass
- ✅ pre-commit (typecheck + biome) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)