### PR TITLE
refactor(analytics): replace daily stats with hourly rollups

### DIFF
--- a/docs/design/admin-analytics.md
+++ b/docs/design/admin-analytics.md
@@ -1,0 +1,39 @@
+# Admin analytics
+
+## Storage model
+
+Admin analytics has one derived table: `stats_rollups_hourly`. Every bucket starts on a UTC hour. The server has no configured reporting time zone and does not persist daily aggregates or time-zone-specific rows.
+
+Each row is identified by UTC bucket, organization, metric, dimension, and dimension value. Metric and dimension combinations must be declared in `server/domain/admin-stats-metrics.ts`. Counters are additive; gauges are point-in-time snapshots; distinct values must never be added across buckets.
+
+The ten-minute scheduler rebuilds the current and previous UTC hours. Rebuilding an hour deletes and inserts that hour atomically, so retries are safe. A `stats.rollup_run` marker means the counter rows for an hour are complete. Snapshot rows are finalized near the next hour and remain useful as waterlines, not event totals.
+
+## Query model
+
+The client sends an IANA time zone with its selected range. Date-only inputs are interpreted as local calendar dates in that zone, including daylight-saving transitions and non-whole-hour offsets.
+
+Queries combine:
+
+- complete UTC hours from `stats_rollups_hourly`;
+- raw rows for the current partial hour, incomplete hours, and partial hours cut by the requested boundary;
+- raw rows for a UTC hour that crosses a local-day boundary, such as `Asia/Kathmandu` at `:15` UTC.
+
+This preserves exact local-day results without storing a daily table. A missing completion marker always fails back to the raw source instead of returning a partial aggregate.
+
+Exact DAU, WAU, and MAU remain a deliberate exception because hourly distinct counts cannot be added. Current inventory, quota pressure, active jobs, downloader status, and active shares are also queried live because they describe current state rather than historical event volume.
+
+## Metric semantics
+
+- Upload bytes mean successfully confirmed upload bytes.
+- Download bytes and counts mean issued downloads, not client-completed transfers.
+- Cloud traffic report status describes metering synchronization and belongs to Operations, not download success.
+- Files older than 90 days are an age cohort, not cold data; access recency is not inferred.
+- Sharing views, downloads, and saves are independent event totals, not a user-level funnel.
+
+Rows with transfer events but no recoverable byte count carry `quality=lower_bound`. The `stats.quality_missing_bytes` metric exposes the affected event count by direction and source.
+
+## Backfill and validation
+
+Run `pnpm stats:backfill -- --apply ...` after the migration in each environment. The script first recovers audit metadata where an exact source still exists, then rebuilds historical hourly counters with conflict-aware updates. Re-running the same script produces no data changes.
+
+Validation must reconcile raw event totals with hourly rows, verify completion markers, report missing transfer byte metadata, and compare dashboard responses for a UTC range, a DST date, and a non-whole-hour time zone.

--- a/docs/roadmap/v2.8.md
+++ b/docs/roadmap/v2.8.md
@@ -59,12 +59,12 @@ Use additive rollups for metrics that would otherwise become expensive.
 Suggested storage:
 
 - **Hourly rollups** by metric, org, source, target type, and time bucket
-- **Daily rollups** derived from hourly rows for long-range charts
+- Daily and longer-range charts are composed from UTC hourly rows at query time
 
 Retention defaults:
 
-- Hourly rollups: 180 days
-- Daily rollups: kept until explicitly pruned by an admin policy
+- Hourly rollups are the only persisted aggregate and are retained until an explicit pruning policy is introduced
+- Reporting time zones are query inputs; no server reporting time zone or time-zone-specific aggregate is stored
 
 Do not create a broad raw event pipeline in v2.8 unless a specific chart needs
 it. The audit log remains the record-level source for operational events.

--- a/migrations/0055_hourly-admin-stats.sql
+++ b/migrations/0055_hourly-admin-stats.sql
@@ -1,0 +1,17 @@
+ALTER TABLE `stats_rollups_daily` RENAME TO `stats_rollups_hourly`;--> statement-breakpoint
+DROP INDEX `stats_rollups_daily_bucket_metric_dim_uniq`;--> statement-breakpoint
+DROP INDEX `stats_rollups_daily_metric_bucket_idx`;--> statement-breakpoint
+CREATE UNIQUE INDEX `stats_rollups_hourly_bucket_metric_dim_uniq` ON `stats_rollups_hourly` (`bucket_start`,`org_id`,`metric_key`,`dimension_key`,`dimension_value`);--> statement-breakpoint
+CREATE INDEX `stats_rollups_hourly_metric_bucket_idx` ON `stats_rollups_hourly` (`metric_key`,`bucket_start`);--> statement-breakpoint
+CREATE INDEX `stats_rollups_hourly_dimension_bucket_idx` ON `stats_rollups_hourly` (`metric_key`,`dimension_key`,`bucket_start`);--> statement-breakpoint
+CREATE INDEX `activity_events_created_idx` ON `activity_events` (`created_at`);--> statement-breakpoint
+CREATE INDEX `background_jobs_created_idx` ON `background_jobs` (`created_at`);--> statement-breakpoint
+CREATE INDEX `cloud_traffic_reports_updated_idx` ON `cloud_traffic_reports` (`updated_at`);--> statement-breakpoint
+CREATE INDEX `download_tasks_created_idx` ON `download_tasks` (`created_at`);--> statement-breakpoint
+CREATE INDEX `download_tasks_finished_idx` ON `download_tasks` (`finished_at`);--> statement-breakpoint
+CREATE INDEX `matters_status_dir_created_idx` ON `matters` (`status`,`dirtype`,`created_at`);--> statement-breakpoint
+CREATE INDEX `remote_download_usage_created_idx` ON `remote_download_usage_reports` (`created_at`);--> statement-breakpoint
+CREATE INDEX `shares_created_idx` ON `shares` (`created_at`);--> statement-breakpoint
+CREATE INDEX `webhook_events_processed_idx` ON `webhook_events` (`processed_at`);--> statement-breakpoint
+CREATE INDEX `session_created_idx` ON `session` (`created_at`);--> statement-breakpoint
+CREATE INDEX `user_created_idx` ON `user` (`created_at`);

--- a/migrations/meta/0055_snapshot.json
+++ b/migrations/meta/0055_snapshot.json
@@ -1,0 +1,4218 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f25df368-dc02-4fb3-827c-da8f7654d5aa",
+  "prevId": "c04d7898-5c72-458a-aa4f-b0a14af47bb9",
+  "tables": {
+    "activity_events": {
+      "name": "activity_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "activity_events_org_created_idx": {
+          "name": "activity_events_org_created_idx",
+          "columns": [
+            "org_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "activity_events_user_created_idx": {
+          "name": "activity_events_user_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "activity_events_action_created_idx": {
+          "name": "activity_events_action_created_idx",
+          "columns": [
+            "action",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "activity_events_target_created_idx": {
+          "name": "activity_events_target_created_idx",
+          "columns": [
+            "target_type",
+            "target_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "activity_events_created_idx": {
+          "name": "activity_events_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "announcements": {
+      "name": "announcements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "announcements_status_priority_idx": {
+          "name": "announcements_status_priority_idx",
+          "columns": [
+            "status",
+            "priority"
+          ],
+          "isUnique": false
+        },
+        "announcements_published_idx": {
+          "name": "announcements_published_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "background_jobs": {
+      "name": "background_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_folder": {
+          "name": "target_folder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_bytes": {
+          "name": "input_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_bytes": {
+          "name": "output_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "processed_bytes": {
+          "name": "processed_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "current_filename": {
+          "name": "current_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_metadata": {
+          "name": "result_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retryable": {
+          "name": "retryable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cancelable": {
+          "name": "cancelable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "retried_from_job_id": {
+          "name": "retried_from_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "background_jobs_org_created_idx": {
+          "name": "background_jobs_org_created_idx",
+          "columns": [
+            "org_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "background_jobs_org_status_idx": {
+          "name": "background_jobs_org_status_idx",
+          "columns": [
+            "org_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "background_jobs_org_type_idx": {
+          "name": "background_jobs_org_type_idx",
+          "columns": [
+            "org_id",
+            "type"
+          ],
+          "isUnique": false
+        },
+        "background_jobs_created_idx": {
+          "name": "background_jobs_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cloud_traffic_reports": {
+      "name": "cloud_traffic_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit_bytes": {
+          "name": "unit_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credits_per_unit": {
+          "name": "credits_per_unit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cloud_traffic_reports_event_uniq": {
+          "name": "cloud_traffic_reports_event_uniq",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": true
+        },
+        "cloud_traffic_reports_org_period_idx": {
+          "name": "cloud_traffic_reports_org_period_idx",
+          "columns": [
+            "org_id",
+            "period"
+          ],
+          "isUnique": false
+        },
+        "cloud_traffic_reports_status_idx": {
+          "name": "cloud_traffic_reports_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "cloud_traffic_reports_updated_idx": {
+          "name": "cloud_traffic_reports_updated_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "download_tasks": {
+      "name": "download_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_uri": {
+          "name": "source_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_folder": {
+          "name": "target_folder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "assigned_downloader_id": {
+          "name": "assigned_downloader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "billing_authorized_bytes": {
+          "name": "billing_authorized_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "billing_charged_bytes": {
+          "name": "billing_charged_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "billing_charged_credits": {
+          "name": "billing_charged_credits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "billing_status": {
+          "name": "billing_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_object_id": {
+          "name": "result_object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolve_started_at": {
+          "name": "resolve_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolve_completed_at": {
+          "name": "resolve_completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_completed_at": {
+          "name": "download_completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ingest_started_at": {
+          "name": "ingest_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ingest_completed_at": {
+          "name": "ingest_completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seeding_started_at": {
+          "name": "seeding_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seeding_stopped_at": {
+          "name": "seeding_stopped_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "download_tasks_org_created_idx": {
+          "name": "download_tasks_org_created_idx",
+          "columns": [
+            "org_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "download_tasks_org_status_idx": {
+          "name": "download_tasks_org_status_idx",
+          "columns": [
+            "org_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "download_tasks_org_category_idx": {
+          "name": "download_tasks_org_category_idx",
+          "columns": [
+            "org_id",
+            "category"
+          ],
+          "isUnique": false
+        },
+        "download_tasks_org_tags_idx": {
+          "name": "download_tasks_org_tags_idx",
+          "columns": [
+            "org_id",
+            "tags"
+          ],
+          "isUnique": false
+        },
+        "download_tasks_downloader_idx": {
+          "name": "download_tasks_downloader_idx",
+          "columns": [
+            "assigned_downloader_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "download_tasks_created_idx": {
+          "name": "download_tasks_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "download_tasks_finished_idx": {
+          "name": "download_tasks_finished_idx",
+          "columns": [
+            "finished_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "downloaders": {
+      "name": "downloaders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_jti": {
+          "name": "token_jti",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'offline'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "engine": {
+          "name": "engine",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'http'"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "max_concurrent_tasks": {
+          "name": "max_concurrent_tasks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "current_tasks": {
+          "name": "current_tasks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "download_bps": {
+          "name": "download_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "upload_bps": {
+          "name": "upload_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "free_disk_bytes": {
+          "name": "free_disk_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remote_download_credit_billing_enabled": {
+          "name": "remote_download_credit_billing_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "remote_download_credit_unit_bytes": {
+          "name": "remote_download_credit_unit_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 104857600
+        },
+        "remote_download_credit_per_unit": {
+          "name": "remote_download_credit_per_unit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "downloaders_token_jti_unique": {
+          "name": "downloaders_token_jti_unique",
+          "columns": [
+            "token_jti"
+          ],
+          "isUnique": true
+        },
+        "downloaders_status_idx": {
+          "name": "downloaders_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "downloaders_enabled_idx": {
+          "name": "downloaders_enabled_idx",
+          "columns": [
+            "enabled"
+          ],
+          "isUnique": false
+        },
+        "downloaders_created_idx": {
+          "name": "downloaders_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "image_hosting_configs": {
+      "name": "image_hosting_configs",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_domain": {
+          "name": "custom_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cf_hostname_id": {
+          "name": "cf_hostname_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "domain_verified_at": {
+          "name": "domain_verified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referer_allowlist": {
+          "name": "referer_allowlist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "image_hosting_configs_custom_domain_unique": {
+          "name": "image_hosting_configs_custom_domain_unique",
+          "columns": [
+            "custom_domain"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "image_hosting_configs_org_id_organization_id_fk": {
+          "name": "image_hosting_configs_org_id_organization_id_fk",
+          "tableFrom": "image_hosting_configs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "image_hostings": {
+      "name": "image_hostings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "image_hostings_token_unique": {
+          "name": "image_hostings_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "image_hostings_org_path_uniq": {
+          "name": "image_hostings_org_path_uniq",
+          "columns": [
+            "org_id",
+            "path"
+          ],
+          "isUnique": true
+        },
+        "image_hostings_org_created_idx": {
+          "name": "image_hostings_org_created_idx",
+          "columns": [
+            "org_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "image_hostings_token_idx": {
+          "name": "image_hostings_token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "image_hostings_org_id_organization_id_fk": {
+          "name": "image_hostings_org_id_organization_id_fk",
+          "tableFrom": "image_hostings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "image_hostings_storage_id_storages_id_fk": {
+          "name": "image_hostings_storage_id_storages_id_fk",
+          "tableFrom": "image_hostings",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invite_codes": {
+      "name": "invite_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invite_codes_code_unique": {
+          "name": "invite_codes_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "license_bindings": {
+      "name": "license_bindings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_binding_id": {
+          "name": "cloud_binding_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_store_id": {
+          "name": "cloud_store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_account_id": {
+          "name": "cloud_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_account_email": {
+          "name": "cloud_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cached_certificate": {
+          "name": "cached_certificate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cached_certificate_expires_at": {
+          "name": "cached_certificate_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bound_at": {
+          "name": "bound_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disconnected_at": {
+          "name": "disconnected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refresh_at": {
+          "name": "last_refresh_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refresh_error": {
+          "name": "last_refresh_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "license_bindings_active_uniq": {
+          "name": "license_bindings_active_uniq",
+          "columns": [
+            "status"
+          ],
+          "isUnique": true,
+          "where": "status = 'active'"
+        },
+        "license_bindings_cloud_binding_idx": {
+          "name": "license_bindings_cloud_binding_idx",
+          "columns": [
+            "cloud_binding_id"
+          ],
+          "isUnique": false
+        },
+        "license_bindings_instance_idx": {
+          "name": "license_bindings_instance_idx",
+          "columns": [
+            "instance_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "matters": {
+      "name": "matters",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dirtype": {
+          "name": "dirtype",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "parent": {
+          "name": "parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "trashed_at": {
+          "name": "trashed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "matters_alias_unique": {
+          "name": "matters_alias_unique",
+          "columns": [
+            "alias"
+          ],
+          "isUnique": true
+        },
+        "matters_status_dir_created_idx": {
+          "name": "matters_status_dir_created_idx",
+          "columns": [
+            "status",
+            "dirtype",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "notifications_user_read_idx": {
+          "name": "notifications_user_read_idx",
+          "columns": [
+            "user_id",
+            "read_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "object_upload_sessions": {
+      "name": "object_upload_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upload_id": {
+          "name": "upload_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "part_size": {
+          "name": "part_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_conflict": {
+          "name": "on_conflict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'fail'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "object_upload_sessions_object_idx": {
+          "name": "object_upload_sessions_object_idx",
+          "columns": [
+            "org_id",
+            "object_id"
+          ],
+          "isUnique": false
+        },
+        "object_upload_sessions_expires_idx": {
+          "name": "object_upload_sessions_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "org_quota_entitlements": {
+      "name": "org_quota_entitlements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entitlement_type": {
+          "name": "entitlement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'grant'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "org_quota_entitlements_org_resource_idx": {
+          "name": "org_quota_entitlements_org_resource_idx",
+          "columns": [
+            "org_id",
+            "resource_type",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "org_quota_entitlements_org_type_idx": {
+          "name": "org_quota_entitlements_org_type_idx",
+          "columns": [
+            "org_id",
+            "resource_type",
+            "entitlement_type",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "org_quota_entitlements_active_plan_uniq": {
+          "name": "org_quota_entitlements_active_plan_uniq",
+          "columns": [
+            "org_id",
+            "resource_type",
+            "entitlement_type"
+          ],
+          "isUnique": true,
+          "where": "status = 'active' AND entitlement_type = 'plan'"
+        },
+        "org_quota_entitlements_source_resource_uniq": {
+          "name": "org_quota_entitlements_source_resource_uniq",
+          "columns": [
+            "source",
+            "source_id",
+            "resource_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "org_quotas": {
+      "name": "org_quotas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quota": {
+          "name": "quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "traffic_quota": {
+          "name": "traffic_quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "traffic_used": {
+          "name": "traffic_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "traffic_period": {
+          "name": "traffic_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1970-01'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_download_usage_reports": {
+      "name": "remote_download_usage_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "downloader_id": {
+          "name": "downloader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit_index": {
+          "name": "unit_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit_bytes": {
+          "name": "unit_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credits_per_unit": {
+          "name": "credits_per_unit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_download_usage_reports_event_id_unique": {
+          "name": "remote_download_usage_reports_event_id_unique",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": true
+        },
+        "remote_download_usage_task_unit_uniq": {
+          "name": "remote_download_usage_task_unit_uniq",
+          "columns": [
+            "task_id",
+            "unit_index"
+          ],
+          "isUnique": true
+        },
+        "remote_download_usage_org_idx": {
+          "name": "remote_download_usage_org_idx",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        },
+        "remote_download_usage_status_idx": {
+          "name": "remote_download_usage_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "remote_download_usage_created_idx": {
+          "name": "remote_download_usage_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_recipients": {
+      "name": "share_recipients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "share_id": {
+          "name": "share_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "share_recipients_share_id_idx": {
+          "name": "share_recipients_share_id_idx",
+          "columns": [
+            "share_id"
+          ],
+          "isUnique": false
+        },
+        "share_recipients_user_id_idx": {
+          "name": "share_recipients_user_id_idx",
+          "columns": [
+            "recipient_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shares": {
+      "name": "shares",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matter_id": {
+          "name": "matter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_limit": {
+          "name": "download_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "downloads": {
+          "name": "downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "shares_token_unique": {
+          "name": "shares_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "shares_creator_status_created_idx": {
+          "name": "shares_creator_status_created_idx",
+          "columns": [
+            "creator_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "shares_created_idx": {
+          "name": "shares_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_invitations": {
+      "name": "site_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "site_invitations_token_unique": {
+          "name": "site_invitations_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "site_invitations_email_idx": {
+          "name": "site_invitations_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "site_invitations_created_idx": {
+          "name": "site_invitations_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "site_invitations_expires_idx": {
+          "name": "site_invitations_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stats_rollups_hourly": {
+      "name": "stats_rollups_hourly",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "metric_key": {
+          "name": "metric_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_key": {
+          "name": "dimension_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "dimension_value": {
+          "name": "dimension_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "unique_count": {
+          "name": "unique_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "stats_rollups_hourly_bucket_metric_dim_uniq": {
+          "name": "stats_rollups_hourly_bucket_metric_dim_uniq",
+          "columns": [
+            "bucket_start",
+            "org_id",
+            "metric_key",
+            "dimension_key",
+            "dimension_value"
+          ],
+          "isUnique": true
+        },
+        "stats_rollups_hourly_metric_bucket_idx": {
+          "name": "stats_rollups_hourly_metric_bucket_idx",
+          "columns": [
+            "metric_key",
+            "bucket_start"
+          ],
+          "isUnique": false
+        },
+        "stats_rollups_hourly_dimension_bucket_idx": {
+          "name": "stats_rollups_hourly_dimension_bucket_idx",
+          "columns": [
+            "metric_key",
+            "dimension_key",
+            "bucket_start"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "storages": {
+      "name": "storages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'auto'"
+        },
+        "access_key": {
+          "name": "access_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_key": {
+          "name": "secret_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "custom_host": {
+          "name": "custom_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "egress_credit_billing_enabled": {
+          "name": "egress_credit_billing_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "egress_credit_unit_bytes": {
+          "name": "egress_credit_unit_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 104857600
+        },
+        "egress_credit_per_unit": {
+          "name": "egress_credit_per_unit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "force_path_style": {
+          "name": "force_path_style",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_options": {
+      "name": "system_options",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "public": {
+          "name": "public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_invite_links": {
+      "name": "team_invite_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_invite_links_token_unique": {
+          "name": "team_invite_links_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webdav_dead_properties": {
+      "name": "webdav_dead_properties",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_path": {
+          "name": "resource_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webdav_dead_properties_resource_prop_uniq": {
+          "name": "webdav_dead_properties_resource_prop_uniq",
+          "columns": [
+            "org_id",
+            "resource_path",
+            "namespace",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "webdav_dead_properties_resource_idx": {
+          "name": "webdav_dead_properties_resource_idx",
+          "columns": [
+            "org_id",
+            "resource_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webdav_locks": {
+      "name": "webdav_locks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_path": {
+          "name": "resource_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "depth": {
+          "name": "depth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'infinity'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webdav_locks_token_unique": {
+          "name": "webdav_locks_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "webdav_locks_resource_idx": {
+          "name": "webdav_locks_resource_idx",
+          "columns": [
+            "org_id",
+            "resource_path"
+          ],
+          "isUnique": false
+        },
+        "webdav_locks_expires_idx": {
+          "name": "webdav_locks_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_events": {
+      "name": "webhook_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cloud'"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'order.quota_changed'"
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhook_events_source_event_uniq": {
+          "name": "webhook_events_source_event_uniq",
+          "columns": [
+            "source",
+            "event_id"
+          ],
+          "isUnique": true
+        },
+        "webhook_events_source_created_idx": {
+          "name": "webhook_events_source_created_idx",
+          "columns": [
+            "source",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "webhook_events_status_idx": {
+          "name": "webhook_events_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "webhook_events_processed_idx": {
+          "name": "webhook_events_processed_idx",
+          "columns": [
+            "processed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_config_id_idx": {
+          "name": "apikey_config_id_idx",
+          "columns": [
+            "config_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_reference_id_idx": {
+          "name": "apikey_reference_id_idx",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "deviceCode": {
+      "name": "deviceCode",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "deviceCode_device_code_idx": {
+          "name": "deviceCode_device_code_idx",
+          "columns": [
+            "device_code"
+          ],
+          "isUnique": false
+        },
+        "deviceCode_user_code_idx": {
+          "name": "deviceCode_user_code_idx",
+          "columns": [
+            "user_code"
+          ],
+          "isUnique": false
+        },
+        "deviceCode_status_idx": {
+          "name": "deviceCode_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "session_created_idx": {
+          "name": "session_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_created_idx": {
+          "name": "user_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {
+      "\"stats_rollups_daily\"": "\"stats_rollups_hourly\""
+    },
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1783647878596,
       "tag": "0054_lively_nuke",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "6",
+      "when": 1783697537563,
+      "tag": "0055_hourly-admin-stats",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/backfill-admin-stats.ts
+++ b/scripts/backfill-admin-stats.ts
@@ -21,9 +21,21 @@ interface ValidationSummary {
   missingUploadBytes: number
   missingDownloadBytes: number
   trafficEvents: number
-  storageRollups: number
+  hourlyRollups: number
   rawActiveShares: number
   validActiveShares: number
+  rawUploadEvents: number
+  rollupUploadEvents: number
+  rawUploadBytes: number
+  rollupUploadBytes: number
+  rawDownloadEvents: number
+  rollupDownloadEvents: number
+  rawDownloadBytes: number
+  rollupDownloadBytes: number
+  rawShareViews: number
+  rollupShareViews: number
+  orphanRollupBuckets: number
+  lowerBoundRollups: number
 }
 
 interface BackfillPlan {
@@ -35,10 +47,6 @@ interface BackfillPlan {
 }
 
 export function buildBackfillSql(now = new Date()): string {
-  const nowSeconds = Math.floor(now.getTime() / 1000)
-  const nowMillis = now.getTime()
-  const bucket = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
-  const bucketDate = now.toISOString().slice(0, 10)
   return `
 UPDATE activity_events
 SET actor_type = CASE WHEN user_id IS NULL THEN 'anonymous' ELSE 'user' END
@@ -97,29 +105,68 @@ SET metadata = json_set(
   '$.bytes', (
     SELECT ctr.bytes FROM cloud_traffic_reports ctr
     WHERE ctr.source_id = ae.target_id
-      AND ctr.source = CASE ae.action WHEN 'share_download' THEN 'landing_share' ELSE 'object_download' END
+      AND (
+        (ae.action = 'share_download' AND ctr.source IN ('direct_share', 'landing_share'))
+        OR ctr.source = CASE ae.action
+          WHEN 'object_download' THEN 'object_download'
+          WHEN 'image_hosting_download' THEN 'image_hosting'
+          WHEN 'webdav_download' THEN 'webdav_download'
+          ELSE ''
+        END
+      )
       AND ABS(CAST(ctr.created_at / 1000 AS INTEGER) - ae.created_at) <= 5
     ORDER BY ctr.created_at, ctr.event_id
     LIMIT 1
   ),
-  '$.source', CASE ae.action WHEN 'share_download' THEN 'landing_share' ELSE 'object_download' END,
+  '$.source', (
+    SELECT ctr.source FROM cloud_traffic_reports ctr
+    WHERE ctr.source_id = ae.target_id
+      AND (
+        (ae.action = 'share_download' AND ctr.source IN ('direct_share', 'landing_share'))
+        OR ctr.source = CASE ae.action
+          WHEN 'object_download' THEN 'object_download'
+          WHEN 'image_hosting_download' THEN 'image_hosting'
+          WHEN 'webdav_download' THEN 'webdav_download'
+          ELSE ''
+        END
+      )
+      AND ABS(CAST(ctr.created_at / 1000 AS INTEGER) - ae.created_at) <= 5
+    ORDER BY ctr.created_at, ctr.event_id
+    LIMIT 1
+  ),
   '$.status', 'issued',
   '$.trafficEventId', (
     SELECT ctr.event_id FROM cloud_traffic_reports ctr
     WHERE ctr.source_id = ae.target_id
-      AND ctr.source = CASE ae.action WHEN 'share_download' THEN 'landing_share' ELSE 'object_download' END
+      AND (
+        (ae.action = 'share_download' AND ctr.source IN ('direct_share', 'landing_share'))
+        OR ctr.source = CASE ae.action
+          WHEN 'object_download' THEN 'object_download'
+          WHEN 'image_hosting_download' THEN 'image_hosting'
+          WHEN 'webdav_download' THEN 'webdav_download'
+          ELSE ''
+        END
+      )
       AND ABS(CAST(ctr.created_at / 1000 AS INTEGER) - ae.created_at) <= 5
     ORDER BY ctr.created_at, ctr.event_id
     LIMIT 1
   ),
   '$.quality', 'recovered_from_matched_cloud_traffic_report'
 )
-WHERE action IN ('share_download', 'object_download')
+WHERE action IN ('share_download', 'object_download', 'image_hosting_download', 'webdav_download')
   AND (metadata IS NULL OR json_valid(metadata) = 0 OR json_type(metadata, '$.trafficEventId') IS NULL)
   AND EXISTS (
     SELECT 1 FROM cloud_traffic_reports ctr
     WHERE ctr.source_id = ae.target_id
-      AND ctr.source = CASE ae.action WHEN 'share_download' THEN 'landing_share' ELSE 'object_download' END
+      AND (
+        (ae.action = 'share_download' AND ctr.source IN ('direct_share', 'landing_share'))
+        OR ctr.source = CASE ae.action
+          WHEN 'object_download' THEN 'object_download'
+          WHEN 'image_hosting_download' THEN 'image_hosting'
+          WHEN 'webdav_download' THEN 'webdav_download'
+          ELSE ''
+        END
+      )
       AND ABS(CAST(ctr.created_at / 1000 AS INTEGER) - ae.created_at) <= 5
   );
 
@@ -159,8 +206,6 @@ WHERE ctr.source IN ('direct_share', 'landing_share', 'image_hosting', 'object_d
     SELECT 1 FROM activity_events ae
     WHERE ae.id = 'backfill_' || ctr.event_id
       OR (
-        ctr.source IN ('landing_share', 'object_download')
-        AND
         ae.target_id = ctr.source_id
         AND ae.action = CASE
           WHEN ctr.source IN ('direct_share', 'landing_share') THEN 'share_download'
@@ -172,31 +217,253 @@ WHERE ctr.source IN ('direct_share', 'landing_share', 'image_hosting', 'object_d
       )
   );
 
-INSERT INTO stats_rollups_daily (
+DELETE FROM stats_rollups_hourly WHERE metric_key = 'storage.used.bytes';
+
+${buildHourlyBackfillSql(now)}
+`
+}
+
+type HourlySource = {
+  metric: string
+  source: string
+  timestampMs: string
+  org: string
+  where?: string
+  count?: string
+  bytes?: string
+  uniqueCount?: string
+  quality?: string
+  dimensions?: Record<string, string>
+}
+
+function buildHourlyBackfillSql(now: Date): string {
+  const sources: HourlySource[] = [
+    {
+      metric: 'transfer.upload',
+      source: 'activity_events ae',
+      timestampMs: 'ae.created_at * 1000',
+      org: 'ae.org_id',
+      where: "ae.action IN ('upload_confirm','upload_cancel','upload_failed')",
+      bytes: "SUM(CASE WHEN ae.action = 'upload_confirm' AND json_valid(ae.metadata) = 1 THEN COALESCE(json_extract(ae.metadata, '$.bytes'), 0) ELSE 0 END)",
+      quality: "CASE WHEN SUM(CASE WHEN ae.action = 'upload_confirm' AND (ae.metadata IS NULL OR json_valid(ae.metadata) = 0 OR json_type(ae.metadata, '$.bytes') IS NULL) THEN 1 ELSE 0 END) > 0 THEN 'lower_bound' ELSE 'exact' END",
+      dimensions: {
+        source: "COALESCE(CASE WHEN json_valid(ae.metadata) = 1 THEN json_extract(ae.metadata, '$.source') END, 'upload')",
+        status: "CASE ae.action WHEN 'upload_confirm' THEN 'success' WHEN 'upload_cancel' THEN 'canceled' ELSE 'failed' END",
+        reason: "CASE WHEN ae.action = 'upload_confirm' THEN NULL WHEN json_valid(ae.metadata) = 1 AND json_type(ae.metadata, '$.reason') IS NOT NULL THEN json_extract(ae.metadata, '$.reason') WHEN ae.action = 'upload_cancel' THEN 'upload_canceled' ELSE 'upload_failed' END",
+        storage_id: "CASE WHEN json_valid(ae.metadata) = 1 THEN json_extract(ae.metadata, '$.storageId') END",
+      },
+    },
+    {
+      metric: 'storage.ingress',
+      source: 'activity_events ae',
+      timestampMs: 'ae.created_at * 1000',
+      org: 'ae.org_id',
+      where: "ae.action = 'upload_confirm'",
+      bytes: "SUM(CASE WHEN json_valid(ae.metadata) = 1 THEN COALESCE(json_extract(ae.metadata, '$.bytes'), 0) ELSE 0 END)",
+      quality: "CASE WHEN SUM(CASE WHEN ae.metadata IS NULL OR json_valid(ae.metadata) = 0 OR json_type(ae.metadata, '$.bytes') IS NULL THEN 1 ELSE 0 END) > 0 THEN 'lower_bound' ELSE 'exact' END",
+      dimensions: {
+        source: "COALESCE(CASE WHEN json_valid(ae.metadata) = 1 THEN json_extract(ae.metadata, '$.source') END, 'web_upload')",
+        status: "'success'",
+        storage_id: "CASE WHEN json_valid(ae.metadata) = 1 THEN json_extract(ae.metadata, '$.storageId') END",
+      },
+    },
+    {
+      metric: 'transfer.download_issued',
+      source: 'activity_events ae',
+      timestampMs: 'ae.created_at * 1000',
+      org: 'ae.org_id',
+      where: "ae.action IN ('share_download','object_download','image_hosting_download','webdav_download')",
+      bytes: "SUM(CASE WHEN json_valid(ae.metadata) = 1 THEN COALESCE(json_extract(ae.metadata, '$.bytes'), 0) ELSE 0 END)",
+      quality: "CASE WHEN SUM(CASE WHEN ae.metadata IS NULL OR json_valid(ae.metadata) = 0 OR json_type(ae.metadata, '$.bytes') IS NULL THEN 1 ELSE 0 END) > 0 THEN 'lower_bound' ELSE 'exact' END",
+      dimensions: {
+        source: "COALESCE(CASE WHEN json_valid(ae.metadata) = 1 THEN json_extract(ae.metadata, '$.source') END, CASE ae.action WHEN 'object_download' THEN 'object_download' WHEN 'image_hosting_download' THEN 'image_hosting' WHEN 'webdav_download' THEN 'webdav_download' ELSE 'landing_share' END)",
+        actor_type: "COALESCE(ae.actor_type, CASE WHEN ae.user_id IS NULL THEN 'anonymous' ELSE 'user' END)",
+        storage_id: "CASE WHEN json_valid(ae.metadata) = 1 THEN json_extract(ae.metadata, '$.storageId') END",
+      },
+    },
+    {
+      metric: 'transfer.download_failed',
+      source: 'activity_events ae',
+      timestampMs: 'ae.created_at * 1000',
+      org: 'ae.org_id',
+      where: "ae.action = 'download_failed'",
+      bytes: "SUM(CASE WHEN json_valid(ae.metadata) = 1 THEN COALESCE(json_extract(ae.metadata, '$.bytes'), 0) ELSE 0 END)",
+      dimensions: {
+        source: "COALESCE(CASE WHEN json_valid(ae.metadata) = 1 THEN json_extract(ae.metadata, '$.source') END, 'unknown')",
+        reason: "COALESCE(CASE WHEN json_valid(ae.metadata) = 1 THEN json_extract(ae.metadata, '$.reason') END, 'unknown')",
+      },
+    },
+    {
+      metric: 'share.created',
+      source: 'shares s',
+      timestampMs: 's.created_at * 1000',
+      org: 's.org_id',
+      dimensions: { kind: 's.kind' },
+    },
+    activitySource('share.view', "ae.action = 'share_view'", { share_id: 'ae.target_id', actor_type: "COALESCE(ae.actor_type, CASE WHEN ae.user_id IS NULL THEN 'anonymous' ELSE 'user' END)" }),
+    activitySource('share.download_issued', "ae.action = 'share_download'", { share_id: "COALESCE(CASE WHEN json_valid(ae.metadata) = 1 THEN json_extract(ae.metadata, '$.shareId') END, ae.target_id)", kind: "CASE WHEN json_valid(ae.metadata) = 1 THEN json_extract(ae.metadata, '$.kind') END", source: "COALESCE(CASE WHEN json_valid(ae.metadata) = 1 THEN json_extract(ae.metadata, '$.source') END, 'landing_share')", actor_type: "COALESCE(ae.actor_type, CASE WHEN ae.user_id IS NULL THEN 'anonymous' ELSE 'user' END)" }, true),
+    activitySource('share.saved', "ae.action = 'save_from_share'", { share_id: "COALESCE(CASE WHEN json_valid(ae.metadata) = 1 THEN json_extract(ae.metadata, '$.shareId') END, ae.target_id)", actor_type: "COALESCE(ae.actor_type, CASE WHEN ae.user_id IS NULL THEN 'anonymous' ELSE 'user' END)" }, true),
+    activitySource('share.password_passed', "ae.action = 'share_password_passed'", { share_id: 'ae.target_id' }),
+    {
+      metric: 'traffic.report_sync',
+      source: 'cloud_traffic_reports ctr',
+      timestampMs: 'ctr.updated_at',
+      org: 'ctr.org_id',
+      bytes: 'SUM(ctr.bytes)',
+      dimensions: { source: 'ctr.source', status: 'ctr.status' },
+    },
+    {
+      metric: 'remote_download.task_created',
+      source: 'download_tasks dt',
+      timestampMs: 'dt.created_at',
+      org: 'dt.org_id',
+      dimensions: { category: "COALESCE(dt.category, 'uncategorized')", source: 'dt.source_type' },
+    },
+    {
+      metric: 'remote_download.task_finished',
+      source: 'download_tasks dt',
+      timestampMs: 'dt.finished_at',
+      org: 'dt.org_id',
+      where: 'dt.finished_at IS NOT NULL',
+      bytes: 'SUM(dt.billing_charged_bytes)',
+      dimensions: { category: "COALESCE(dt.category, 'uncategorized')", downloader_id: 'dt.assigned_downloader_id', outcome: 'dt.status' },
+    },
+    {
+      metric: 'background_job.finished',
+      source: 'background_jobs bj',
+      timestampMs: 'bj.finished_at',
+      org: 'bj.org_id',
+      where: 'bj.finished_at IS NOT NULL',
+      dimensions: { job_type: 'bj.type', outcome: 'bj.status' },
+    },
+    {
+      metric: 'remote_download.usage',
+      source: 'remote_download_usage_reports ru',
+      timestampMs: 'ru.created_at',
+      org: 'ru.org_id',
+      count: 'SUM(ru.credits_per_unit)',
+      bytes: 'SUM(ru.unit_bytes)',
+      dimensions: { downloader_id: 'ru.downloader_id', status: 'ru.status' },
+    },
+    {
+      metric: 'webhook.processed',
+      source: 'webhook_events we',
+      timestampMs: 'we.processed_at',
+      org: "''",
+      where: 'we.processed_at IS NOT NULL',
+      dimensions: { outcome: 'we.status' },
+    },
+    {
+      metric: 'stats.quality_missing_bytes',
+      source: 'activity_events ae',
+      timestampMs: 'ae.created_at * 1000',
+      org: 'ae.org_id',
+      where: "ae.action IN ('upload_confirm','share_download','object_download','image_hosting_download','webdav_download') AND (ae.metadata IS NULL OR json_valid(ae.metadata) = 0 OR json_type(ae.metadata, '$.bytes') IS NULL)",
+      dimensions: {
+        direction: "CASE WHEN ae.action = 'upload_confirm' THEN 'upload' ELSE 'download' END",
+        source: "COALESCE(CASE WHEN json_valid(ae.metadata) = 1 THEN json_extract(ae.metadata, '$.source') END, ae.action)",
+      },
+    },
+  ]
+
+  const statements = sources.flatMap((source) => hourlyStatements(source))
+  statements.push(userSignupBackfillSql(), activeUserBackfillSql(), rollupMarkerBackfillSql(now))
+  return statements.join('\n\n')
+}
+
+function activitySource(metric: string, where: string, dimensions: Record<string, string>, bytes = false): HourlySource {
+  return {
+    metric,
+    source: 'activity_events ae',
+    timestampMs: 'ae.created_at * 1000',
+    org: 'ae.org_id',
+    where,
+    bytes: bytes ? "SUM(CASE WHEN json_valid(ae.metadata) = 1 THEN COALESCE(json_extract(ae.metadata, '$.bytes'), 0) ELSE 0 END)" : undefined,
+    dimensions,
+  }
+}
+
+function hourlyStatements(source: HourlySource): string[] {
+  return [hourlyInsert(source), ...Object.entries(source.dimensions ?? {}).map(([key, value]) => hourlyInsert(source, key, value))]
+}
+
+function hourlyInsert(source: HourlySource, dimensionKey = '', dimensionExpression = "''"): string {
+  const bucket = `CAST((${source.timestampMs}) / 3600000 AS INTEGER) * 3600000`
+  const where = [source.where, dimensionKey ? `(${dimensionExpression}) IS NOT NULL AND CAST((${dimensionExpression}) AS TEXT) <> ''` : null]
+    .filter(Boolean)
+    .join(' AND ')
+  const dimension = dimensionKey ? `CAST((${dimensionExpression}) AS TEXT)` : "''"
+  const count = source.count ?? 'COUNT(*)'
+  const bytes = source.bytes ?? '0'
+  const uniqueCount = source.uniqueCount ?? '0'
+  const quality = source.quality ?? "'exact'"
+  return `INSERT INTO stats_rollups_hourly (
   id, bucket_start, org_id, metric_key, dimension_key, dimension_value,
   count, bytes, unique_count, metadata, updated_at
 )
 SELECT
-  'storage-used-${bucketDate}',
-  ${bucket},
-  '',
-  'storage.used.bytes',
-  '',
-  '',
-  0,
-  COALESCE(SUM(used), 0),
-  0,
-  json_object('source', 'org_quotas.used', 'quality', 'exact_snapshot', 'backfilledAt', ${nowSeconds}),
-  ${nowMillis}
-FROM org_quotas
+  CAST(bucket_start AS TEXT) || ':' || COALESCE(NULLIF(org_id, ''), 'global') || ':${source.metric}:${dimensionKey || 'all'}:' || hex(dimension_value),
+  bucket_start, org_id, '${source.metric}', '${dimensionKey}', dimension_value,
+  count_value, bytes_value, unique_value,
+  json_object('version', 1, 'quality', quality_value),
+  bucket_start + 3600000
+FROM (
+  SELECT ${bucket} AS bucket_start, ${source.org} AS org_id, ${dimension} AS dimension_value,
+    ${count} AS count_value, ${bytes} AS bytes_value, ${uniqueCount} AS unique_value, ${quality} AS quality_value
+  FROM ${source.source}
+  ${where ? `WHERE ${where}` : ''}
+  GROUP BY bucket_start, org_id${dimensionKey ? ', dimension_value' : ''}
+) rollup
 WHERE true
 ON CONFLICT(bucket_start, org_id, metric_key, dimension_key, dimension_value)
-DO UPDATE SET
-  bytes = excluded.bytes,
-  metadata = excluded.metadata,
-  updated_at = excluded.updated_at
-WHERE stats_rollups_daily.bytes <> excluded.bytes;
-`
+DO UPDATE SET count = excluded.count, bytes = excluded.bytes, unique_count = excluded.unique_count,
+  metadata = excluded.metadata, updated_at = excluded.updated_at
+WHERE count <> excluded.count OR bytes <> excluded.bytes OR unique_count <> excluded.unique_count OR metadata <> excluded.metadata;`
+}
+
+function userSignupBackfillSql(): string {
+  return hourlyInsert({
+    metric: 'user.signup',
+    source: `user u LEFT JOIN account a ON a.id = (
+      SELECT a2.id FROM account a2 WHERE a2.user_id = u.id ORDER BY a2.created_at, a2.id LIMIT 1
+    )`,
+    timestampMs: 'u.created_at',
+    org: "''",
+    dimensions: { provider: "COALESCE(a.provider_id, 'direct')" },
+  }) + '\n' + hourlyInsert({
+    metric: 'user.signup',
+    source: `user u LEFT JOIN account a ON a.id = (
+      SELECT a2.id FROM account a2 WHERE a2.user_id = u.id ORDER BY a2.created_at, a2.id LIMIT 1
+    )`,
+    timestampMs: 'u.created_at',
+    org: "''",
+  })
+}
+
+function activeUserBackfillSql(): string {
+  return hourlyInsert({
+    metric: 'user.active_hour',
+    source: `(SELECT created_at AS at, user_id FROM session
+      UNION ALL
+      SELECT ae.created_at * 1000 AS at, ae.user_id FROM activity_events ae JOIN user u ON u.id = ae.user_id) active`,
+    timestampMs: 'active.at',
+    org: "''",
+    count: '0',
+    uniqueCount: 'COUNT(DISTINCT active.user_id)',
+  })
+}
+
+function rollupMarkerBackfillSql(now: Date): string {
+  const currentHour = Math.floor(now.getTime() / 3_600_000) * 3_600_000
+  return hourlyInsert({
+    metric: 'stats.rollup_run',
+    source: `(SELECT DISTINCT bucket_start AS at
+      FROM stats_rollups_hourly WHERE metric_key <> 'stats.rollup_run'
+      UNION SELECT ${currentHour} AS at) buckets`,
+    timestampMs: 'buckets.at',
+    org: "''",
+    count: '1',
+  })
 }
 
 export const VALIDATION_SQL = `
@@ -220,8 +487,8 @@ SELECT json_object(
     SELECT COUNT(*) FROM activity_events
     WHERE action IN ('share_download', 'object_download', 'image_hosting_download', 'webdav_download', 'download_failed')
   ),
-  'storageRollups', (
-    SELECT COUNT(*) FROM stats_rollups_daily WHERE metric_key = 'storage.used.bytes'
+  'hourlyRollups', (
+    SELECT COUNT(*) FROM stats_rollups_hourly WHERE metric_key = 'stats.rollup_run' AND dimension_key = ''
   ),
   'rawActiveShares', (SELECT COUNT(*) FROM shares WHERE status = 'active'),
   'validActiveShares', (
@@ -229,6 +496,56 @@ SELECT json_object(
     WHERE status = 'active'
       AND (expires_at IS NULL OR expires_at > unixepoch())
       AND (download_limit IS NULL OR downloads < download_limit)
+  ),
+  'rawUploadEvents', (SELECT COUNT(*) FROM activity_events WHERE action = 'upload_confirm'),
+  'rollupUploadEvents', (
+    SELECT COALESCE(SUM(count), 0) FROM stats_rollups_hourly
+    WHERE metric_key = 'transfer.upload' AND dimension_key = 'status' AND dimension_value = 'success'
+  ),
+  'rawUploadBytes', (
+    SELECT COALESCE(SUM(CASE WHEN json_valid(metadata) = 1 THEN COALESCE(json_extract(metadata, '$.bytes'), 0) ELSE 0 END), 0)
+    FROM activity_events WHERE action = 'upload_confirm'
+  ),
+  'rollupUploadBytes', (
+    SELECT COALESCE(SUM(bytes), 0) FROM stats_rollups_hourly
+    WHERE metric_key = 'transfer.upload' AND dimension_key = 'status' AND dimension_value = 'success'
+  ),
+  'rawDownloadEvents', (
+    SELECT COUNT(*) FROM activity_events
+    WHERE action IN ('share_download', 'object_download', 'image_hosting_download', 'webdav_download')
+  ),
+  'rollupDownloadEvents', (
+    SELECT COALESCE(SUM(count), 0) FROM stats_rollups_hourly
+    WHERE metric_key = 'transfer.download_issued' AND dimension_key = ''
+  ),
+  'rawDownloadBytes', (
+    SELECT COALESCE(SUM(CASE WHEN json_valid(metadata) = 1 THEN COALESCE(json_extract(metadata, '$.bytes'), 0) ELSE 0 END), 0)
+    FROM activity_events
+    WHERE action IN ('share_download', 'object_download', 'image_hosting_download', 'webdav_download')
+  ),
+  'rollupDownloadBytes', (
+    SELECT COALESCE(SUM(bytes), 0) FROM stats_rollups_hourly
+    WHERE metric_key = 'transfer.download_issued' AND dimension_key = ''
+  ),
+  'rawShareViews', (SELECT COUNT(*) FROM activity_events WHERE action = 'share_view'),
+  'rollupShareViews', (
+    SELECT COALESCE(SUM(count), 0) FROM stats_rollups_hourly
+    WHERE metric_key = 'share.view' AND dimension_key = ''
+  ),
+  'orphanRollupBuckets', (
+    SELECT COUNT(DISTINCT r.bucket_start)
+    FROM stats_rollups_hourly r
+    WHERE r.metric_key <> 'stats.rollup_run'
+      AND NOT EXISTS (
+        SELECT 1 FROM stats_rollups_hourly marker
+        WHERE marker.bucket_start = r.bucket_start
+          AND marker.metric_key = 'stats.rollup_run'
+          AND marker.dimension_key = ''
+      )
+  ),
+  'lowerBoundRollups', (
+    SELECT COUNT(*) FROM stats_rollups_hourly
+    WHERE json_valid(metadata) = 1 AND json_extract(metadata, '$.quality') = 'lower_bound'
   )
 ) AS summary;
 `
@@ -272,9 +589,13 @@ SELECT json_object(
         SELECT 1 FROM activity_events ae
         WHERE ae.id = 'backfill_' || ctr.event_id
           OR (
-            ctr.source IN ('landing_share', 'object_download')
-            AND ae.target_id = ctr.source_id
-            AND ae.action = CASE ctr.source WHEN 'landing_share' THEN 'share_download' ELSE 'object_download' END
+            ae.target_id = ctr.source_id
+            AND ae.action = CASE
+              WHEN ctr.source IN ('direct_share', 'landing_share') THEN 'share_download'
+              WHEN ctr.source = 'image_hosting' THEN 'image_hosting_download'
+              WHEN ctr.source = 'object_download' THEN 'object_download'
+              ELSE 'webdav_download'
+            END
             AND ABS(ae.created_at - CAST(ctr.created_at / 1000 AS INTEGER)) <= 5
           )
       )
@@ -330,13 +651,41 @@ function queryD1(target: Extract<Target, { kind: 'd1' }>, sql: string): string {
 
 function applyD1(target: Extract<Target, { kind: 'd1' }>, sql: string): void {
   const dir = mkdtempSync(join(tmpdir(), 'zpan-stats-backfill-'))
-  const file = join(dir, 'backfill.sql')
   try {
-    writeFileSync(file, sql)
-    execFileSync('pnpm', [...d1Args(target), '--file', file], { stdio: 'inherit' })
+    const statements = splitSqlStatements(sql)
+    for (let index = 0; index < statements.length; index += 8) {
+      const batch = statements.slice(index, index + 8)
+      const file = join(dir, `backfill-${String(index / 8).padStart(3, '0')}.sql`)
+      writeFileSync(file, `${batch.join(';\n\n')};\n`)
+      execFileSync('pnpm', [...d1Args(target), '--file', file], { stdio: 'inherit' })
+    }
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }
+}
+
+export function splitSqlStatements(sql: string): string[] {
+  const statements: string[] = []
+  let start = 0
+  let quoted = false
+  for (let index = 0; index < sql.length; index += 1) {
+    if (sql[index] === "'") {
+      if (quoted && sql[index + 1] === "'") {
+        index += 1
+        continue
+      }
+      quoted = !quoted
+      continue
+    }
+    if (sql[index] !== ';' || quoted) continue
+    const statement = sql.slice(start, index).trim()
+    if (statement) statements.push(statement)
+    start = index + 1
+  }
+  const trailing = sql.slice(start).trim()
+  if (trailing) statements.push(trailing)
+  if (quoted) throw new Error('admin_stats_backfill_unterminated_sql_string')
+  return statements
 }
 
 function parseD1Summary<T>(output: string): T {
@@ -367,6 +716,21 @@ function apply(target: Target, sql: string): void {
   }
 }
 
+function assertBackfillValidation(summary: ValidationSummary): void {
+  const mismatches = [
+    ['upload events', summary.rawUploadEvents, summary.rollupUploadEvents],
+    ['upload bytes', summary.rawUploadBytes, summary.rollupUploadBytes],
+    ['download events', summary.rawDownloadEvents, summary.rollupDownloadEvents],
+    ['download bytes', summary.rawDownloadBytes, summary.rollupDownloadBytes],
+    ['share views', summary.rawShareViews, summary.rollupShareViews],
+  ].filter(([, raw, rollup]) => raw !== rollup)
+  if (mismatches.length > 0 || summary.orphanRollupBuckets > 0) {
+    throw new Error(
+      `admin_stats_validation_failed:${JSON.stringify({ mismatches, orphanRollupBuckets: summary.orphanRollupBuckets })}`,
+    )
+  }
+}
+
 function main(): void {
   const options = parseOptions(process.argv.slice(2))
   const before = querySummary<ValidationSummary>(options.target, VALIDATION_SQL)
@@ -375,6 +739,7 @@ function main(): void {
   if (!options.apply) return
   apply(options.target, buildBackfillSql())
   const after = querySummary<ValidationSummary>(options.target, VALIDATION_SQL)
+  assertBackfillValidation(after)
   console.log(
     JSON.stringify(
       {
@@ -385,7 +750,7 @@ function main(): void {
           activityEvents: after.activityEvents - before.activityEvents,
           uploadMetadata: before.missingUploadBytes - after.missingUploadBytes,
           downloadMetadata: before.missingDownloadBytes - after.missingDownloadBytes,
-          storageRollups: after.storageRollups - before.storageRollups,
+          hourlyRollups: after.hourlyRollups - before.hourlyRollups,
         },
         skipped: {
           uploadBytes: { count: after.missingUploadBytes, reason: 'historical matter no longer exists' },

--- a/server/adapters/repos/admin-stats-hourly.ts
+++ b/server/adapters/repos/admin-stats-hourly.ts
@@ -1,0 +1,175 @@
+import { and, eq, gte, lt } from 'drizzle-orm'
+import { statsRollupsHourly } from '../../db/schema'
+import { ADMIN_STATS_METRICS, type AdminStatsMetric } from '../../domain/admin-stats-metrics'
+import { statsDayKey } from '../../domain/admin-stats-time'
+import type { Database } from '../../platform/interface'
+import type { AdminStatsDateRange } from '../../usecases/ports'
+
+const HOUR_MS = 3_600_000
+
+export interface StatsInterval {
+  from: Date
+  toExclusive: Date
+}
+
+export interface HourlyMetricRow {
+  bucketStart: Date
+  orgId: string
+  dimensionKey: string
+  dimensionValue: string
+  count: number
+  bytes: number
+  uniqueCount: number
+  lowerBound: boolean
+}
+
+export class AdminStatsHourlyReader {
+  private readonly toExclusive: Date
+  private readonly plan: Promise<HourlyReadPlan>
+
+  constructor(
+    private readonly db: Database,
+    private readonly range: AdminStatsDateRange,
+    now: Date,
+  ) {
+    const nextWholeSecond = Math.ceil((now.getTime() + 1) / 1000) * 1000
+    this.toExclusive = new Date(Math.min(range.to.getTime() + 1, nextWholeSecond))
+    this.plan = buildReadPlan(db, { from: range.from, toExclusive: this.toExclusive }, range.timeZone)
+  }
+
+  async rows(metric: AdminStatsMetric): Promise<HourlyMetricRow[]> {
+    const plan = await this.plan
+    if (plan.completeBuckets.size === 0) return []
+    const rows = await this.db
+      .select({
+        bucketStart: statsRollupsHourly.bucketStart,
+        orgId: statsRollupsHourly.orgId,
+        dimensionKey: statsRollupsHourly.dimensionKey,
+        dimensionValue: statsRollupsHourly.dimensionValue,
+        count: statsRollupsHourly.count,
+        bytes: statsRollupsHourly.bytes,
+        uniqueCount: statsRollupsHourly.uniqueCount,
+        metadata: statsRollupsHourly.metadata,
+      })
+      .from(statsRollupsHourly)
+      .where(
+        and(
+          eq(statsRollupsHourly.metricKey, metric),
+          gte(statsRollupsHourly.bucketStart, plan.queryFrom),
+          lt(statsRollupsHourly.bucketStart, plan.queryTo),
+        ),
+      )
+    return rows
+      .filter((row) => plan.completeBuckets.has(row.bucketStart.getTime()))
+      .map((row) => ({
+        bucketStart: row.bucketStart,
+        orgId: row.orgId,
+        dimensionKey: row.dimensionKey,
+        dimensionValue: row.dimensionValue,
+        count: row.count,
+        bytes: row.bytes,
+        uniqueCount: row.uniqueCount,
+        lowerBound: parseQuality(row.metadata) === 'lower_bound',
+      }))
+  }
+
+  async rawIntervals(): Promise<StatsInterval[]> {
+    return (await this.plan).rawIntervals
+  }
+
+  endExclusive(): Date {
+    return this.toExclusive
+  }
+
+  dayKey(date: Date): string {
+    return statsDayKey(date, this.range.timeZone)
+  }
+}
+
+type HourlyReadPlan = {
+  queryFrom: Date
+  queryTo: Date
+  completeBuckets: Set<number>
+  rawIntervals: StatsInterval[]
+}
+
+async function buildReadPlan(db: Database, range: StatsInterval, timeZone: string): Promise<HourlyReadPlan> {
+  const queryFrom = ceilHour(range.from)
+  const queryTo = floorHour(range.toExclusive)
+  const markerRows =
+    queryFrom < queryTo
+      ? await db
+          .select({ bucketStart: statsRollupsHourly.bucketStart })
+          .from(statsRollupsHourly)
+          .where(
+            and(
+              eq(statsRollupsHourly.metricKey, ADMIN_STATS_METRICS.statsRollupRun),
+              eq(statsRollupsHourly.dimensionKey, ''),
+              gte(statsRollupsHourly.bucketStart, queryFrom),
+              lt(statsRollupsHourly.bucketStart, queryTo),
+            ),
+          )
+      : []
+  const marked = new Set(markerRows.map((row) => row.bucketStart.getTime()))
+  const completeBuckets = new Set<number>()
+  const rawIntervals: StatsInterval[] = []
+
+  if (range.from < queryFrom)
+    rawIntervals.push({ from: range.from, toExclusive: minDate(queryFrom, range.toExclusive) })
+  for (let at = queryFrom.getTime(); at < queryTo.getTime(); at += HOUR_MS) {
+    const from = new Date(at)
+    const toExclusive = new Date(at + HOUR_MS)
+    const crossesLocalDay = statsDayKey(from, timeZone) !== statsDayKey(new Date(toExclusive.getTime() - 1), timeZone)
+    if (!marked.has(at) || crossesLocalDay) rawIntervals.push({ from, toExclusive })
+    else completeBuckets.add(at)
+  }
+  if (queryTo < range.toExclusive)
+    rawIntervals.push({ from: maxDate(queryTo, range.from), toExclusive: range.toExclusive })
+
+  return { queryFrom, queryTo, completeBuckets, rawIntervals: mergeIntervals(rawIntervals) }
+}
+
+function parseQuality(metadata: string | null): string {
+  if (!metadata) return 'unknown'
+  try {
+    const value: unknown = JSON.parse(metadata)
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return 'unknown'
+    const quality = (value as Record<string, unknown>).quality
+    return typeof quality === 'string' ? quality : 'unknown'
+  } catch {
+    return 'unknown'
+  }
+}
+
+function floorHour(date: Date): Date {
+  return new Date(Math.floor(date.getTime() / HOUR_MS) * HOUR_MS)
+}
+
+function ceilHour(date: Date): Date {
+  const floor = floorHour(date)
+  return floor.getTime() === date.getTime() ? floor : new Date(floor.getTime() + HOUR_MS)
+}
+
+function mergeIntervals(intervals: StatsInterval[]): StatsInterval[] {
+  const sorted = intervals
+    .filter((interval) => interval.from < interval.toExclusive)
+    .sort((left, right) => left.from.getTime() - right.from.getTime())
+  const result: StatsInterval[] = []
+  for (const interval of sorted) {
+    const previous = result.at(-1)
+    if (!previous || interval.from > previous.toExclusive) {
+      result.push({ ...interval })
+      continue
+    }
+    if (interval.toExclusive > previous.toExclusive) previous.toExclusive = interval.toExclusive
+  }
+  return result
+}
+
+function minDate(left: Date, right: Date): Date {
+  return left < right ? left : right
+}
+
+function maxDate(left: Date, right: Date): Date {
+  return left > right ? left : right
+}

--- a/server/adapters/repos/admin-stats-rollup.integration.test.ts
+++ b/server/adapters/repos/admin-stats-rollup.integration.test.ts
@@ -1,0 +1,252 @@
+import { sql } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+import { assertMetricDimension, ADMIN_STATS_METRICS as M } from '../../domain/admin-stats-metrics'
+import { adminHeaders, createTestApp } from '../../test/setup.js'
+import { AdminStatsHourlyReader } from './admin-stats-hourly'
+import { rebuildAdminStatsHour } from './admin-stats-rollup'
+
+type RollupRow = {
+  orgId: string
+  metric: string
+  dimensionKey: string
+  dimensionValue: string
+  count: number
+  bytes: number
+  uniqueCount: number
+  metadata: string
+}
+
+describe('admin hourly stats rollup', () => {
+  it('rebuilds event, user, operational, and snapshot metrics idempotently', async () => {
+    const { app, db } = await createTestApp()
+    await adminHeaders(app)
+    const [{ id: orgId }] = await db.all<{ id: string }>(
+      sql`SELECT id FROM organization WHERE metadata LIKE '%"type":"personal"%' LIMIT 1`,
+    )
+    const [{ id: userId }] = await db.all<{ id: string }>(sql`SELECT id FROM user LIMIT 1`)
+    const bucketStart = new Date('2026-07-10T12:00:00.000Z')
+    const generatedAt = new Date('2026-07-10T12:30:00.000Z')
+    const atMs = bucketStart.getTime() + 60_000
+    const atSec = Math.floor(atMs / 1000)
+
+    await db.run(sql`UPDATE user SET created_at = ${atMs}, updated_at = ${atMs} WHERE id = ${userId}`)
+    await db.run(sql`UPDATE account SET created_at = ${atMs}, updated_at = ${atMs} WHERE user_id = ${userId}`)
+    await db.run(sql`UPDATE session SET created_at = ${atMs}, updated_at = ${atMs} WHERE user_id = ${userId}`)
+    await db.run(sql`UPDATE organization SET created_at = ${atMs}, updated_at = ${atMs} WHERE id = ${orgId}`)
+    await db.run(sql`
+      INSERT INTO organization (id, name, slug, metadata, created_at, updated_at)
+      VALUES ('rollup-team', 'Rollup Team', 'rollup-team', '{"type":"team"}', ${atMs}, ${atMs})
+    `)
+    await db.run(sql`
+      UPDATE org_quotas
+      SET used = 500, quota = 1000, traffic_used = 300, traffic_quota = 2000
+      WHERE org_id = ${orgId}
+    `)
+    await db.run(sql`
+      INSERT INTO storages
+        (id, bucket, endpoint, region, access_key, secret_key, file_path, custom_host, capacity, used, status, created_at, updated_at)
+      VALUES
+        ('rollup-storage', 'bucket', 'https://s3.example', 'auto', 'AK', 'SK', '', '', 1000, 500, 'active', ${atSec}, ${atSec}),
+        ('rollup-storage-disabled', 'bucket-2', 'https://s3.example', 'auto', 'AK', 'SK', '', '', 1000, 900, 'disabled', ${atSec}, ${atSec})
+    `)
+    await db.run(sql`
+      INSERT INTO matters
+        (id, org_id, alias, name, type, size, dirtype, parent, object, storage_id, status, created_at, updated_at)
+      VALUES
+        ('rollup-file', ${orgId}, 'rollup-file', 'video.mp4', 'video/mp4', 200, 0, '', 'video.mp4', 'rollup-storage', 'active', ${atSec}, ${atSec}),
+        ('rollup-dir', ${orgId}, 'rollup-dir', 'folder', '', 0, 1, '', '', 'rollup-storage', 'active', ${atSec}, ${atSec}),
+        ('rollup-trashed', ${orgId}, 'rollup-trashed', 'old.bin', 'application/octet-stream', 800, 0, '', 'old.bin', 'rollup-storage', 'trashed', ${atSec}, ${atSec})
+    `)
+    await db.run(sql`
+      INSERT INTO image_hostings
+        (id, org_id, token, path, storage_id, storage_key, size, mime, status, access_count, created_at)
+      VALUES ('rollup-image', ${orgId}, 'ih_rollup', 'image.png', 'rollup-storage', 'image.png', 300,
+        'image/png', 'active', 0, ${atMs})
+    `)
+    await db.run(sql`
+      INSERT INTO shares
+        (id, token, kind, matter_id, org_id, creator_id, expires_at, download_limit, views, downloads, status, created_at)
+      VALUES
+        ('rollup-share-usable', 'rollup-share-usable', 'landing', 'rollup-file', ${orgId}, ${userId}, NULL, NULL, 0, 0, 'active', ${atSec}),
+        ('rollup-share-revoked', 'rollup-share-revoked', 'direct', 'rollup-file', ${orgId}, ${userId}, NULL, NULL, 0, 0, 'revoked', ${atSec}),
+        ('rollup-share-expired', 'rollup-share-expired', 'landing', 'rollup-file', ${orgId}, ${userId}, ${atSec - 1}, NULL, 0, 0, 'active', ${atSec}),
+        ('rollup-share-limited', 'rollup-share-limited', 'direct', 'rollup-file', ${orgId}, ${userId}, NULL, 1, 0, 1, 'active', ${atSec})
+    `)
+    await db.run(sql`
+      INSERT INTO activity_events
+        (id, org_id, user_id, actor_type, action, target_type, target_id, target_name, metadata, created_at)
+      VALUES
+        ('rollup-upload-ok', ${orgId}, ${userId}, 'user', 'upload_confirm', 'file', 'rollup-file', 'ok.bin',
+          '{"bytes":100,"source":"upload","storageId":"rollup-storage"}', ${atSec}),
+        ('rollup-upload-missing', ${orgId}, ${userId}, NULL, 'upload_confirm', 'file', 'rollup-file', 'missing.bin',
+          'not-json', ${atSec}),
+        ('rollup-upload-cancel', ${orgId}, ${userId}, 'user', 'upload_cancel', 'file', 'rollup-file', 'cancel.bin',
+          '{}', ${atSec}),
+        ('rollup-upload-failed', ${orgId}, ${userId}, 'user', 'upload_failed', 'file', 'rollup-file', 'failed.bin',
+          '{"reason":"network"}', ${atSec}),
+        ('rollup-share-download', ${orgId}, NULL, NULL, 'share_download', 'share', 'rollup-share-usable', 'shared.bin',
+          '{"bytes":20,"shareId":"rollup-share-usable","kind":"landing"}', ${atSec}),
+        ('rollup-object-download', ${orgId}, ${userId}, NULL, 'object_download', 'file', 'rollup-file', 'object.bin',
+          '{"bytes":30}', ${atSec}),
+        ('rollup-image-download', ${orgId}, NULL, 'anonymous', 'image_hosting_download', 'image', 'rollup-image', 'image.png',
+          '[]', ${atSec}),
+        ('rollup-webdav-download', ${orgId}, ${userId}, 'user', 'webdav_download', 'file', 'rollup-file', 'webdav.bin',
+          '{"bytes":40}', ${atSec}),
+        ('rollup-download-failed', ${orgId}, ${userId}, 'user', 'download_failed', 'file', 'rollup-file', 'blocked.bin',
+          '{"bytes":5,"reason":"quota_exceeded"}', ${atSec}),
+        ('rollup-share-view', ${orgId}, NULL, 'anonymous', 'share_view', 'share', 'rollup-share-usable', 'shared.bin',
+          NULL, ${atSec}),
+        ('rollup-share-save', ${orgId}, ${userId}, 'user', 'save_from_share', 'share', 'rollup-share-usable', 'shared.bin',
+          '{"bytes":6}', ${atSec}),
+        ('rollup-share-password', ${orgId}, NULL, 'anonymous', 'share_password_passed', 'share', 'rollup-share-usable', 'shared.bin',
+          NULL, ${atSec}),
+        ('rollup-restore', ${orgId}, ${userId}, 'user', 'restore', 'file', 'rollup-file', 'restored.bin', NULL, ${atSec}),
+        ('rollup-purge', ${orgId}, ${userId}, 'user', 'object_purge', 'file', 'rollup-file', 'purged.bin', NULL, ${atSec}),
+        ('rollup-team-join', ${orgId}, ${userId}, 'user', 'team_member_join', 'organization', 'rollup-team', 'team', NULL, ${atSec}),
+        ('rollup-team-remove', ${orgId}, ${userId}, 'user', 'team_member_remove', 'organization', 'rollup-team', 'team', NULL, ${atSec}),
+        ('rollup-license', ${orgId}, NULL, 'system', 'license_refresh', 'license', NULL, 'license',
+          '{"status":"failed"}', ${atSec})
+    `)
+    await db.run(sql`
+      INSERT INTO cloud_traffic_reports
+        (id, org_id, period, source, source_id, storage_id, event_id, bytes, unit_bytes, credits_per_unit, status, created_at, updated_at)
+      VALUES
+        ('rollup-traffic-ok', ${orgId}, '2026-07', 'object_download', 'rollup-file', 'rollup-storage', 'traffic-ok', 100, 50, 2, 'reported', ${atMs}, ${atMs}),
+        ('rollup-traffic-blocked', ${orgId}, '2026-07', 'landing_share', 'rollup-share-usable', NULL, 'traffic-blocked', 200, 50, 2, 'blocked', ${atMs}, ${atMs})
+    `)
+    await db.run(sql`
+      INSERT INTO downloaders
+        (id, name, token_hash, token_jti, status, enabled, version, hostname, platform, arch, engine, capabilities,
+          max_concurrent_tasks, current_tasks, download_bps, upload_bps, free_disk_bytes, created_by, created_at, updated_at)
+      VALUES
+        ('rollup-downloader', 'Online', 'hash-1', 'jti-1', 'online', 1, '1', 'host', 'linux', 'x64', 'http', '[]', 2, 1, 0, 0, 1, ${userId}, ${atMs}, ${atMs}),
+        ('rollup-downloader-offline', 'Offline', 'hash-2', 'jti-2', 'offline', 1, '1', 'host', 'linux', 'x64', 'http', '[]', 2, 0, 0, 0, 1, ${userId}, ${atMs}, ${atMs})
+    `)
+    await db.run(sql`
+      INSERT INTO download_tasks
+        (id, org_id, created_by_user_id, source_type, source_uri, display_name, target_folder, category, tags,
+          assigned_downloader_id, status, billing_charged_bytes, created_at, updated_at, finished_at)
+      VALUES
+        ('rollup-task-finished', ${orgId}, ${userId}, 'http', 'https://example.com/a', 'a', '', NULL, '[]',
+          'rollup-downloader', 'completed', 60, ${atMs}, ${atMs}, ${atMs}),
+        ('rollup-task-queued', ${orgId}, ${userId}, 'torrent', 'magnet:?xt=1', 'b', '', 'media', '[]',
+          'rollup-downloader', 'queued', 0, ${atMs}, ${atMs}, NULL)
+    `)
+    await db.run(sql`
+      INSERT INTO background_jobs
+        (id, org_id, user_id, type, status, target_folder, target_path, created_at, updated_at, finished_at)
+      VALUES
+        ('rollup-job-finished', ${orgId}, ${userId}, 'archive', 'failed', '', '', ${atMs}, ${atMs}, ${atMs}),
+        ('rollup-job-queued', ${orgId}, ${userId}, 'extract', 'queued', '', '', ${atMs}, ${atMs}, NULL)
+    `)
+    await db.run(sql`
+      INSERT INTO remote_download_usage_reports
+        (id, org_id, downloader_id, task_id, event_id, unit_index, unit_bytes, credits_per_unit, status, created_at, updated_at)
+      VALUES ('rollup-usage', ${orgId}, 'rollup-downloader', 'rollup-task-finished', 'usage-event', 0, 70, 3,
+        'reported', ${atMs}, ${atMs})
+    `)
+    await db.run(sql`
+      INSERT INTO webhook_events
+        (id, source, event_id, event_type, payload_hash, raw_payload, status, created_at, processed_at)
+      VALUES ('rollup-webhook', 'cloud', 'webhook-event', 'order.quota_changed', 'hash', '{}', 'processed', ${atMs}, ${atMs})
+    `)
+
+    const first = await rebuildAdminStatsHour(db, bucketStart, generatedAt, true)
+    const rows = await db.all<RollupRow>(sql`
+      SELECT org_id AS orgId, metric_key AS metric, dimension_key AS dimensionKey,
+        dimension_value AS dimensionValue, count, bytes, unique_count AS uniqueCount, metadata
+      FROM stats_rollups_hourly
+      WHERE bucket_start = ${bucketStart.getTime()}
+    `)
+    const row = (metric: string, dimensionKey = '', dimensionValue = '', rowOrgId = orgId) =>
+      rows.find(
+        (value) =>
+          value.metric === metric &&
+          value.orgId === rowOrgId &&
+          value.dimensionKey === dimensionKey &&
+          value.dimensionValue === dimensionValue,
+      )
+
+    expect(first).toMatchObject({
+      bucketStart,
+      bucketEnd: new Date('2026-07-10T13:00:00.000Z'),
+      rows: rows.length,
+      lowerBoundRows: expect.any(Number),
+    })
+    expect(first.lowerBoundRows).toBeGreaterThan(0)
+    expect(row(M.transferUpload)).toMatchObject({ count: 4, bytes: 100 })
+    expect(row(M.storageIngress)).toMatchObject({ count: 2, bytes: 100 })
+    expect(row(M.transferDownloadIssued)).toMatchObject({ count: 4, bytes: 90 })
+    expect(row(M.trafficQuotaBlocked)).toMatchObject({ count: 1, bytes: 5 })
+    expect(row(M.shareDownloadIssued)).toMatchObject({ count: 1, bytes: 20 })
+    expect(row(M.statsMissingBytes)).toMatchObject({ count: 2 })
+    expect(row(M.teamMembershipChange)).toMatchObject({ count: 2 })
+    expect(row(M.userSignup, '', '', '')).toMatchObject({ count: 1 })
+    expect(row(M.userActiveHour, '', '', '')).toMatchObject({ uniqueCount: 1 })
+    expect(row(M.spaceCreated, '', '', '')).toMatchObject({ count: 2 })
+    expect(row(M.shareCreated)).toMatchObject({ count: 4 })
+    expect(row(M.trafficReportSync)).toMatchObject({ count: 2, bytes: 300 })
+    expect(row(M.trafficCreditConsumed)).toMatchObject({ count: 4, bytes: 100 })
+    expect(row(M.remoteDownloadTaskCreated)).toMatchObject({ count: 2 })
+    expect(row(M.remoteDownloadTaskFinished)).toMatchObject({ count: 1, bytes: 60 })
+    expect(row(M.backgroundJobFinished)).toMatchObject({ count: 1 })
+    expect(row(M.remoteDownloadUsage)).toMatchObject({ count: 3, bytes: 70 })
+    expect(row(M.webhookProcessed, '', '', '')).toMatchObject({ count: 1 })
+    expect(row(M.storageInventory)).toMatchObject({ count: 2, bytes: 500 })
+    expect(row(M.shareInventory, 'lifecycle', 'usable')).toMatchObject({ count: 1 })
+    expect(row(M.shareInventory, 'lifecycle', 'revoked')).toMatchObject({ count: 1 })
+    expect(row(M.shareInventory, 'lifecycle', 'expired')).toMatchObject({ count: 1 })
+    expect(row(M.shareInventory, 'lifecycle', 'download_limit_reached')).toMatchObject({ count: 1 })
+    expect(row(M.backgroundJobSnapshot)).toMatchObject({ count: 1 })
+    expect(row(M.remoteDownloadTaskSnapshot)).toMatchObject({ count: 1 })
+    expect(row(M.downloaderSnapshot, '', '', '')).toMatchObject({ count: 2 })
+    expect(row(M.statsRollupRun, '', '', '')).toMatchObject({ count: 1 })
+    expect(JSON.parse(row(M.transferUpload)?.metadata ?? '{}')).toMatchObject({ quality: 'lower_bound' })
+
+    const second = await rebuildAdminStatsHour(db, bucketStart, generatedAt, true)
+    const [{ count: storedRows }] = await db.all<{ count: number }>(sql`
+      SELECT COUNT(*) AS count FROM stats_rollups_hourly WHERE bucket_start = ${bucketStart.getTime()}
+    `)
+    expect(second.rows).toBe(first.rows)
+    expect(storedRows).toBe(first.rows)
+  })
+
+  it('rejects buckets that are not aligned to a UTC hour', async () => {
+    const { db } = await createTestApp()
+
+    await expect(
+      rebuildAdminStatsHour(db, new Date('2026-07-10T12:00:00.001Z'), new Date('2026-07-10T12:30:00Z'), false),
+    ).rejects.toThrow('stats_bucket_must_align_to_utc_hour')
+  })
+
+  it('treats absent and malformed rollup quality metadata as exact data', async () => {
+    const { db } = await createTestApp()
+    const bucketStart = Date.parse('2026-07-10T10:00:00.000Z')
+    await db.run(sql`
+      INSERT INTO stats_rollups_hourly
+        (id, bucket_start, org_id, metric_key, dimension_key, dimension_value,
+          count, bytes, unique_count, metadata, updated_at)
+      VALUES
+        ('quality-marker', ${bucketStart}, '', 'stats.rollup_run', '', '', 1, 0, 0, '{}', ${bucketStart}),
+        ('quality-null', ${bucketStart}, 'org-null', 'transfer.upload', '', '', 1, 1, 0, NULL, ${bucketStart}),
+        ('quality-array', ${bucketStart}, 'org-array', 'transfer.upload', '', '', 1, 2, 0, '[]', ${bucketStart}),
+        ('quality-invalid', ${bucketStart}, 'org-invalid', 'transfer.upload', '', '', 1, 3, 0, '{', ${bucketStart})
+    `)
+    const reader = new AdminStatsHourlyReader(
+      db,
+      {
+        from: new Date(bucketStart),
+        to: new Date(bucketStart + 3_600_000 - 1),
+        timeZone: 'UTC',
+      },
+      new Date(bucketStart + 7_200_000),
+    )
+
+    expect(reader.endExclusive()).toEqual(new Date(bucketStart + 3_600_000))
+    expect(await reader.rows(M.transferUpload)).toHaveLength(3)
+    expect((await reader.rows(M.transferUpload)).every((row) => row.lowerBound === false)).toBe(true)
+    expect(() => assertMetricDimension(M.transferUpload, 'not-a-dimension')).toThrow(
+      'Unsupported stats dimension: transfer.upload/not-a-dimension',
+    )
+  })
+})

--- a/server/adapters/repos/admin-stats-rollup.integration.test.ts
+++ b/server/adapters/repos/admin-stats-rollup.integration.test.ts
@@ -1,6 +1,6 @@
 import { sql } from 'drizzle-orm'
 import { describe, expect, it } from 'vitest'
-import { assertMetricDimension, ADMIN_STATS_METRICS as M } from '../../domain/admin-stats-metrics'
+import { assertMetricDimension, ADMIN_STATS_METRICS as M, metricDefinition } from '../../domain/admin-stats-metrics'
 import { adminHeaders, createTestApp } from '../../test/setup.js'
 import { AdminStatsHourlyReader } from './admin-stats-hourly'
 import { rebuildAdminStatsHour } from './admin-stats-rollup'
@@ -219,6 +219,15 @@ describe('admin hourly stats rollup', () => {
     ).rejects.toThrow('stats_bucket_must_align_to_utc_hour')
   })
 
+  it('identifies the snapshot query stage that failed', async () => {
+    const { db } = await createTestApp()
+    await db.run(sql`DROP TABLE org_quotas`)
+
+    await expect(
+      rebuildAdminStatsHour(db, new Date('2026-07-10T12:00:00Z'), new Date('2026-07-10T12:30:00Z'), true),
+    ).rejects.toThrow('stats_rollup_query_failed:quota')
+  })
+
   it('treats absent and malformed rollup quality metadata as exact data', async () => {
     const { db } = await createTestApp()
     const bucketStart = Date.parse('2026-07-10T10:00:00.000Z')
@@ -230,7 +239,8 @@ describe('admin hourly stats rollup', () => {
         ('quality-marker', ${bucketStart}, '', 'stats.rollup_run', '', '', 1, 0, 0, '{}', ${bucketStart}),
         ('quality-null', ${bucketStart}, 'org-null', 'transfer.upload', '', '', 1, 1, 0, NULL, ${bucketStart}),
         ('quality-array', ${bucketStart}, 'org-array', 'transfer.upload', '', '', 1, 2, 0, '[]', ${bucketStart}),
-        ('quality-invalid', ${bucketStart}, 'org-invalid', 'transfer.upload', '', '', 1, 3, 0, '{', ${bucketStart})
+        ('quality-invalid', ${bucketStart}, 'org-invalid', 'transfer.upload', '', '', 1, 3, 0, '{', ${bucketStart}),
+        ('quality-object', ${bucketStart}, 'org-object', 'transfer.upload', '', '', 1, 4, 0, '{}', ${bucketStart})
     `)
     const reader = new AdminStatsHourlyReader(
       db,
@@ -243,8 +253,9 @@ describe('admin hourly stats rollup', () => {
     )
 
     expect(reader.endExclusive()).toEqual(new Date(bucketStart + 3_600_000))
-    expect(await reader.rows(M.transferUpload)).toHaveLength(3)
+    expect(await reader.rows(M.transferUpload)).toHaveLength(4)
     expect((await reader.rows(M.transferUpload)).every((row) => row.lowerBound === false)).toBe(true)
+    expect(metricDefinition(M.transferUpload)).toMatchObject({ kind: 'counter', bytesUnit: 'bytes' })
     expect(() => assertMetricDimension(M.transferUpload, 'not-a-dimension')).toThrow(
       'Unsupported stats dimension: transfer.upload/not-a-dimension',
     )

--- a/server/adapters/repos/admin-stats-rollup.integration.test.ts
+++ b/server/adapters/repos/admin-stats-rollup.integration.test.ts
@@ -34,6 +34,10 @@ describe('admin hourly stats rollup', () => {
     await db.run(sql`UPDATE session SET created_at = ${atMs}, updated_at = ${atMs} WHERE user_id = ${userId}`)
     await db.run(sql`UPDATE organization SET created_at = ${atMs}, updated_at = ${atMs} WHERE id = ${orgId}`)
     await db.run(sql`
+      INSERT INTO user (id, name, email, email_verified, created_at, updated_at)
+      VALUES ('rollup-direct-user', 'Direct User', 'direct@example.com', 0, ${atMs}, ${atMs})
+    `)
+    await db.run(sql`
       INSERT INTO organization (id, name, slug, metadata, created_at, updated_at)
       VALUES ('rollup-team', 'Rollup Team', 'rollup-team', '{"type":"team"}', ${atMs}, ${atMs})
     `)
@@ -181,7 +185,8 @@ describe('admin hourly stats rollup', () => {
     expect(row(M.shareDownloadIssued)).toMatchObject({ count: 1, bytes: 20 })
     expect(row(M.statsMissingBytes)).toMatchObject({ count: 2 })
     expect(row(M.teamMembershipChange)).toMatchObject({ count: 2 })
-    expect(row(M.userSignup, '', '', '')).toMatchObject({ count: 1 })
+    expect(row(M.userSignup, '', '', '')).toMatchObject({ count: 2 })
+    expect(row(M.userSignup, 'provider', 'direct', '')).toMatchObject({ count: 1 })
     expect(row(M.userActiveHour, '', '', '')).toMatchObject({ uniqueCount: 1 })
     expect(row(M.spaceCreated, '', '', '')).toMatchObject({ count: 2 })
     expect(row(M.shareCreated)).toMatchObject({ count: 4 })

--- a/server/adapters/repos/admin-stats-rollup.ts
+++ b/server/adapters/repos/admin-stats-rollup.ts
@@ -456,7 +456,7 @@ async function addSnapshotMetrics(db: Database, rollups: RollupAccumulator, now:
   }
   for (const row of storageRows) rollups.setGauge(M.storageUsed, '', 0, row.used, 'storage_id', row.id)
   for (const row of [...inventoryRows, ...inventoryByType, ...inventoryBySize, ...inventoryByAge]) {
-    rollups.setGauge(M.storageInventory, row.orgId, row.files, row.bytes, row.dimensionKey, row.dimensionValue)
+    rollups.incrementGauge(M.storageInventory, row.orgId, row.files, row.bytes, row.dimensionKey, row.dimensionValue)
   }
   for (const row of shareRows) {
     const lifecycle = shareLifecycle(row, now)

--- a/server/adapters/repos/admin-stats-rollup.ts
+++ b/server/adapters/repos/admin-stats-rollup.ts
@@ -1,0 +1,705 @@
+import { isPersonalOrgLike } from '@shared/org-slugs'
+import { and, eq, gte, inArray, lt, sql } from 'drizzle-orm'
+import { account, organization, session, user } from '../../db/auth-schema'
+import {
+  activityEvents,
+  backgroundJobs,
+  cloudTrafficReports,
+  downloaders,
+  downloadTasks,
+  imageHostings,
+  matters,
+  orgQuotas,
+  remoteDownloadUsageReports,
+  shares,
+  statsRollupsHourly,
+  storages,
+  webhookEvents,
+} from '../../db/schema'
+import { type AtomicQuery, executeWriteTransaction } from '../../db/transaction'
+import {
+  type AdminStatsDimension,
+  type AdminStatsMetric,
+  assertMetricDimension,
+  ADMIN_STATS_METRICS as M,
+  ROLLUP_VERSION,
+} from '../../domain/admin-stats-metrics'
+import type { Database } from '../../platform/interface'
+
+const HOUR_MS = 3_600_000
+const DOWNLOAD_ACTIONS = ['share_download', 'object_download', 'image_hosting_download', 'webdav_download']
+const COUNTER_METRICS: AdminStatsMetric[] = [
+  M.backgroundJobFinished,
+  M.licenseRefresh,
+  M.remoteDownloadTaskCreated,
+  M.remoteDownloadTaskFinished,
+  M.remoteDownloadUsage,
+  M.shareCreated,
+  M.shareDownloadIssued,
+  M.sharePasswordPassed,
+  M.shareSaved,
+  M.shareView,
+  M.spaceCreated,
+  M.statsMissingBytes,
+  M.statsRollupRun,
+  M.storageIngress,
+  M.storageRemoved,
+  M.storageRestored,
+  M.teamMembershipChange,
+  M.trafficCreditConsumed,
+  M.trafficQuotaBlocked,
+  M.trafficReportSync,
+  M.transferDownloadFailed,
+  M.transferDownloadIssued,
+  M.transferUpload,
+  M.userActiveHour,
+  M.userSessionStarted,
+  M.userSignup,
+  M.webhookProcessed,
+]
+
+type RollupValue = {
+  metric: AdminStatsMetric
+  orgId: string
+  dimensionKey: AdminStatsDimension | ''
+  dimensionValue: string
+  count: number
+  bytes: number
+  uniqueCount: number
+  lowerBound: boolean
+}
+
+type DimensionValues = Partial<Record<AdminStatsDimension, string | null | undefined>>
+
+export interface AdminStatsHourlyRollupResult {
+  bucketStart: Date
+  bucketEnd: Date
+  rows: number
+  lowerBoundRows: number
+}
+
+export async function rebuildAdminStatsHour(
+  db: Database,
+  bucketStartInput: Date,
+  generatedAt: Date,
+  includeSnapshots: boolean,
+): Promise<AdminStatsHourlyRollupResult> {
+  const bucketStart = startOfHour(bucketStartInput)
+  if (bucketStart.getTime() !== bucketStartInput.getTime()) throw new Error('stats_bucket_must_align_to_utc_hour')
+  const bucketEnd = new Date(bucketStart.getTime() + HOUR_MS)
+  const rollups = new RollupAccumulator()
+
+  await addEventMetrics(db, rollups, bucketStart, bucketEnd)
+  await addUserMetrics(db, rollups, bucketStart, bucketEnd)
+  await addOperationalMetrics(db, rollups, bucketStart, bucketEnd)
+  if (includeSnapshots) await addSnapshotMetrics(db, rollups, generatedAt)
+
+  const values = rollups.values()
+  const lowerBoundRows = values.filter((row) => row.lowerBound).length
+  rollups.add(M.statsRollupRun, '', 1, 0, { outcome: 'success' })
+
+  const updatedAt = generatedAt
+  const rows = rollups.values().map((row) => ({
+    id: rollupId(bucketStart, row),
+    bucketStart,
+    orgId: row.orgId,
+    metricKey: row.metric,
+    dimensionKey: row.dimensionKey,
+    dimensionValue: row.dimensionValue,
+    count: row.count,
+    bytes: row.bytes,
+    uniqueCount: row.uniqueCount,
+    metadata: JSON.stringify({
+      version: ROLLUP_VERSION,
+      quality: row.lowerBound ? 'lower_bound' : 'exact',
+      generatedAt: generatedAt.toISOString(),
+    }),
+    updatedAt,
+  }))
+
+  const deleteWhere = includeSnapshots
+    ? eq(statsRollupsHourly.bucketStart, bucketStart)
+    : and(eq(statsRollupsHourly.bucketStart, bucketStart), inArray(statsRollupsHourly.metricKey, COUNTER_METRICS))
+  const writes: AtomicQuery[] = [db.delete(statsRollupsHourly).where(deleteWhere)]
+  for (let index = 0; index < rows.length; index += 80) {
+    writes.push(db.insert(statsRollupsHourly).values(rows.slice(index, index + 80)))
+  }
+  await executeWriteTransaction(db, writes)
+  return { bucketStart, bucketEnd, rows: rows.length, lowerBoundRows }
+}
+
+async function addEventMetrics(db: Database, rollups: RollupAccumulator, from: Date, to: Date): Promise<void> {
+  const rows = await db
+    .select({
+      orgId: activityEvents.orgId,
+      userId: activityEvents.userId,
+      actorType: activityEvents.actorType,
+      action: activityEvents.action,
+      targetId: activityEvents.targetId,
+      metadata: activityEvents.metadata,
+    })
+    .from(activityEvents)
+    .where(and(gte(activityEvents.createdAt, from), lt(activityEvents.createdAt, to)))
+
+  for (const row of rows) {
+    const metadata = parseMetadata(row.metadata)
+    const bytes = metadataNumber(metadata, 'bytes')
+    const source = metadataString(metadata, 'source')
+    const storageId = metadataString(metadata, 'storageId')
+    const actorType = row.actorType ?? (row.userId ? 'user' : 'anonymous')
+    const lowerBound = needsBytes(row.action) && !hasFiniteNumber(metadata.bytes)
+
+    if (row.action === 'upload_confirm' || row.action === 'upload_cancel' || row.action === 'upload_failed') {
+      const status =
+        row.action === 'upload_confirm' ? 'success' : row.action === 'upload_cancel' ? 'canceled' : 'failed'
+      const reason =
+        row.action === 'upload_confirm'
+          ? null
+          : (metadataString(metadata, 'reason') ??
+            (row.action === 'upload_cancel' ? 'upload_canceled' : 'upload_failed'))
+      const confirmedBytes = row.action === 'upload_confirm' ? bytes : 0
+      rollups.add(
+        M.transferUpload,
+        row.orgId,
+        1,
+        confirmedBytes,
+        { source: source ?? 'upload', status, reason, storage_id: storageId },
+        lowerBound,
+      )
+      if (row.action === 'upload_confirm') {
+        rollups.add(
+          M.storageIngress,
+          row.orgId,
+          1,
+          bytes,
+          { source: source ?? 'web_upload', status, storage_id: storageId },
+          lowerBound,
+        )
+      }
+    }
+
+    if (DOWNLOAD_ACTIONS.includes(row.action)) {
+      rollups.add(
+        M.transferDownloadIssued,
+        row.orgId,
+        1,
+        bytes,
+        {
+          source: source ?? fallbackDownloadSource(row.action),
+          storage_id: storageId,
+          actor_type: actorType,
+        },
+        lowerBound,
+      )
+    }
+
+    if (row.action === 'download_failed') {
+      const reason = metadataString(metadata, 'reason') ?? 'unknown'
+      rollups.add(M.transferDownloadFailed, row.orgId, 1, bytes, { source: source ?? 'unknown', reason })
+      if (reason === 'quota_exceeded') rollups.add(M.trafficQuotaBlocked, row.orgId, 1, bytes, { source })
+    }
+
+    if (row.action === 'share_view') {
+      rollups.add(M.shareView, row.orgId, 1, 0, { share_id: row.targetId, actor_type: actorType })
+    }
+    if (row.action === 'share_download') {
+      rollups.add(M.shareDownloadIssued, row.orgId, 1, bytes, {
+        share_id: metadataString(metadata, 'shareId') ?? row.targetId,
+        kind: metadataString(metadata, 'kind'),
+        source: source ?? fallbackDownloadSource(row.action),
+        actor_type: actorType,
+      })
+    }
+    if (row.action === 'save_from_share') {
+      rollups.add(M.shareSaved, row.orgId, 1, bytes, {
+        share_id: metadataString(metadata, 'shareId') ?? row.targetId,
+        actor_type: actorType,
+      })
+    }
+    if (row.action === 'share_password_passed') {
+      rollups.add(M.sharePasswordPassed, row.orgId, 1, 0, { share_id: row.targetId })
+    }
+    if (row.action === 'restore') rollups.add(M.storageRestored, row.orgId, 1, bytes, { source: 'trash' }, lowerBound)
+    if (row.action === 'object_purge') {
+      rollups.add(M.storageRemoved, row.orgId, 1, bytes, { reason: 'purged' }, lowerBound)
+    }
+    if (row.action === 'team_member_join') rollups.add(M.teamMembershipChange, row.orgId, 1, 0, { outcome: 'join' })
+    if (row.action === 'team_member_remove') rollups.add(M.teamMembershipChange, row.orgId, 1, 0, { outcome: 'remove' })
+    if (row.action === 'license_refresh') {
+      rollups.add(M.licenseRefresh, '', 1, 0, { outcome: metadataString(metadata, 'status') ?? 'success' })
+    }
+    if (lowerBound) {
+      rollups.add(M.statsMissingBytes, row.orgId, 1, 0, {
+        direction: row.action === 'upload_confirm' ? 'upload' : 'download',
+        source: source ?? row.action,
+      })
+    }
+  }
+}
+
+async function addUserMetrics(db: Database, rollups: RollupAccumulator, from: Date, to: Date): Promise<void> {
+  const [signupRows, sessionRows, activeActivityRows, spaceRows, shareRows] = await Promise.all([
+    db
+      .select({ userId: user.id, provider: account.providerId, accountCreatedAt: account.createdAt })
+      .from(user)
+      .leftJoin(account, eq(account.userId, user.id))
+      .where(and(gte(user.createdAt, from), lt(user.createdAt, to))),
+    db
+      .select({ userId: session.userId })
+      .from(session)
+      .where(and(gte(session.createdAt, from), lt(session.createdAt, to))),
+    db
+      .select({ userId: activityEvents.userId })
+      .from(activityEvents)
+      .innerJoin(user, eq(activityEvents.userId, user.id))
+      .where(and(gte(activityEvents.createdAt, from), lt(activityEvents.createdAt, to))),
+    db
+      .select({ slug: organization.slug, metadata: organization.metadata })
+      .from(organization)
+      .where(and(gte(organization.createdAt, from), lt(organization.createdAt, to))),
+    db
+      .select({ orgId: shares.orgId, kind: shares.kind })
+      .from(shares)
+      .where(and(gte(shares.createdAt, from), lt(shares.createdAt, to))),
+  ])
+
+  const providers = new Map<string, { provider: string; at: Date }>()
+  for (const row of signupRows) {
+    if (!row.provider || !row.accountCreatedAt) continue
+    const current = providers.get(row.userId)
+    if (!current || row.accountCreatedAt < current.at)
+      providers.set(row.userId, { provider: row.provider, at: row.accountCreatedAt })
+  }
+  for (const userId of new Set(signupRows.map((row) => row.userId))) {
+    rollups.add(M.userSignup, '', 1, 0, { provider: providers.get(userId)?.provider ?? 'direct' })
+  }
+  rollups.add(M.userSessionStarted, '', sessionRows.length)
+  rollups.addDistinct(
+    M.userActiveHour,
+    '',
+    [...sessionRows, ...activeActivityRows].map((row) => row.userId).filter(Boolean) as string[],
+  )
+  for (const row of spaceRows) {
+    const orgType = isPersonalOrgLike({ slug: row.slug, metadata: row.metadata }) ? 'personal' : 'team'
+    rollups.add(M.spaceCreated, '', 1, 0, { org_type: orgType })
+  }
+  for (const row of shareRows) rollups.add(M.shareCreated, row.orgId, 1, 0, { kind: row.kind })
+}
+
+async function addOperationalMetrics(db: Database, rollups: RollupAccumulator, from: Date, to: Date): Promise<void> {
+  const [trafficRows, taskCreatedRows, taskFinishedRows, jobRows, usageRows, webhookRows] = await Promise.all([
+    db
+      .select({
+        orgId: cloudTrafficReports.orgId,
+        source: cloudTrafficReports.source,
+        status: cloudTrafficReports.status,
+        bytes: cloudTrafficReports.bytes,
+        storageId: cloudTrafficReports.storageId,
+        unitBytes: cloudTrafficReports.unitBytes,
+        creditsPerUnit: cloudTrafficReports.creditsPerUnit,
+      })
+      .from(cloudTrafficReports)
+      .where(and(gte(cloudTrafficReports.updatedAt, from), lt(cloudTrafficReports.updatedAt, to))),
+    db
+      .select({ orgId: downloadTasks.orgId, category: downloadTasks.category, sourceType: downloadTasks.sourceType })
+      .from(downloadTasks)
+      .where(and(gte(downloadTasks.createdAt, from), lt(downloadTasks.createdAt, to))),
+    db
+      .select({
+        orgId: downloadTasks.orgId,
+        category: downloadTasks.category,
+        downloaderId: downloadTasks.assignedDownloaderId,
+        status: downloadTasks.status,
+        bytes: downloadTasks.billingChargedBytes,
+      })
+      .from(downloadTasks)
+      .where(and(gte(downloadTasks.finishedAt, from), lt(downloadTasks.finishedAt, to))),
+    db
+      .select({ orgId: backgroundJobs.orgId, type: backgroundJobs.type, status: backgroundJobs.status })
+      .from(backgroundJobs)
+      .where(and(gte(backgroundJobs.finishedAt, from), lt(backgroundJobs.finishedAt, to))),
+    db
+      .select({
+        orgId: remoteDownloadUsageReports.orgId,
+        downloaderId: remoteDownloadUsageReports.downloaderId,
+        status: remoteDownloadUsageReports.status,
+        bytes: remoteDownloadUsageReports.unitBytes,
+        credits: remoteDownloadUsageReports.creditsPerUnit,
+      })
+      .from(remoteDownloadUsageReports)
+      .where(and(gte(remoteDownloadUsageReports.createdAt, from), lt(remoteDownloadUsageReports.createdAt, to))),
+    db
+      .select({ status: webhookEvents.status })
+      .from(webhookEvents)
+      .where(and(gte(webhookEvents.processedAt, from), lt(webhookEvents.processedAt, to))),
+  ])
+
+  for (const row of trafficRows) {
+    rollups.add(M.trafficReportSync, row.orgId, 1, row.bytes, { source: row.source, status: row.status })
+    if (row.status !== 'blocked' && row.unitBytes && row.creditsPerUnit) {
+      rollups.add(
+        M.trafficCreditConsumed,
+        row.orgId,
+        Math.ceil(row.bytes / row.unitBytes) * row.creditsPerUnit,
+        row.bytes,
+        { source: row.source, storage_id: row.storageId },
+      )
+    }
+  }
+  for (const row of taskCreatedRows) {
+    rollups.add(M.remoteDownloadTaskCreated, row.orgId, 1, 0, {
+      category: row.category ?? 'uncategorized',
+      source: row.sourceType,
+    })
+  }
+  for (const row of taskFinishedRows) {
+    rollups.add(M.remoteDownloadTaskFinished, row.orgId, 1, row.bytes, {
+      category: row.category ?? 'uncategorized',
+      downloader_id: row.downloaderId,
+      outcome: row.status,
+    })
+  }
+  for (const row of jobRows) {
+    rollups.add(M.backgroundJobFinished, row.orgId, 1, 0, { job_type: row.type, outcome: row.status })
+  }
+  for (const row of usageRows) {
+    rollups.add(M.remoteDownloadUsage, row.orgId, row.credits, row.bytes, {
+      downloader_id: row.downloaderId,
+      status: row.status,
+    })
+  }
+  for (const row of webhookRows) rollups.add(M.webhookProcessed, '', 1, 0, { outcome: row.status })
+}
+
+async function addSnapshotMetrics(db: Database, rollups: RollupAccumulator, now: Date): Promise<void> {
+  const [
+    quotaRows,
+    storageRows,
+    inventoryRows,
+    inventoryByType,
+    inventoryBySize,
+    inventoryByAge,
+    shareRows,
+    jobRows,
+    taskRows,
+    downloaderRows,
+  ] = await Promise.all([
+    queryStage(
+      'quota',
+      db
+        .select({
+          orgId: orgQuotas.orgId,
+          used: orgQuotas.used,
+          quota: orgQuotas.quota,
+          trafficUsed: orgQuotas.trafficUsed,
+          trafficQuota: orgQuotas.trafficQuota,
+        })
+        .from(orgQuotas),
+    ),
+    queryStage(
+      'storage',
+      db.select({ id: storages.id, used: storages.used }).from(storages).where(eq(storages.status, 'active')),
+    ),
+    queryStage('inventory-base', inventoryGroups(db, now, 'base')),
+    queryStage('inventory-type', inventoryGroups(db, now, 'file_type_group')),
+    queryStage('inventory-size', inventoryGroups(db, now, 'size_bucket')),
+    queryStage('inventory-age', inventoryGroups(db, now, 'age_bucket')),
+    queryStage(
+      'shares',
+      db
+        .select({
+          orgId: shares.orgId,
+          kind: shares.kind,
+          status: shares.status,
+          expiresAt: shares.expiresAt,
+          downloadLimit: shares.downloadLimit,
+          downloads: shares.downloads,
+        })
+        .from(shares),
+    ),
+    queryStage(
+      'jobs',
+      db
+        .select({ orgId: backgroundJobs.orgId, type: backgroundJobs.type, status: backgroundJobs.status })
+        .from(backgroundJobs)
+        .where(inArray(backgroundJobs.status, ['queued', 'running'])),
+    ),
+    queryStage(
+      'tasks',
+      db
+        .select({
+          orgId: downloadTasks.orgId,
+          downloaderId: downloadTasks.assignedDownloaderId,
+          status: downloadTasks.status,
+        })
+        .from(downloadTasks)
+        .where(
+          inArray(downloadTasks.status, [
+            'queued',
+            'assigned',
+            'downloading',
+            'uploading',
+            'suspended',
+            'paused',
+            'interrupted',
+          ]),
+        ),
+    ),
+    queryStage('downloaders', db.select({ id: downloaders.id, status: downloaders.status }).from(downloaders)),
+  ])
+
+  for (const row of quotaRows) {
+    rollups.setGauge(M.storageUsed, row.orgId, 0, row.used)
+    rollups.setGauge(M.storageQuota, row.orgId, 0, row.quota)
+    rollups.setGauge(M.trafficQuotaUsed, row.orgId, 0, row.trafficUsed)
+    rollups.setGauge(M.trafficQuota, row.orgId, 0, row.trafficQuota)
+  }
+  for (const row of storageRows) rollups.setGauge(M.storageUsed, '', 0, row.used, 'storage_id', row.id)
+  for (const row of [...inventoryRows, ...inventoryByType, ...inventoryBySize, ...inventoryByAge]) {
+    rollups.setGauge(M.storageInventory, row.orgId, row.files, row.bytes, row.dimensionKey, row.dimensionValue)
+  }
+  for (const row of shareRows) {
+    const lifecycle = shareLifecycle(row, now)
+    rollups.incrementGauge(M.shareInventory, row.orgId, 1, 0)
+    rollups.incrementGauge(M.shareInventory, row.orgId, 1, 0, 'kind', row.kind)
+    rollups.incrementGauge(M.shareInventory, row.orgId, 1, 0, 'lifecycle', lifecycle)
+  }
+  for (const row of jobRows) {
+    rollups.incrementGauge(M.backgroundJobSnapshot, row.orgId, 1, 0)
+    rollups.incrementGauge(M.backgroundJobSnapshot, row.orgId, 1, 0, 'job_type', row.type)
+    rollups.incrementGauge(M.backgroundJobSnapshot, row.orgId, 1, 0, 'status', row.status)
+  }
+  for (const row of taskRows) {
+    rollups.incrementGauge(M.remoteDownloadTaskSnapshot, row.orgId, 1, 0)
+    if (row.downloaderId)
+      rollups.incrementGauge(M.remoteDownloadTaskSnapshot, row.orgId, 1, 0, 'downloader_id', row.downloaderId)
+    rollups.incrementGauge(M.remoteDownloadTaskSnapshot, row.orgId, 1, 0, 'status', row.status)
+  }
+  for (const row of downloaderRows) {
+    rollups.incrementGauge(M.downloaderSnapshot, '', 1, 0)
+    rollups.incrementGauge(M.downloaderSnapshot, '', 1, 0, 'downloader_id', row.id)
+    rollups.incrementGauge(M.downloaderSnapshot, '', 1, 0, 'status', row.status)
+  }
+}
+
+type InventoryGroup = {
+  orgId: string
+  files: number
+  bytes: number
+  dimensionKey: AdminStatsDimension | ''
+  dimensionValue: string
+}
+
+async function inventoryGroups(
+  db: Database,
+  now: Date,
+  dimension: '' | 'base' | AdminStatsDimension,
+): Promise<InventoryGroup[]> {
+  const dimensionSql =
+    dimension === 'file_type_group'
+      ? sql<string>`CASE WHEN instr(${matters.type}, '/') > 0 THEN substr(${matters.type}, 1, instr(${matters.type}, '/') - 1) ELSE COALESCE(NULLIF(${matters.type}, ''), 'unknown') END`
+      : dimension === 'size_bucket'
+        ? sql<string>`CASE WHEN ${matters.size} <= ${10 * 1024 * 1024} THEN '<10MB' WHEN ${matters.size} <= ${100 * 1024 * 1024} THEN '10-100MB' WHEN ${matters.size} <= ${1024 * 1024 * 1024} THEN '100MB-1GB' ELSE '>1GB' END`
+        : dimension === 'age_bucket'
+          ? sql<string>`CASE WHEN ${matters.createdAt} >= ${Math.floor(now.getTime() / 1000) - 30 * 86_400} THEN '<30d' WHEN ${matters.createdAt} >= ${Math.floor(now.getTime() / 1000) - 90 * 86_400} THEN '30-90d' WHEN ${matters.createdAt} >= ${Math.floor(now.getTime() / 1000) - 180 * 86_400} THEN '90-180d' ELSE '>180d' END`
+          : sql<string>`''`
+  const matterRows = await db
+    .select({
+      orgId: matters.orgId,
+      files: sql<number>`COUNT(*)`,
+      bytes: sql<number>`COALESCE(SUM(${matters.size}), 0)`,
+      dimensionValue: dimensionSql,
+    })
+    .from(matters)
+    .where(and(eq(matters.status, 'active'), eq(matters.dirtype, 0)))
+    .groupBy(matters.orgId, dimensionSql)
+  const imageDimensionSql =
+    dimension === 'file_type_group'
+      ? sql<string>`'image'`
+      : dimension === 'size_bucket'
+        ? sql<string>`CASE WHEN ${imageHostings.size} <= ${10 * 1024 * 1024} THEN '<10MB' WHEN ${imageHostings.size} <= ${100 * 1024 * 1024} THEN '10-100MB' WHEN ${imageHostings.size} <= ${1024 * 1024 * 1024} THEN '100MB-1GB' ELSE '>1GB' END`
+        : dimension === 'age_bucket'
+          ? sql<string>`CASE WHEN ${imageHostings.createdAt} >= ${now.getTime() - 30 * 86_400_000} THEN '<30d' WHEN ${imageHostings.createdAt} >= ${now.getTime() - 90 * 86_400_000} THEN '30-90d' WHEN ${imageHostings.createdAt} >= ${now.getTime() - 180 * 86_400_000} THEN '90-180d' ELSE '>180d' END`
+          : sql<string>`''`
+  const imageRows = await db
+    .select({
+      orgId: imageHostings.orgId,
+      files: sql<number>`COUNT(*)`,
+      bytes: sql<number>`COALESCE(SUM(${imageHostings.size}), 0)`,
+      dimensionValue: imageDimensionSql,
+    })
+    .from(imageHostings)
+    .where(eq(imageHostings.status, 'active'))
+    .groupBy(imageHostings.orgId, imageDimensionSql)
+  const result: InventoryGroup[] = matterRows.map((row) => ({
+    orgId: row.orgId,
+    files: Number(row.files),
+    bytes: Number(row.bytes),
+    dimensionKey: dimension === 'base' ? '' : dimension,
+    dimensionValue: row.dimensionValue,
+  }))
+  for (const row of imageRows) {
+    result.push({
+      orgId: row.orgId,
+      files: Number(row.files),
+      bytes: Number(row.bytes),
+      dimensionKey: dimension === 'base' ? '' : dimension,
+      dimensionValue: row.dimensionValue,
+    })
+  }
+  return result
+}
+
+class RollupAccumulator {
+  private readonly rows = new Map<string, RollupValue>()
+
+  add(
+    metric: AdminStatsMetric,
+    orgId: string,
+    count: number,
+    bytes = 0,
+    dimensions: DimensionValues = {},
+    lowerBound = false,
+  ): void {
+    this.increment(metric, orgId, '', '', count, bytes, 0, lowerBound)
+    for (const [dimensionKey, dimensionValue] of Object.entries(dimensions)) {
+      if (!dimensionValue) continue
+      assertMetricDimension(metric, dimensionKey)
+      this.increment(metric, orgId, dimensionKey, dimensionValue, count, bytes, 0, lowerBound)
+    }
+  }
+
+  addDistinct(metric: AdminStatsMetric, orgId: string, values: string[]): void {
+    this.increment(metric, orgId, '', '', 0, 0, new Set(values).size, false)
+  }
+
+  setGauge(
+    metric: AdminStatsMetric,
+    orgId: string,
+    count: number,
+    bytes: number,
+    dimensionKey: AdminStatsDimension | '' = '',
+    dimensionValue = '',
+  ): void {
+    if (dimensionKey) assertMetricDimension(metric, dimensionKey)
+    this.rows.set(key(metric, orgId, dimensionKey, dimensionValue), {
+      metric,
+      orgId,
+      dimensionKey,
+      dimensionValue,
+      count,
+      bytes,
+      uniqueCount: 0,
+      lowerBound: false,
+    })
+  }
+
+  incrementGauge(
+    metric: AdminStatsMetric,
+    orgId: string,
+    count: number,
+    bytes: number,
+    dimensionKey: AdminStatsDimension | '' = '',
+    dimensionValue = '',
+  ): void {
+    if (dimensionKey) assertMetricDimension(metric, dimensionKey)
+    this.increment(metric, orgId, dimensionKey, dimensionValue, count, bytes, 0, false)
+  }
+
+  values(): RollupValue[] {
+    return [...this.rows.values()]
+  }
+
+  private increment(
+    metric: AdminStatsMetric,
+    orgId: string,
+    dimensionKey: AdminStatsDimension | '',
+    dimensionValue: string,
+    count: number,
+    bytes: number,
+    uniqueCount: number,
+    lowerBound: boolean,
+  ): void {
+    const rowKey = key(metric, orgId, dimensionKey, dimensionValue)
+    const row = this.rows.get(rowKey) ?? {
+      metric,
+      orgId,
+      dimensionKey,
+      dimensionValue,
+      count: 0,
+      bytes: 0,
+      uniqueCount: 0,
+      lowerBound: false,
+    }
+    row.count += count
+    row.bytes += bytes
+    row.uniqueCount += uniqueCount
+    row.lowerBound ||= lowerBound
+    this.rows.set(rowKey, row)
+  }
+}
+
+function startOfHour(date: Date): Date {
+  return new Date(Math.floor(date.getTime() / HOUR_MS) * HOUR_MS)
+}
+
+function key(metric: AdminStatsMetric, orgId: string, dimensionKey: string, dimensionValue: string): string {
+  return `${metric}\u0000${orgId}\u0000${dimensionKey}\u0000${dimensionValue}`
+}
+
+function rollupId(bucketStart: Date, row: RollupValue): string {
+  return `${bucketStart.getTime()}:${row.orgId || 'global'}:${row.metric}:${row.dimensionKey || 'all'}:${row.dimensionValue || 'all'}`
+}
+
+function parseMetadata(value: string | null): Record<string, unknown> {
+  if (!value) return {}
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {}
+  } catch {
+    return {}
+  }
+}
+
+function metadataString(metadata: Record<string, unknown>, keyValue: string): string | null {
+  const value = metadata[keyValue]
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+function metadataNumber(metadata: Record<string, unknown>, keyValue: string): number {
+  const value = metadata[keyValue]
+  return hasFiniteNumber(value) ? value : 0
+}
+
+function hasFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function needsBytes(action: string): boolean {
+  return action === 'upload_confirm' || DOWNLOAD_ACTIONS.includes(action)
+}
+
+function fallbackDownloadSource(action: string): string {
+  if (action === 'object_download') return 'object_download'
+  if (action === 'image_hosting_download') return 'image_hosting'
+  if (action === 'webdav_download') return 'webdav_download'
+  return 'landing_share'
+}
+
+function shareLifecycle(
+  share: { status: string; expiresAt: Date | null; downloadLimit: number | null; downloads: number },
+  now: Date,
+): string {
+  if (share.status !== 'active') return 'revoked'
+  if (share.expiresAt && share.expiresAt <= now) return 'expired'
+  if (share.downloadLimit !== null && share.downloads >= share.downloadLimit) return 'download_limit_reached'
+  return 'usable'
+}
+
+async function queryStage<T>(name: string, query: PromiseLike<T>): Promise<T> {
+  try {
+    return await query
+  } catch (error) {
+    throw new Error(`stats_rollup_query_failed:${name}`, { cause: error })
+  }
+}

--- a/server/adapters/repos/admin-stats.ts
+++ b/server/adapters/repos/admin-stats.ts
@@ -1,71 +1,63 @@
 import { isPersonalOrgLike } from '@shared/org-slugs'
 import type {
   AdminDashboardGrowthStats,
+  AdminDashboardOperationsStats,
   AdminDashboardOverviewStats,
-  AdminDashboardRankingStats,
   AdminDashboardSharingStats,
   AdminDashboardStorageStats,
   AdminDashboardTrafficStats,
   AdminStatsDelta,
-  AdminStorageByType,
   AdminTopShare,
   AdminTransferDataQuality,
 } from '@shared/types'
 import type { SQL } from 'drizzle-orm'
-import { and, count, desc, eq, gt, gte, inArray, isNull, lte, or, sql } from 'drizzle-orm'
+import { and, count, desc, eq, gt, gte, inArray, isNull, lt, lte, or, sql } from 'drizzle-orm'
 import type { SQLiteTable } from 'drizzle-orm/sqlite-core'
 import { account, organization, session, user } from '../../db/auth-schema'
-import { activityEvents, cloudTrafficReports, matters, orgQuotas, shares, statsRollupsDaily } from '../../db/schema'
+import {
+  activityEvents,
+  backgroundJobs,
+  cloudTrafficReports,
+  downloaders,
+  downloadTasks,
+  matters,
+  orgQuotas,
+  shares,
+  statsRollupsHourly,
+  webhookEvents,
+} from '../../db/schema'
+import { ADMIN_STATS_METRICS } from '../../domain/admin-stats-metrics'
+import { addCalendarDays, statsDayKey as dayKey, localDateStart } from '../../domain/admin-stats-time'
 import type { Database } from '../../platform/interface'
 import type { AdminStatsDateRange, AdminStatsRepo } from '../../usecases/ports'
+import { AdminStatsHourlyReader, type StatsInterval } from './admin-stats-hourly'
+import { rebuildAdminStatsHour } from './admin-stats-rollup'
 
 const DOWNLOAD_ACTIVITY_ACTIONS = ['share_download', 'object_download', 'image_hosting_download', 'webdav_download']
 const DOWNLOAD_FAILURE_ACTION = 'download_failed'
-const STORAGE_USED_ROLLUP_METRIC = 'storage.used.bytes'
-const GLOBAL_ROLLUP_ORG_ID = ''
+const STORAGE_USED_ROLLUP_METRIC = ADMIN_STATS_METRICS.storageUsed
 const GLOBAL_ROLLUP_DIMENSION_KEY = ''
 const GLOBAL_ROLLUP_DIMENSION_VALUE = ''
 
 export function createAdminStatsRepo(db: Database): AdminStatsRepo {
   return {
-    writeStorageUsedRollup: (now) => writeStorageUsedRollup(db, now),
+    refreshHourlyRollups: (now) => refreshHourlyRollups(db, now),
     getDashboardOverviewStats: (now, range) => getDashboardOverviewStats(db, now, range),
+    getDashboardOperationsStats: (now, range) => getDashboardOperationsStats(db, now, range),
     getDashboardGrowthStats: (now, range) => getDashboardGrowthStats(db, now, range),
     getDashboardStorageStats: (now, range) => getDashboardStorageStats(db, now, range),
     getDashboardTrafficStats: (now, range) => getDashboardTrafficStats(db, now, range),
     getDashboardSharingStats: (now, range) => getDashboardSharingStats(db, now, range),
-    getDashboardRankingStats: (now, range) => getDashboardRankingStats(db, now, range),
   }
 }
 
-async function writeStorageUsedRollup(db: Database, now: Date): Promise<{ bucketStart: Date; bytes: number }> {
-  const bucketStart = startOfDay(now)
-  const { usedBytes } = await getQuotaTotals(db)
-  const metadata = JSON.stringify({ source: 'org_quotas.used', quality: 'exact_snapshot' })
-  await db
-    .insert(statsRollupsDaily)
-    .values({
-      id: `storage-used-${dayKey(bucketStart)}`,
-      bucketStart,
-      orgId: GLOBAL_ROLLUP_ORG_ID,
-      metricKey: STORAGE_USED_ROLLUP_METRIC,
-      dimensionKey: GLOBAL_ROLLUP_DIMENSION_KEY,
-      dimensionValue: GLOBAL_ROLLUP_DIMENSION_VALUE,
-      bytes: usedBytes,
-      metadata,
-      updatedAt: now,
-    })
-    .onConflictDoUpdate({
-      target: [
-        statsRollupsDaily.bucketStart,
-        statsRollupsDaily.orgId,
-        statsRollupsDaily.metricKey,
-        statsRollupsDaily.dimensionKey,
-        statsRollupsDaily.dimensionValue,
-      ],
-      set: { bytes: usedBytes, metadata, updatedAt: now },
-    })
-  return { bucketStart, bytes: usedBytes }
+async function refreshHourlyRollups(db: Database, now: Date) {
+  const currentHour = startOfHour(now)
+  const previousHour = new Date(currentHour.getTime() - 3_600_000)
+  const finalizePreviousSnapshot = now.getUTCMinutes() < 10
+  const previous = await rebuildAdminStatsHour(db, previousHour, now, finalizePreviousSnapshot)
+  const current = await rebuildAdminStatsHour(db, currentHour, now, true)
+  return [previous, current]
 }
 
 async function countRows(db: Database, table: typeof user): Promise<number> {
@@ -78,7 +70,7 @@ async function countRowsWhere(db: Database, table: SQLiteTable, where: SQL | und
   return toNumber(rows[0]?.value)
 }
 
-async function getStorageByType(db: Database, range?: AdminStatsDateRange): Promise<AdminStorageByType[]> {
+async function getStorageByType(db: Database): Promise<Array<{ type: string; bytes: number; files: number }>> {
   const rows = await db
     .select({
       type: matters.type,
@@ -86,14 +78,7 @@ async function getStorageByType(db: Database, range?: AdminStatsDateRange): Prom
       bytes: sql<number>`COALESCE(SUM(${matters.size}), 0)`,
     })
     .from(matters)
-    .where(
-      and(
-        eq(matters.status, 'active'),
-        eq(matters.dirtype, 0),
-        range ? gte(matters.createdAt, range.from) : undefined,
-        range ? lte(matters.createdAt, range.to) : undefined,
-      ),
-    )
+    .where(and(eq(matters.status, 'active'), eq(matters.dirtype, 0)))
     .groupBy(matters.type)
     .orderBy(desc(sql`COALESCE(SUM(${matters.size}), 0)`))
 
@@ -119,6 +104,8 @@ async function getDashboardOverviewStats(
   range: AdminStatsDateRange,
 ): Promise<AdminDashboardOverviewStats> {
   const previous = previousRange(range)
+  const reader = new AdminStatsHourlyReader(db, range, now)
+  const previousReader = new AdminStatsHourlyReader(db, previous, now)
   const [
     totalUsers,
     newUsers,
@@ -129,25 +116,27 @@ async function getDashboardOverviewStats(
     traffic,
     previousTraffic,
     sharing,
+    previousSharing,
     dataQuality,
   ] = await Promise.all([
     countRows(db, user),
-    countRowsWhere(db, user, and(gte(user.createdAt, range.from), lte(user.createdAt, range.to))),
-    countRowsWhere(db, user, and(gte(user.createdAt, previous.from), lte(user.createdAt, previous.to))),
+    getSignupTotal(db, reader),
+    getSignupTotal(db, previousReader),
     countActiveUsers(db, range),
     countActiveUsers(db, previous),
     getQuotaTotals(db),
-    getTrafficTotals(db, range),
-    getTrafficTotals(db, previous),
-    getSharingEventTotals(db, range, now),
-    getTransferDataQuality(db, range),
+    getTrafficTotals(db, reader),
+    getTrafficTotals(db, previousReader),
+    getSharingEventTotals(db, now, reader),
+    getSharingEventTotals(db, now, previousReader),
+    getTransferDataQuality(db, range, now),
   ])
   const [trendNewUsers, activeByDay, storageUsedByDay, uploadByDay, downloadByDay] = await Promise.all([
-    getNewUsersByDay(db, range),
+    getSignupsByDay(db, range, reader),
     getActiveUsersByDay(db, range),
     getStorageUsedByDay(db, range),
-    getActivityBytesByDay(db, range, ['upload_confirm']),
-    getDownloadBytesByDay(db, range),
+    getActivityMetricByDay(db, range, reader, metricSpec(['upload_confirm']), 'bytes'),
+    getActivityMetricByDay(db, range, reader, metricSpec(DOWNLOAD_ACTIVITY_ACTIONS), 'bytes'),
   ])
   const trends = createDateBuckets(range).map((date) => {
     return {
@@ -176,10 +165,75 @@ async function getDashboardOverviewStats(
       uploadBytes: delta(traffic.uploadBytes, previousTraffic.uploadBytes),
       downloadBytes: delta(traffic.downloadBytes, previousTraffic.downloadBytes),
       activeShares: sharing.activeShares,
-      shareViews: delta(sharing.views, (await getSharingEventTotals(db, previous, now)).views),
-      shareDownloads: delta(sharing.downloads, (await getSharingEventTotals(db, previous, now)).downloads),
+      shareViews: delta(sharing.views, previousSharing.views),
+      shareDownloads: delta(sharing.downloads, previousSharing.downloads),
     },
     trends,
+  }
+}
+
+async function getDashboardOperationsStats(
+  db: Database,
+  now: Date,
+  range: AdminStatsDateRange,
+): Promise<AdminDashboardOperationsStats> {
+  const reader = new AdminStatsHourlyReader(db, range, now)
+  const activeTaskStatuses = ['queued', 'assigned', 'downloading', 'uploading', 'suspended', 'paused', 'interrupted']
+  const [
+    activeBackgroundJobs,
+    activeRemoteDownloads,
+    downloaderRows,
+    cloudReportBacklog,
+    webhookFailures,
+    backgroundJobOutcomes,
+    remoteDownloadOutcomes,
+    cloudReportStatus,
+    backgroundJobsByDay,
+    remoteDownloadsByDay,
+  ] = await Promise.all([
+    countRowsWhere(db, backgroundJobs, inArray(backgroundJobs.status, ['queued', 'running'])),
+    countRowsWhere(db, downloadTasks, inArray(downloadTasks.status, activeTaskStatuses)),
+    db.select({ status: downloaders.status }).from(downloaders),
+    countRowsWhere(db, cloudTrafficReports, inArray(cloudTrafficReports.status, ['pending', 'failed'])),
+    countRowsWhere(db, webhookEvents, eq(webhookEvents.status, 'failed')),
+    getOperationalOutcomes(db, reader, 'background_job'),
+    getOperationalOutcomes(db, reader, 'remote_download'),
+    getCloudReportOutcomes(db, reader),
+    getOperationalOutcomesByDay(db, reader, range, 'background_job'),
+    getOperationalOutcomesByDay(db, reader, range, 'remote_download'),
+  ])
+  const downloaderStatus = countBy(downloaderRows, (row) => row.status)
+  const completedJobs = backgroundJobOutcomes.get('completed') ?? 0
+  const failedJobs = backgroundJobOutcomes.get('failed') ?? 0
+  const completedRemoteDownloads = remoteDownloadOutcomes.get('completed') ?? 0
+  const failedRemoteDownloads = remoteDownloadOutcomes.get('failed') ?? 0
+
+  return {
+    ...statsFrame(now, range),
+    summary: {
+      activeBackgroundJobs,
+      activeRemoteDownloads,
+      onlineDownloaders: downloaderStatus.get('online') ?? 0,
+      offlineDownloaders: (downloaderStatus.get('offline') ?? 0) + (downloaderStatus.get('disabled') ?? 0),
+      backgroundJobFailureRate: nullablePercent(failedJobs, completedJobs + failedJobs),
+      remoteDownloadSuccessRate: nullablePercent(
+        completedRemoteDownloads,
+        completedRemoteDownloads + failedRemoteDownloads,
+      ),
+      cloudReportBacklog,
+      webhookFailures,
+    },
+    trend: createDateBuckets(range).map((date) => ({
+      date,
+      completedJobs: backgroundJobsByDay.get(date)?.get('completed') ?? 0,
+      failedJobs: backgroundJobsByDay.get(date)?.get('failed') ?? 0,
+      completedRemoteDownloads: remoteDownloadsByDay.get(date)?.get('completed') ?? 0,
+      failedRemoteDownloads: remoteDownloadsByDay.get(date)?.get('failed') ?? 0,
+    })),
+    backgroundJobOutcomes: percentRows([...backgroundJobOutcomes].map(([name, value]) => ({ name, value }))),
+    remoteDownloadOutcomes: percentRows([...remoteDownloadOutcomes].map(([name, value]) => ({ name, value }))),
+    downloaderStatus: percentRows([...downloaderStatus].map(([name, value]) => ({ name, value }))),
+    cloudReportStatus: percentRows([...cloudReportStatus].map(([name, value]) => ({ name, value }))),
   }
 }
 
@@ -189,17 +243,19 @@ async function getDashboardGrowthStats(
   range: AdminStatsDateRange,
 ): Promise<AdminDashboardGrowthStats> {
   const previous = previousRange(range)
+  const reader = new AdminStatsHourlyReader(db, range, now)
+  const previousReader = new AdminStatsHourlyReader(db, previous, now)
   const [usersRows, newUsers, previousNewUsers, activeUsers, previousActiveUsers, activeByDay, registrationSources] =
     await Promise.all([
       db
         .select({ id: user.id, emailVerified: user.emailVerified, banned: user.banned, createdAt: user.createdAt })
         .from(user),
-      countRowsWhere(db, user, and(gte(user.createdAt, range.from), lte(user.createdAt, range.to))),
-      countRowsWhere(db, user, and(gte(user.createdAt, previous.from), lte(user.createdAt, previous.to))),
+      getSignupTotal(db, reader),
+      getSignupTotal(db, previousReader),
       countActiveUsers(db, range),
       countActiveUsers(db, previous),
       getRollingActiveUserTrend(db, range),
-      getRegistrationSources(db, range),
+      getRegistrationSources(db, reader),
     ])
   const activeLast30 = await activeUserIds(db, { from: daysAgo(now, 30), to: now, timeZone: range.timeZone })
   const totalUsers = usersRows.length
@@ -208,7 +264,7 @@ async function getDashboardGrowthStats(
   const unverifiedUsers = usersRows.filter((row) => !row.emailVerified && !row.banned).length
   const silentUsers = usersRows.filter((row) => row.emailVerified && !row.banned && !activeLast30.has(row.id)).length
   const normalUsers = Math.max(0, totalUsers - unverifiedUsers - bannedUsers - silentUsers)
-  const newUsersByDay = await getNewUsersByDay(db, range)
+  const newUsersByDay = await getSignupsByDay(db, range, reader)
   let totalAtStart = usersRows.filter((row) => row.createdAt < range.from).length
   const userScaleTrend = createDateBuckets(range).map((date) => {
     const dailyNew = newUsersByDay.get(date) ?? 0
@@ -244,6 +300,8 @@ async function getDashboardStorageStats(
   range: AdminStatsDateRange,
 ): Promise<AdminDashboardStorageStats> {
   const previous = previousRange(range)
+  const reader = new AdminStatsHourlyReader(db, range, now)
+  const previousReader = new AdminStatsHourlyReader(db, previous, now)
   const [
     quotas,
     files,
@@ -256,6 +314,7 @@ async function getDashboardStorageStats(
     uploadsByDay,
     uploadFilesByDay,
     dataQuality,
+    spaceUsage,
   ] = await Promise.all([
     getQuotaTotals(db),
     db
@@ -264,13 +323,14 @@ async function getDashboardStorageStats(
       .where(and(eq(matters.status, 'active'), eq(matters.dirtype, 0))),
     getStorageUsedByDay(db, range),
     getStorageByType(db),
-    countActivityEvents(db, range, ['upload_confirm']),
-    countActivityEvents(db, previous, ['upload_confirm']),
-    getActivityBytesTotal(db, range, ['upload_confirm']),
-    getActivityBytesTotal(db, previous, ['upload_confirm']),
-    getActivityBytesByDay(db, range, ['upload_confirm']),
-    getActivityCountByDay(db, range, ['upload_confirm']),
-    getTransferDataQuality(db, range),
+    getActivityMetricTotal(db, reader, metricSpec(['upload_confirm']), 'count'),
+    getActivityMetricTotal(db, previousReader, metricSpec(['upload_confirm']), 'count'),
+    getActivityMetricTotal(db, reader, metricSpec(['upload_confirm']), 'bytes'),
+    getActivityMetricTotal(db, previousReader, metricSpec(['upload_confirm']), 'bytes'),
+    getActivityMetricByDay(db, range, reader, metricSpec(['upload_confirm']), 'bytes'),
+    getActivityMetricByDay(db, range, reader, metricSpec(['upload_confirm']), 'count'),
+    getTransferDataQuality(db, range, now),
+    getUsageBySpaceRows(db),
   ])
   const fileItems = files.map((row) => ({ bytes: row.size ?? 0, createdAt: row.createdAt }))
   const storageTrend = createDateBuckets(range).map((date) => {
@@ -294,6 +354,8 @@ async function getDashboardStorageStats(
       newFiles: delta(newFiles, previousNewFiles),
       newBytes: delta(uploadBytes, previousUploadBytes),
       coldFileBytes,
+      nearQuotaSpaces: spaceUsage.filter((space) => space.utilization >= 80 && space.utilization < 100).length,
+      overQuotaSpaces: spaceUsage.filter((space) => space.utilization >= 100).length,
     },
     storageTrend,
     typeBreakdown: percentByBytes(
@@ -309,6 +371,7 @@ async function getDashboardStorageStats(
       { name: '>1GB', max: Number.POSITIVE_INFINITY },
     ]),
     ageBreakdown: ageBucketBreakdown(fileItems, now),
+    topSpaces: spaceUsage.slice(0, 8),
   }
 }
 
@@ -318,6 +381,8 @@ async function getDashboardTrafficStats(
   range: AdminStatsDateRange,
 ): Promise<AdminDashboardTrafficStats> {
   const previous = previousRange(range)
+  const reader = new AdminStatsHourlyReader(db, range, now)
+  const previousReader = new AdminStatsHourlyReader(db, previous, now)
   const [
     traffic,
     previousTraffic,
@@ -325,73 +390,60 @@ async function getDashboardTrafficStats(
     downloadByDay,
     uploadRequestsByDay,
     downloadRequestsByDay,
-    cloudRows,
-    downloadRows,
+    downloadSourceBytes,
+    downloadSourceRequests,
     uploadSuccessByDay,
     uploadFailureByDay,
-    downloadFailureRows,
-    uploadFailureRows,
+    downloadSuccessByDay,
+    downloadFailuresByDay,
+    downloadFailureReasons,
+    uploadFailureReasons,
     dataQuality,
   ] = await Promise.all([
-    getTrafficTotals(db, range),
-    getTrafficTotals(db, previous),
-    getActivityBytesByDay(db, range, ['upload_confirm']),
-    getDownloadBytesByDay(db, range),
-    getActivityCountByDay(db, range, ['upload_confirm', 'upload_cancel', 'upload_failed']),
-    getDownloadRequestsByDay(db, range),
-    getCloudTrafficRows(db, range),
-    getDownloadIssueRows(db, range),
-    getActivityCountByDay(db, range, ['upload_confirm']),
-    getActivityCountByDay(db, range, ['upload_cancel', 'upload_failed']),
-    getDownloadFailureRows(db, range),
-    getActivityFailureRows(db, range, ['upload_cancel', 'upload_failed']),
-    getTransferDataQuality(db, range),
+    getTrafficTotals(db, reader),
+    getTrafficTotals(db, previousReader),
+    getActivityMetricByDay(db, range, reader, metricSpec(['upload_confirm']), 'bytes'),
+    getActivityMetricByDay(db, range, reader, metricSpec(DOWNLOAD_ACTIVITY_ACTIONS), 'bytes'),
+    getActivityMetricByDay(
+      db,
+      range,
+      reader,
+      metricSpec(['upload_confirm', 'upload_cancel', 'upload_failed']),
+      'count',
+    ),
+    getDownloadRequestsByDay(db, range, reader),
+    getActivityMetricDimensionTotals(db, reader, metricSpec(DOWNLOAD_ACTIVITY_ACTIONS), 'source', 'bytes'),
+    getActivityMetricDimensionTotals(db, reader, metricSpec(DOWNLOAD_ACTIVITY_ACTIONS), 'source', 'count'),
+    getActivityMetricByDay(db, range, reader, metricSpec(['upload_confirm']), 'count'),
+    getActivityMetricByDay(db, range, reader, metricSpec(['upload_cancel', 'upload_failed']), 'count'),
+    getActivityMetricByDay(db, range, reader, metricSpec(DOWNLOAD_ACTIVITY_ACTIONS), 'count'),
+    getActivityMetricByDay(db, range, reader, metricSpec([DOWNLOAD_FAILURE_ACTION]), 'count'),
+    getActivityMetricDimensionTotals(db, reader, metricSpec([DOWNLOAD_FAILURE_ACTION]), 'reason', 'count'),
+    getActivityMetricDimensionTotals(db, reader, metricSpec(['upload_cancel', 'upload_failed']), 'reason', 'count'),
+    getTransferDataQuality(db, range, now),
   ])
   const sourceRows = new Map<string, { name: string; bytes: number; requests: number }>()
   if (traffic.uploadBytes > 0 || traffic.uploadRequests > 0) {
     sourceRows.set('upload', { name: 'upload', bytes: traffic.uploadBytes, requests: traffic.uploadRequests })
   }
-  for (const row of downloadRows) {
-    const item = sourceRows.get(row.source) ?? { name: row.source, bytes: 0, requests: 0 }
-    item.bytes += row.bytes
-    item.requests += 1
-    sourceRows.set(row.source, item)
+  for (const [source, bytes] of downloadSourceBytes) {
+    sourceRows.set(source, { name: source, bytes, requests: downloadSourceRequests.get(source) ?? 0 })
   }
-  for (const row of cloudRows) {
-    if (isCloudRowCovered(row, downloadRows, downloadFailureRows) || row.status === 'blocked') continue
-    const item = sourceRows.get(row.source) ?? { name: row.source, bytes: 0, requests: 0 }
-    item.bytes += row.bytes
-    item.requests += 1
-    sourceRows.set(row.source, item)
-  }
-  const statusRows = countBy(cloudRows, (row) => row.status)
-  const downloadSuccessByDay = new Map<string, number>()
-  const downloadFailuresByDay = new Map<string, number>()
+  const statusRows = new Map<string, number>([
+    [
+      'issued',
+      Math.max(
+        0,
+        traffic.downloadRequests - [...downloadFailureReasons.values()].reduce((sum, value) => sum + value, 0),
+      ),
+    ],
+    ['failed', [...downloadFailureReasons.values()].reduce((sum, value) => sum + value, 0)],
+  ])
   const failureReasonRows = new Map<string, { name: string; value: number }>()
-  for (const row of downloadRows) incrementMap(downloadSuccessByDay, dayKey(row.createdAt, range.timeZone), 1)
-  for (const row of uploadFailureRows) {
-    const item = failureReasonRows.get(row.reason) ?? { name: row.reason, value: 0 }
-    item.value += 1
-    failureReasonRows.set(row.reason, item)
-  }
-  for (const row of downloadFailureRows) {
-    incrementMap(downloadFailuresByDay, dayKey(row.createdAt, range.timeZone), 1)
-    const item = failureReasonRows.get(row.reason) ?? { name: row.reason, value: 0 }
-    item.value += 1
-    failureReasonRows.set(row.reason, item)
-  }
-  for (const row of cloudRows) {
-    const date = dayKey(row.createdAt, range.timeZone)
-    if (isCloudRowCovered(row, downloadRows, downloadFailureRows)) continue
-    if (row.status === 'blocked') {
-      incrementMap(downloadFailuresByDay, date, 1)
-      const name = row.source || 'blocked'
-      const item = failureReasonRows.get(name) ?? { name, value: 0 }
-      item.value += 1
-      failureReasonRows.set(name, item)
-      continue
-    }
-    incrementMap(downloadSuccessByDay, date, 1)
+  for (const [reason, value] of [...uploadFailureReasons, ...downloadFailureReasons]) {
+    const item = failureReasonRows.get(reason) ?? { name: reason, value: 0 }
+    item.value += value
+    failureReasonRows.set(reason, item)
   }
   const trafficTrend = createDateBuckets(range).map((date) => ({
     date,
@@ -413,10 +465,7 @@ async function getDashboardTrafficStats(
     }
   })
   const totalRequests = traffic.uploadRequests + traffic.downloadRequests
-  const blockedDownloads =
-    downloadFailureRows.length +
-    cloudRows.filter((row) => row.status === 'blocked' && !isCloudRowCovered(row, downloadRows, downloadFailureRows))
-      .length
+  const blockedDownloads = [...downloadFailureReasons.values()].reduce((sum, value) => sum + value, 0)
   const issuedDownloads = Math.max(0, traffic.downloadRequests - blockedDownloads)
 
   return {
@@ -438,7 +487,6 @@ async function getDashboardTrafficStats(
     issueStatus: percentRows(
       [...statusRows.entries()].map(([status, countValue]) => ({ status, name: status, value: countValue })),
     ).map(({ name, value, percent: pct }) => ({ status: name, count: value, percent: pct })),
-    bandwidthTrend: trafficTrend.map((row) => ({ date: row.date, bytes: row.uploadBytes + row.downloadBytes })),
     successTrend,
     failureReasons: percentRows([...failureReasonRows.values()]),
   }
@@ -450,9 +498,21 @@ async function getDashboardSharingStats(
   range: AdminStatsDateRange,
 ): Promise<AdminDashboardSharingStats> {
   const previous = previousRange(range)
-  const [sharing, previousSharing, shareRows, saveCount, previousSaveCount, downloadSources] = await Promise.all([
-    getSharingEventTotals(db, range, now),
-    getSharingEventTotals(db, previous, now),
+  const reader = new AdminStatsHourlyReader(db, range, now)
+  const previousReader = new AdminStatsHourlyReader(db, previous, now)
+  const [
+    sharing,
+    previousSharing,
+    shareRows,
+    createdInRange,
+    createdPrevious,
+    typeCounts,
+    saveCount,
+    previousSaveCount,
+    downloadSources,
+  ] = await Promise.all([
+    getSharingEventTotals(db, now, reader),
+    getSharingEventTotals(db, now, previousReader),
     db
       .select({
         kind: shares.kind,
@@ -460,19 +520,21 @@ async function getDashboardSharingStats(
         expiresAt: shares.expiresAt,
         downloadLimit: shares.downloadLimit,
         downloads: shares.downloads,
-        createdAt: shares.createdAt,
       })
       .from(shares),
-    countActivityEvents(db, range, ['save_from_share']),
-    countActivityEvents(db, previous, ['save_from_share']),
-    getActivitySourceCounts(db, range, ['share_download']),
+    getShareCreatedTotal(db, reader),
+    getShareCreatedTotal(db, previousReader),
+    getShareCreatedKinds(db, reader),
+    getActivityMetricTotal(db, reader, metricSpec(['save_from_share']), 'count'),
+    getActivityMetricTotal(db, previousReader, metricSpec(['save_from_share']), 'count'),
+    getActivityMetricDimensionTotals(db, reader, metricSpec(['share_download']), 'source', 'count'),
   ])
   const landingDownloads = downloadSources.get('landing_share') ?? 0
   const directDownloads = downloadSources.get('direct_share') ?? 0
   const [viewsByDay, downloadsByDay, savesByDay] = await Promise.all([
-    getActivityCountByDay(db, range, ['share_view']),
-    getActivityCountByDay(db, range, ['share_download']),
-    getActivityCountByDay(db, range, ['save_from_share']),
+    getActivityMetricByDay(db, range, reader, metricSpec(['share_view']), 'count'),
+    getActivityMetricByDay(db, range, reader, metricSpec(['share_download']), 'count'),
+    getActivityMetricByDay(db, range, reader, metricSpec(['save_from_share']), 'count'),
   ])
   const trend = createDateBuckets(range).map((date) => ({
     date,
@@ -480,16 +542,8 @@ async function getDashboardSharingStats(
     downloads: downloadsByDay.get(date) ?? 0,
     saves: savesByDay.get(date) ?? 0,
   }))
-  const createdInRange = shareRows.filter((row) => row.createdAt >= range.from && row.createdAt <= range.to).length
-  const createdPrevious = shareRows.filter(
-    (row) => row.createdAt >= previous.from && row.createdAt <= previous.to,
-  ).length
   const activeShares = shareRows.filter((row) => isShareActive(row, now)).length
-  const typeCounts = countBy(
-    shareRows.filter((row) => row.createdAt >= range.from && row.createdAt <= range.to),
-    (row) => row.kind,
-  )
-  const topShares = await getTopSharesWithPercent(db, range, {
+  const topShares = await getTopSharesWithPercent(db, reader, {
     totalViews: sharing.views,
     totalDownloads: sharing.downloads,
   })
@@ -505,11 +559,6 @@ async function getDashboardSharingStats(
       downloadConversionRate: nullablePercent(landingDownloads, sharing.views),
       passwordPasses: sharing.passwordPasses,
     },
-    funnel: funnelRows([
-      { name: 'views', value: sharing.views },
-      { name: 'downloads', value: landingDownloads },
-      { name: 'saved_to_drive', value: saveCount },
-    ]),
     trend,
     typeBreakdown: percentRows([...typeCounts.entries()].map(([name, value]) => ({ name, value }))),
     sourceBreakdown: percentRows([
@@ -521,22 +570,42 @@ async function getDashboardSharingStats(
   }
 }
 
-async function getDashboardRankingStats(
-  db: Database,
-  now: Date,
-  range: AdminStatsDateRange,
-): Promise<AdminDashboardRankingStats> {
-  const [topShares, topSpaces, storageByType] = await Promise.all([
-    getTopSharesWithPercent(db, range),
-    getUsageBySpaceRows(db, range),
-    getStorageByType(db, range),
+async function getShareCreatedTotal(db: Database, reader: AdminStatsHourlyReader): Promise<number> {
+  const [rollupRows, rawRows] = await Promise.all([
+    reader.rows(ADMIN_STATS_METRICS.shareCreated),
+    getShareRowsForIntervals(db, await reader.rawIntervals()),
   ])
-  return {
-    ...statsFrame(now, range),
-    topShares,
-    topSpaces,
-    storageByType,
+  return rollupRows.filter((row) => row.dimensionKey === '').reduce((sum, row) => sum + row.count, 0) + rawRows.length
+}
+
+async function getShareCreatedKinds(db: Database, reader: AdminStatsHourlyReader): Promise<Map<string, number>> {
+  const [rollupRows, rawRows] = await Promise.all([
+    reader.rows(ADMIN_STATS_METRICS.shareCreated),
+    getShareRowsForIntervals(db, await reader.rawIntervals()),
+  ])
+  const result = new Map<string, number>()
+  for (const row of rollupRows) {
+    if (row.dimensionKey === 'kind') incrementMap(result, row.dimensionValue, row.count)
   }
+  for (const row of rawRows) incrementMap(result, row.kind, 1)
+  return result
+}
+
+async function getShareRowsForIntervals(db: Database, intervals: StatsInterval[]): Promise<Array<{ kind: string }>> {
+  const rows: Array<{ kind: string }> = []
+  for (let index = 0; index < intervals.length; index += 40) {
+    const conditions = intervals
+      .slice(index, index + 40)
+      .map((interval) => and(gte(shares.createdAt, interval.from), lt(shares.createdAt, interval.toExclusive)))
+    if (conditions.length === 0) continue
+    rows.push(
+      ...(await db
+        .select({ kind: shares.kind })
+        .from(shares)
+        .where(or(...conditions))),
+    )
+  }
+  return rows
 }
 
 function statsFrame(now: Date, range: AdminStatsDateRange) {
@@ -544,6 +613,19 @@ function statsFrame(now: Date, range: AdminStatsDateRange) {
 }
 
 function previousRange(range: AdminStatsDateRange): AdminStatsDateRange {
+  const firstDate = dayKey(range.from, range.timeZone)
+  const lastDate = dayKey(range.to, range.timeZone)
+  const localStart = localDateStart(firstDate, range.timeZone)
+  const localEnd = new Date(localDateStart(addCalendarDays(lastDate, 1), range.timeZone).getTime() - 1)
+  if (localStart.getTime() === range.from.getTime() && localEnd.getTime() === range.to.getTime()) {
+    const days = Math.floor((dateOrdinal(lastDate) - dateOrdinal(firstDate)) / 86_400_000) + 1
+    const previousStartDate = addCalendarDays(firstDate, -days)
+    return {
+      from: localDateStart(previousStartDate, range.timeZone),
+      to: new Date(localDateStart(firstDate, range.timeZone).getTime() - 1),
+      timeZone: range.timeZone,
+    }
+  }
   const durationMs = Math.max(0, range.to.getTime() - range.from.getTime())
   const to = new Date(range.from.getTime() - 1)
   return { from: new Date(to.getTime() - durationMs), to, timeZone: range.timeZone }
@@ -582,27 +664,19 @@ async function activeUserIds(db: Database, range: AdminStatsDateRange): Promise<
       .select({ userId: activityEvents.userId })
       .from(activityEvents)
       .innerJoin(user, eq(activityEvents.userId, user.id))
-      .where(and(gte(activityEvents.createdAt, range.from), lte(activityEvents.createdAt, range.to))),
+      .where(and(gte(activityEvents.createdAt, range.from), lte(activityEvents.createdAt, range.to)))
+      .groupBy(activityEvents.userId),
     db
       .select({ userId: session.userId })
       .from(session)
       .innerJoin(user, eq(session.userId, user.id))
-      .where(and(gte(session.createdAt, range.from), lte(session.createdAt, range.to))),
+      .where(and(gte(session.createdAt, range.from), lte(session.createdAt, range.to)))
+      .groupBy(session.userId),
   ])
   const ids = new Set<string>()
   for (const row of activityRows) if (row.userId) ids.add(row.userId)
   for (const row of sessionRows) ids.add(row.userId)
   return ids
-}
-
-async function getNewUsersByDay(db: Database, range: AdminStatsDateRange): Promise<Map<string, number>> {
-  const rows = await db
-    .select({ createdAt: user.createdAt })
-    .from(user)
-    .where(and(gte(user.createdAt, range.from), lte(user.createdAt, range.to)))
-  const byDay = new Map<string, number>()
-  for (const row of rows) incrementMap(byDay, dayKey(row.createdAt, range.timeZone), 1)
-  return byDay
 }
 
 async function getActiveUsersByDay(db: Database, range: AdminStatsDateRange): Promise<Map<string, Set<string>>> {
@@ -659,119 +733,376 @@ async function getRollingActiveUserTrend(
 
 async function getRegistrationSources(
   db: Database,
-  range: AdminStatsDateRange,
+  reader: AdminStatsHourlyReader,
 ): Promise<Array<{ name: string; value: number; percent: number }>> {
-  const newUsers = await db
-    .select({ id: user.id })
-    .from(user)
-    .where(and(gte(user.createdAt, range.from), lte(user.createdAt, range.to)))
-  if (newUsers.length === 0) return []
-  const userIds = newUsers.map((row) => row.id)
-  const accounts = await db
-    .select({ userId: account.userId, providerId: account.providerId })
-    .from(account)
-    .where(inArray(account.userId, userIds))
-  const seen = new Set<string>()
   const counts = new Map<string, number>()
-  for (const row of accounts.sort((left, right) =>
-    left.userId === right.userId
-      ? left.providerId.localeCompare(right.providerId)
-      : left.userId.localeCompare(right.userId),
-  )) {
-    if (seen.has(row.userId)) continue
-    seen.add(row.userId)
-    incrementMap(counts, row.providerId || 'unknown', 1)
+  const [rollupRows, rawRows] = await Promise.all([
+    reader.rows(ADMIN_STATS_METRICS.userSignup),
+    getSignupRowsForIntervals(db, await reader.rawIntervals()),
+  ])
+  for (const row of rollupRows) {
+    if (row.dimensionKey === 'provider') incrementMap(counts, row.dimensionValue, row.count)
   }
-  const direct = userIds.length - seen.size
-  if (direct > 0) counts.set('direct', direct)
+  for (const row of rawRows) incrementMap(counts, row.provider, 1)
   return percentRows([...counts.entries()].map(([name, value]) => ({ name, value })))
 }
 
-async function getActivityBytesTotal(db: Database, range: AdminStatsDateRange, actions: string[]): Promise<number> {
-  const rows = await getActivityMetadataRows(db, range, actions)
-  return rows.reduce((sum, row) => sum + metadataNumber(row.metadata, 'bytes'), 0)
+async function getSignupTotal(db: Database, reader: AdminStatsHourlyReader): Promise<number> {
+  const [rollupRows, rawRows] = await Promise.all([
+    reader.rows(ADMIN_STATS_METRICS.userSignup),
+    getSignupRowsForIntervals(db, await reader.rawIntervals()),
+  ])
+  return rollupRows.filter((row) => row.dimensionKey === '').reduce((sum, row) => sum + row.count, 0) + rawRows.length
 }
 
-async function getActivityBytesByDay(
+async function getSignupsByDay(
   db: Database,
   range: AdminStatsDateRange,
-  actions: string[],
+  reader: AdminStatsHourlyReader,
 ): Promise<Map<string, number>> {
-  const rows = await getActivityMetadataRows(db, range, actions)
-  const byDay = new Map<string, number>()
-  for (const row of rows)
-    incrementMap(byDay, dayKey(row.createdAt, range.timeZone), metadataNumber(row.metadata, 'bytes'))
-  return byDay
-}
-
-async function getActivityCountByDay(
-  db: Database,
-  range: AdminStatsDateRange,
-  actions: string[],
-): Promise<Map<string, number>> {
-  const rows = await getActivityMetadataRows(db, range, actions)
-  const byDay = new Map<string, number>()
-  for (const row of rows) incrementMap(byDay, dayKey(row.createdAt, range.timeZone), 1)
-  return byDay
-}
-
-async function getActivitySourceCounts(
-  db: Database,
-  range: AdminStatsDateRange,
-  actions: string[],
-): Promise<Map<string, number>> {
-  const rows = await getActivityMetadataRows(db, range, actions)
-  const counts = new Map<string, number>()
-  for (const row of rows) {
-    const metadata = parseMetadata(row.metadata)
-    const source = typeof metadata.source === 'string' ? metadata.source : 'unknown'
-    incrementMap(counts, source, 1)
+  const [rollupRows, rawRows] = await Promise.all([
+    reader.rows(ADMIN_STATS_METRICS.userSignup),
+    getSignupRowsForIntervals(db, await reader.rawIntervals()),
+  ])
+  const result = new Map<string, number>()
+  for (const row of rollupRows) {
+    if (row.dimensionKey === '') incrementMap(result, reader.dayKey(row.bucketStart), row.count)
   }
-  return counts
+  for (const row of rawRows) incrementMap(result, dayKey(row.createdAt, range.timeZone), 1)
+  return result
 }
 
-async function countActivityEvents(db: Database, range: AdminStatsDateRange, actions: string[]): Promise<number> {
-  if (actions.length === 0) return 0
-  return countRowsWhere(
-    db,
-    activityEvents,
-    and(
-      inArray(activityEvents.action, actions),
-      gte(activityEvents.createdAt, range.from),
-      lte(activityEvents.createdAt, range.to),
-    ),
+async function getSignupRowsForIntervals(
+  db: Database,
+  intervals: StatsInterval[],
+): Promise<Array<{ userId: string; createdAt: Date; provider: string }>> {
+  const rows: Array<{ userId: string; createdAt: Date; provider: string }> = []
+  for (let index = 0; index < intervals.length; index += 40) {
+    const conditions = intervals
+      .slice(index, index + 40)
+      .map((interval) => and(gte(user.createdAt, interval.from), lt(user.createdAt, interval.toExclusive)))
+    if (conditions.length === 0) continue
+    const userRows = await db
+      .select({
+        userId: user.id,
+        createdAt: user.createdAt,
+        provider: account.providerId,
+      })
+      .from(user)
+      .leftJoin(account, eq(account.userId, user.id))
+      .where(or(...conditions))
+      .orderBy(user.id, account.createdAt, account.id)
+    const seen = new Set<string>()
+    for (const row of userRows) {
+      if (seen.has(row.userId)) continue
+      seen.add(row.userId)
+      rows.push({ userId: row.userId, createdAt: row.createdAt, provider: row.provider || 'direct' })
+    }
+  }
+  return rows
+}
+
+type ActivityMetricSpec = {
+  metric: (typeof ADMIN_STATS_METRICS)[keyof typeof ADMIN_STATS_METRICS]
+  actions: string[]
+  dimensionKey?: string
+  dimensionValues?: string[]
+}
+
+function metricSpec(actions: string[]): ActivityMetricSpec {
+  const key = [...actions].sort().join(',')
+  if (key === 'upload_confirm') {
+    return { metric: ADMIN_STATS_METRICS.transferUpload, actions, dimensionKey: 'status', dimensionValues: ['success'] }
+  }
+  if (key === 'upload_cancel,upload_failed') {
+    return {
+      metric: ADMIN_STATS_METRICS.transferUpload,
+      actions,
+      dimensionKey: 'status',
+      dimensionValues: ['canceled', 'failed'],
+    }
+  }
+  if (key === 'upload_cancel,upload_confirm,upload_failed') {
+    return { metric: ADMIN_STATS_METRICS.transferUpload, actions }
+  }
+  if (key === [...DOWNLOAD_ACTIVITY_ACTIONS].sort().join(',')) {
+    return { metric: ADMIN_STATS_METRICS.transferDownloadIssued, actions }
+  }
+  if (key === 'download_failed') return { metric: ADMIN_STATS_METRICS.transferDownloadFailed, actions }
+  if (key === 'share_download') return { metric: ADMIN_STATS_METRICS.shareDownloadIssued, actions }
+  if (key === 'share_password_passed') return { metric: ADMIN_STATS_METRICS.sharePasswordPassed, actions }
+  if (key === 'share_view') return { metric: ADMIN_STATS_METRICS.shareView, actions }
+  if (key === 'save_from_share') return { metric: ADMIN_STATS_METRICS.shareSaved, actions }
+  throw new Error(`Unsupported hourly activity metric: ${key}`)
+}
+
+type OperationalSource = 'background_job' | 'remote_download'
+
+async function getOperationalOutcomes(
+  db: Database,
+  reader: AdminStatsHourlyReader,
+  source: OperationalSource,
+): Promise<Map<string, number>> {
+  const metric =
+    source === 'background_job'
+      ? ADMIN_STATS_METRICS.backgroundJobFinished
+      : ADMIN_STATS_METRICS.remoteDownloadTaskFinished
+  const [rollup, raw] = await Promise.all([
+    getActivityMetricDimensionTotalsFromRollup(reader, metric, 'outcome', 'count'),
+    getOperationalRowsForIntervals(db, await reader.rawIntervals(), source),
+  ])
+  for (const row of raw) incrementMap(rollup, row.outcome, 1)
+  return rollup
+}
+
+async function getOperationalOutcomesByDay(
+  db: Database,
+  reader: AdminStatsHourlyReader,
+  range: AdminStatsDateRange,
+  source: OperationalSource,
+): Promise<Map<string, Map<string, number>>> {
+  const metric =
+    source === 'background_job'
+      ? ADMIN_STATS_METRICS.backgroundJobFinished
+      : ADMIN_STATS_METRICS.remoteDownloadTaskFinished
+  const [rollupRows, rawRows] = await Promise.all([
+    reader.rows(metric),
+    getOperationalRowsForIntervals(db, await reader.rawIntervals(), source),
+  ])
+  const result = new Map<string, Map<string, number>>()
+  for (const row of rollupRows) {
+    if (row.dimensionKey !== 'outcome') continue
+    incrementNestedMap(result, reader.dayKey(row.bucketStart), row.dimensionValue, row.count)
+  }
+  for (const row of rawRows) incrementNestedMap(result, dayKey(row.finishedAt, range.timeZone), row.outcome, 1)
+  return result
+}
+
+async function getOperationalRowsForIntervals(
+  db: Database,
+  intervals: StatsInterval[],
+  source: OperationalSource,
+): Promise<Array<{ outcome: string; finishedAt: Date }>> {
+  const rows: Array<{ outcome: string; finishedAt: Date }> = []
+  for (let index = 0; index < intervals.length; index += 40) {
+    const chunk = intervals.slice(index, index + 40)
+    if (source === 'background_job') {
+      const conditions = chunk.map((interval) =>
+        and(gte(backgroundJobs.finishedAt, interval.from), lt(backgroundJobs.finishedAt, interval.toExclusive)),
+      )
+      rows.push(
+        ...(
+          await db
+            .select({ outcome: backgroundJobs.status, finishedAt: backgroundJobs.finishedAt })
+            .from(backgroundJobs)
+            .where(and(sql`${backgroundJobs.finishedAt} IS NOT NULL`, or(...conditions)))
+        ).flatMap((row) => (row.finishedAt ? [{ outcome: row.outcome, finishedAt: row.finishedAt }] : [])),
+      )
+      continue
+    }
+    const conditions = chunk.map((interval) =>
+      and(gte(downloadTasks.finishedAt, interval.from), lt(downloadTasks.finishedAt, interval.toExclusive)),
+    )
+    rows.push(
+      ...(
+        await db
+          .select({ outcome: downloadTasks.status, finishedAt: downloadTasks.finishedAt })
+          .from(downloadTasks)
+          .where(and(sql`${downloadTasks.finishedAt} IS NOT NULL`, or(...conditions)))
+      ).flatMap((row) => (row.finishedAt ? [{ outcome: row.outcome, finishedAt: row.finishedAt }] : [])),
+    )
+  }
+  return rows
+}
+
+async function getActivityMetricDimensionTotalsFromRollup(
+  reader: AdminStatsHourlyReader,
+  metric: (typeof ADMIN_STATS_METRICS)[keyof typeof ADMIN_STATS_METRICS],
+  dimensionKey: string,
+  field: 'count' | 'bytes',
+): Promise<Map<string, number>> {
+  const rows = await reader.rows(metric)
+  const result = new Map<string, number>()
+  for (const row of rows) {
+    if (row.dimensionKey === dimensionKey) incrementMap(result, row.dimensionValue, row[field])
+  }
+  return result
+}
+
+async function getCloudReportOutcomes(db: Database, reader: AdminStatsHourlyReader): Promise<Map<string, number>> {
+  const [result, intervals] = await Promise.all([
+    getActivityMetricDimensionTotalsFromRollup(reader, ADMIN_STATS_METRICS.trafficReportSync, 'status', 'count'),
+    reader.rawIntervals(),
+  ])
+  for (let index = 0; index < intervals.length; index += 40) {
+    const conditions = intervals
+      .slice(index, index + 40)
+      .map((interval) =>
+        and(gte(cloudTrafficReports.updatedAt, interval.from), lt(cloudTrafficReports.updatedAt, interval.toExclusive)),
+      )
+    const rows = await db
+      .select({ status: cloudTrafficReports.status, value: count() })
+      .from(cloudTrafficReports)
+      .where(or(...conditions))
+      .groupBy(cloudTrafficReports.status)
+    for (const row of rows) incrementMap(result, row.status, toNumber(row.value))
+  }
+  return result
+}
+
+async function getActivityMetricTotal(
+  db: Database,
+  reader: AdminStatsHourlyReader,
+  spec: ActivityMetricSpec,
+  field: 'count' | 'bytes',
+): Promise<number> {
+  const [rollupRows, rawRows] = await Promise.all([
+    reader.rows(spec.metric),
+    getActivityRowsForIntervals(db, spec.actions, await reader.rawIntervals()),
+  ])
+  const rollupTotal = filterMetricRows(rollupRows, spec).reduce((sum, row) => sum + row[field], 0)
+  const rawTotal = rawRows.reduce(
+    (sum, row) => sum + (field === 'count' ? 1 : metadataNumber(row.metadata, 'bytes')),
+    0,
+  )
+  return rollupTotal + rawTotal
+}
+
+async function getActivityMetricByDay(
+  db: Database,
+  range: AdminStatsDateRange,
+  reader: AdminStatsHourlyReader,
+  spec: ActivityMetricSpec,
+  field: 'count' | 'bytes',
+): Promise<Map<string, number>> {
+  const [rollupRows, rawRows] = await Promise.all([
+    reader.rows(spec.metric),
+    getActivityRowsForIntervals(db, spec.actions, await reader.rawIntervals()),
+  ])
+  const result = new Map<string, number>()
+  for (const row of filterMetricRows(rollupRows, spec)) {
+    incrementMap(result, reader.dayKey(row.bucketStart), row[field])
+  }
+  for (const row of rawRows) {
+    incrementMap(
+      result,
+      dayKey(row.createdAt, range.timeZone),
+      field === 'count' ? 1 : metadataNumber(row.metadata, 'bytes'),
+    )
+  }
+  return result
+}
+
+async function getActivityMetricDimensionTotals(
+  db: Database,
+  reader: AdminStatsHourlyReader,
+  spec: ActivityMetricSpec,
+  dimensionKey: string,
+  field: 'count' | 'bytes',
+): Promise<Map<string, number>> {
+  const [rollupRows, rawRows] = await Promise.all([
+    reader.rows(spec.metric),
+    getActivityRowsForIntervals(db, spec.actions, await reader.rawIntervals()),
+  ])
+  const result = new Map<string, number>()
+  for (const row of rollupRows) {
+    if (row.dimensionKey === dimensionKey) incrementMap(result, row.dimensionValue, row[field])
+  }
+  for (const row of rawRows) {
+    const metadata = parseMetadata(row.metadata)
+    const metadataValue = metadata[dimensionKey]
+    const value =
+      typeof metadataValue === 'string'
+        ? metadataValue
+        : dimensionKey === 'share_id' && row.targetId
+          ? row.targetId
+          : dimensionKey === 'reason' && row.action === 'upload_cancel'
+            ? 'upload_canceled'
+            : dimensionKey === 'reason' && row.action === 'upload_failed'
+              ? 'upload_failed'
+              : dimensionKey === 'source' && row.action === 'object_download'
+                ? 'object_download'
+                : dimensionKey === 'source' && row.action === 'image_hosting_download'
+                  ? 'image_hosting'
+                  : dimensionKey === 'source' && row.action === 'webdav_download'
+                    ? 'webdav_download'
+                    : dimensionKey === 'source' && row.action === 'share_download'
+                      ? 'landing_share'
+                      : 'unknown'
+    incrementMap(result, value, field === 'count' ? 1 : metadataNumber(row.metadata, 'bytes'))
+  }
+  return result
+}
+
+function filterMetricRows(rows: Awaited<ReturnType<AdminStatsHourlyReader['rows']>>, spec: ActivityMetricSpec) {
+  if (!spec.dimensionKey) return rows.filter((row) => row.dimensionKey === '')
+  const values = new Set(spec.dimensionValues ?? [])
+  return rows.filter(
+    (row) => row.dimensionKey === spec.dimensionKey && (values.size === 0 || values.has(row.dimensionValue)),
   )
 }
 
-async function getActivityMetadataRows(db: Database, range: AdminStatsDateRange, actions: string[]) {
-  if (actions.length === 0) return []
-  return db
-    .select({ action: activityEvents.action, metadata: activityEvents.metadata, createdAt: activityEvents.createdAt })
-    .from(activityEvents)
-    .where(
-      and(
-        inArray(activityEvents.action, actions),
-        gte(activityEvents.createdAt, range.from),
-        lte(activityEvents.createdAt, range.to),
-      ),
+async function getActivityRowsForIntervals(
+  db: Database,
+  actions: string[],
+  intervals: StatsInterval[],
+): Promise<Array<{ action: string; metadata: string | null; createdAt: Date; targetId: string | null }>> {
+  const rows: Array<{ action: string; metadata: string | null; createdAt: Date; targetId: string | null }> = []
+  for (let index = 0; index < intervals.length; index += 40) {
+    const conditions = intervals
+      .slice(index, index + 40)
+      .map((interval) =>
+        and(gte(activityEvents.createdAt, interval.from), lt(activityEvents.createdAt, interval.toExclusive)),
+      )
+    if (conditions.length === 0) continue
+    rows.push(
+      ...(await db
+        .select({
+          action: activityEvents.action,
+          metadata: activityEvents.metadata,
+          createdAt: activityEvents.createdAt,
+          targetId: activityEvents.targetId,
+        })
+        .from(activityEvents)
+        .where(and(inArray(activityEvents.action, actions), or(...conditions)))),
     )
+  }
+  return rows
 }
 
-async function getTransferDataQuality(db: Database, range: AdminStatsDateRange): Promise<AdminTransferDataQuality> {
+async function getTransferDataQuality(
+  db: Database,
+  range: AdminStatsDateRange,
+  now: Date,
+): Promise<AdminTransferDataQuality> {
   const previous = previousRange(range)
-  const actions = ['upload_confirm', ...DOWNLOAD_ACTIVITY_ACTIONS]
-  const [currentRows, previousRows] = await Promise.all([
-    getActivityMetadataRows(db, range, actions),
-    getActivityMetadataRows(db, previous, actions),
+  const [current, previousCounts] = await Promise.all([
+    getMissingTransferBytes(db, new AdminStatsHourlyReader(db, range, now)),
+    getMissingTransferBytes(db, new AdminStatsHourlyReader(db, previous, now)),
   ])
-  const current = missingTransferBytes(currentRows)
-  const previousCounts = missingTransferBytes(previousRows)
   return {
     missingUploadBytesEvents: current.upload,
     previousMissingUploadBytesEvents: previousCounts.upload,
     missingDownloadBytesEvents: current.download,
     previousMissingDownloadBytesEvents: previousCounts.download,
   }
+}
+
+async function getMissingTransferBytes(
+  db: Database,
+  reader: AdminStatsHourlyReader,
+): Promise<{ upload: number; download: number }> {
+  const [rollupRows, rawRows] = await Promise.all([
+    reader.rows(ADMIN_STATS_METRICS.statsMissingBytes),
+    getActivityRowsForIntervals(db, ['upload_confirm', ...DOWNLOAD_ACTIVITY_ACTIONS], await reader.rawIntervals()),
+  ])
+  const result = missingTransferBytes(rawRows)
+  for (const row of rollupRows) {
+    if (row.dimensionKey !== 'direction') continue
+    if (row.dimensionValue === 'upload') result.upload += row.count
+    if (row.dimensionValue === 'download') result.download += row.count
+  }
+  return result
 }
 
 function missingTransferBytes(rows: Array<{ action: string; metadata: string | null }>): {
@@ -797,158 +1128,72 @@ async function getStorageUsedByDay(db: Database, range: AdminStatsDateRange): Pr
   const lastBucketStart = dateKeyStart(buckets[buckets.length - 1])
   const rows = await db
     .select({
-      bucketStart: statsRollupsDaily.bucketStart,
-      bytes: statsRollupsDaily.bytes,
+      bucketStart: statsRollupsHourly.bucketStart,
+      orgId: statsRollupsHourly.orgId,
+      bytes: statsRollupsHourly.bytes,
     })
-    .from(statsRollupsDaily)
+    .from(statsRollupsHourly)
     .where(
       and(
-        eq(statsRollupsDaily.metricKey, STORAGE_USED_ROLLUP_METRIC),
-        eq(statsRollupsDaily.orgId, GLOBAL_ROLLUP_ORG_ID),
-        eq(statsRollupsDaily.dimensionKey, GLOBAL_ROLLUP_DIMENSION_KEY),
-        eq(statsRollupsDaily.dimensionValue, GLOBAL_ROLLUP_DIMENSION_VALUE),
-        gte(statsRollupsDaily.bucketStart, daysAgo(firstBucketStart, 1)),
-        lte(statsRollupsDaily.bucketStart, daysAgo(lastBucketStart, -1)),
+        eq(statsRollupsHourly.metricKey, STORAGE_USED_ROLLUP_METRIC),
+        eq(statsRollupsHourly.dimensionKey, GLOBAL_ROLLUP_DIMENSION_KEY),
+        eq(statsRollupsHourly.dimensionValue, GLOBAL_ROLLUP_DIMENSION_VALUE),
+        gte(statsRollupsHourly.bucketStart, daysAgo(firstBucketStart, 1)),
+        lte(statsRollupsHourly.bucketStart, daysAgo(lastBucketStart, -1)),
       ),
     )
 
-  const byDay = new Map(rows.map((row) => [dayKey(row.bucketStart), toNumber(row.bytes)]))
-  return byDay
-}
-
-async function getCloudTrafficRows(db: Database, range: AdminStatsDateRange) {
-  return db
-    .select({
-      source: cloudTrafficReports.source,
-      eventId: cloudTrafficReports.eventId,
-      bytes: cloudTrafficReports.bytes,
-      status: cloudTrafficReports.status,
-      createdAt: cloudTrafficReports.createdAt,
-    })
-    .from(cloudTrafficReports)
-    .where(and(gte(cloudTrafficReports.createdAt, range.from), lte(cloudTrafficReports.createdAt, range.to)))
-}
-
-async function getDownloadIssueRows(
-  db: Database,
-  range: AdminStatsDateRange,
-): Promise<Array<{ source: string; bytes: number; trafficEventId: string | null; createdAt: Date }>> {
-  const rows = await getActivityMetadataRows(db, range, DOWNLOAD_ACTIVITY_ACTIONS)
-  return rows.map((row) => {
-    const metadata = parseMetadata(row.metadata)
-    return {
-      source:
-        typeof metadata.source === 'string'
-          ? metadata.source
-          : row.action === 'object_download'
-            ? 'object_download'
-            : 'landing_share',
-      bytes: toNumber(metadata.bytes),
-      trafficEventId: typeof metadata.trafficEventId === 'string' ? metadata.trafficEventId : null,
-      createdAt: row.createdAt,
-    }
-  })
-}
-
-async function getDownloadFailureRows(
-  db: Database,
-  range: AdminStatsDateRange,
-): Promise<Array<{ reason: string; trafficEventId: string | null; createdAt: Date }>> {
-  const rows = await getActivityMetadataRows(db, range, [DOWNLOAD_FAILURE_ACTION])
-  return rows.map((row) => {
-    const metadata = parseMetadata(row.metadata)
-    return {
-      reason: typeof metadata.reason === 'string' ? metadata.reason : 'unknown',
-      trafficEventId: typeof metadata.trafficEventId === 'string' ? metadata.trafficEventId : null,
-      createdAt: row.createdAt,
-    }
-  })
-}
-
-async function getActivityFailureRows(
-  db: Database,
-  range: AdminStatsDateRange,
-  actions: string[],
-): Promise<Array<{ reason: string; createdAt: Date }>> {
-  const rows = await getActivityMetadataRows(db, range, actions)
-  return rows.map((row) => {
-    const metadata = parseMetadata(row.metadata)
-    return {
-      reason:
-        typeof metadata.reason === 'string'
-          ? metadata.reason
-          : row.action === 'upload_cancel'
-            ? 'upload_canceled'
-            : 'upload_failed',
-      createdAt: row.createdAt,
-    }
-  })
-}
-
-async function getDownloadBytesByDay(db: Database, range: AdminStatsDateRange): Promise<Map<string, number>> {
-  const [activityRows, cloudRows] = await Promise.all([getDownloadIssueRows(db, range), getCloudTrafficRows(db, range)])
-  const byDay = new Map<string, number>()
-  for (const row of activityRows) incrementMap(byDay, dayKey(row.createdAt, range.timeZone), row.bytes)
-  for (const row of cloudRows) {
-    if (isCloudRowCovered(row, activityRows, []) || row.status === 'blocked') continue
-    incrementMap(byDay, dayKey(row.createdAt, range.timeZone), row.bytes)
+  const byBucket = new Map<number, number>()
+  for (const row of rows) {
+    const at = row.bucketStart.getTime()
+    byBucket.set(at, (byBucket.get(at) ?? 0) + toNumber(row.bytes))
   }
-  return byDay
+  const byDay = new Map<string, { at: number; bytes: number }>()
+  for (const [at, bytes] of byBucket) {
+    const date = dayKey(new Date(at), range.timeZone)
+    const current = byDay.get(date)
+    if (!current || at > current.at) byDay.set(date, { at, bytes })
+  }
+  return new Map([...byDay].map(([date, value]) => [date, value.bytes]))
 }
 
-async function getDownloadRequestsByDay(db: Database, range: AdminStatsDateRange): Promise<Map<string, number>> {
-  const [activityRows, failureRows, cloudRows] = await Promise.all([
-    getDownloadIssueRows(db, range),
-    getDownloadFailureRows(db, range),
-    getCloudTrafficRows(db, range),
+async function getDownloadRequestsByDay(
+  db: Database,
+  range: AdminStatsDateRange,
+  reader: AdminStatsHourlyReader,
+): Promise<Map<string, number>> {
+  const [issued, failed] = await Promise.all([
+    getActivityMetricByDay(db, range, reader, metricSpec(DOWNLOAD_ACTIVITY_ACTIONS), 'count'),
+    getActivityMetricByDay(db, range, reader, metricSpec([DOWNLOAD_FAILURE_ACTION]), 'count'),
   ])
-  const byDay = new Map<string, number>()
-  for (const row of activityRows) incrementMap(byDay, dayKey(row.createdAt, range.timeZone), 1)
-  for (const row of failureRows) incrementMap(byDay, dayKey(row.createdAt, range.timeZone), 1)
-  for (const row of cloudRows) {
-    if (isCloudRowCovered(row, activityRows, failureRows)) continue
-    incrementMap(byDay, dayKey(row.createdAt, range.timeZone), 1)
-  }
-  return byDay
+  const result = new Map(issued)
+  for (const [date, value] of failed) incrementMap(result, date, value)
+  return result
 }
 
 async function getTrafficTotals(
   db: Database,
-  range: AdminStatsDateRange,
+  reader: AdminStatsHourlyReader,
 ): Promise<{ uploadBytes: number; uploadRequests: number; downloadBytes: number; downloadRequests: number }> {
-  const [uploadBytes, uploadRequests, activityDownloadRows, activityFailureRows, cloudRows] = await Promise.all([
-    getActivityBytesTotal(db, range, ['upload_confirm']),
-    countActivityEvents(db, range, ['upload_confirm', 'upload_cancel', 'upload_failed']),
-    getDownloadIssueRows(db, range),
-    getDownloadFailureRows(db, range),
-    getCloudTrafficRows(db, range),
+  const [uploadBytes, uploadRequests, downloadBytes, issuedDownloads, failedDownloads] = await Promise.all([
+    getActivityMetricTotal(db, reader, metricSpec(['upload_confirm']), 'bytes'),
+    getActivityMetricTotal(db, reader, metricSpec(['upload_confirm', 'upload_cancel', 'upload_failed']), 'count'),
+    getActivityMetricTotal(db, reader, metricSpec(DOWNLOAD_ACTIVITY_ACTIONS), 'bytes'),
+    getActivityMetricTotal(db, reader, metricSpec(DOWNLOAD_ACTIVITY_ACTIONS), 'count'),
+    getActivityMetricTotal(db, reader, metricSpec([DOWNLOAD_FAILURE_ACTION]), 'count'),
   ])
-  const uncoveredCloudRows = cloudRows.filter(
-    (row) => !isCloudRowCovered(row, activityDownloadRows, activityFailureRows),
-  )
-  const cloudDownloadRows = uncoveredCloudRows.filter((row) => row.status !== 'blocked')
   return {
     uploadBytes,
     uploadRequests,
-    downloadBytes:
-      activityDownloadRows.reduce((sum, row) => sum + row.bytes, 0) +
-      cloudDownloadRows.reduce((sum, row) => sum + row.bytes, 0),
-    downloadRequests: activityDownloadRows.length + activityFailureRows.length + uncoveredCloudRows.length,
+    downloadBytes,
+    downloadRequests: issuedDownloads + failedDownloads,
   }
-}
-
-function isCloudRowCovered(
-  cloudRow: { source: string; eventId: string },
-  issuedRows: Array<{ trafficEventId: string | null }>,
-  failureRows: Array<{ trafficEventId: string | null }>,
-): boolean {
-  return [...issuedRows, ...failureRows].some((row) => row.trafficEventId === cloudRow.eventId)
 }
 
 async function getSharingEventTotals(
   db: Database,
-  range: AdminStatsDateRange,
   now: Date,
+  reader: AdminStatsHourlyReader,
 ): Promise<{ activeShares: number; views: number; passwordPasses: number; downloads: number }> {
   const [activeShares, views, passwordPasses, downloads] = await Promise.all([
     countRowsWhere(
@@ -960,24 +1205,24 @@ async function getSharingEventTotals(
         or(isNull(shares.downloadLimit), sql`${shares.downloads} < ${shares.downloadLimit}`),
       ),
     ),
-    countActivityEvents(db, range, ['share_view']),
-    countActivityEvents(db, range, ['share_password_passed']),
-    countActivityEvents(db, range, ['share_download']),
+    getActivityMetricTotal(db, reader, metricSpec(['share_view']), 'count'),
+    getActivityMetricTotal(db, reader, metricSpec(['share_password_passed']), 'count'),
+    getActivityMetricTotal(db, reader, metricSpec(['share_download']), 'count'),
   ])
   return { activeShares, views, passwordPasses, downloads }
 }
 
 async function getTopSharesWithPercent(
   db: Database,
-  range: AdminStatsDateRange,
+  reader: AdminStatsHourlyReader,
   totals?: { totalViews: number; totalDownloads: number },
 ): Promise<Array<AdminTopShare & { viewPercent: number; downloadPercent: number }>> {
-  const rows = await getTopSharesByActivity(db, range)
+  const rows = await getTopSharesByActivity(db, reader)
   const [totalViews, totalDownloads] = totals
     ? [totals.totalViews, totals.totalDownloads]
     : await Promise.all([
-        countActivityEvents(db, range, ['share_view']),
-        countActivityEvents(db, range, ['share_download']),
+        getActivityMetricTotal(db, reader, metricSpec(['share_view']), 'count'),
+        getActivityMetricTotal(db, reader, metricSpec(['share_download']), 'count'),
       ])
   return rows.map((row) => ({
     ...row,
@@ -986,24 +1231,17 @@ async function getTopSharesWithPercent(
   }))
 }
 
-async function getTopSharesByActivity(db: Database, range: AdminStatsDateRange): Promise<AdminTopShare[]> {
-  const activityRows = await db
-    .select({ targetId: activityEvents.targetId, action: activityEvents.action })
-    .from(activityEvents)
-    .where(
-      and(
-        inArray(activityEvents.action, ['share_view', 'share_download']),
-        gte(activityEvents.createdAt, range.from),
-        lte(activityEvents.createdAt, range.to),
-      ),
-    )
+async function getTopSharesByActivity(db: Database, reader: AdminStatsHourlyReader): Promise<AdminTopShare[]> {
+  const [viewCounts, downloadCounts] = await Promise.all([
+    getActivityMetricDimensionTotals(db, reader, metricSpec(['share_view']), 'share_id', 'count'),
+    getActivityMetricDimensionTotals(db, reader, metricSpec(['share_download']), 'share_id', 'count'),
+  ])
   const counts = new Map<string, { views: number; downloads: number }>()
-  for (const row of activityRows) {
-    if (!row.targetId) continue
-    const item = counts.get(row.targetId) ?? { views: 0, downloads: 0 }
-    if (row.action === 'share_view') item.views += 1
-    if (row.action === 'share_download') item.downloads += 1
-    counts.set(row.targetId, item)
+  for (const [shareId, views] of viewCounts) counts.set(shareId, { views, downloads: 0 })
+  for (const [shareId, downloads] of downloadCounts) {
+    const item = counts.get(shareId) ?? { views: 0, downloads: 0 }
+    item.downloads = downloads
+    counts.set(shareId, item)
   }
   const topIds = [...counts.entries()]
     .sort((a, b) => b[1].views - a[1].views || b[1].downloads - a[1].downloads)
@@ -1043,11 +1281,7 @@ async function getTopSharesByActivity(db: Database, range: AdminStatsDateRange):
   })
 }
 
-async function getUsageBySpaceRows(
-  db: Database,
-  range?: AdminStatsDateRange,
-): Promise<AdminDashboardRankingStats['topSpaces']> {
-  if (range) return getUsageBySpaceRowsForRange(db, range)
+async function getUsageBySpaceRows(db: Database): Promise<AdminDashboardStorageStats['topSpaces']> {
   const rows = await db
     .select({
       orgId: orgQuotas.orgId,
@@ -1060,7 +1294,6 @@ async function getUsageBySpaceRows(
     .from(orgQuotas)
     .leftJoin(organization, eq(organization.id, orgQuotas.orgId))
     .orderBy(desc(orgQuotas.used))
-    .limit(8)
   return rows.map((row) => ({
     orgId: row.orgId,
     orgName: row.orgName ?? row.orgId,
@@ -1069,48 +1302,6 @@ async function getUsageBySpaceRows(
     quotaBytes: row.quotaBytes,
     utilization: percent(row.usedBytes, row.quotaBytes),
   }))
-}
-
-async function getUsageBySpaceRowsForRange(
-  db: Database,
-  range: AdminStatsDateRange,
-): Promise<AdminDashboardRankingStats['topSpaces']> {
-  const rows = await db
-    .select({
-      orgId: matters.orgId,
-      usedBytes: sql<number>`COALESCE(SUM(${matters.size}), 0)`,
-      quotaBytes: orgQuotas.quota,
-      orgName: organization.name,
-      slug: organization.slug,
-      metadata: organization.metadata,
-    })
-    .from(matters)
-    .leftJoin(orgQuotas, eq(orgQuotas.orgId, matters.orgId))
-    .leftJoin(organization, eq(organization.id, matters.orgId))
-    .where(
-      and(
-        eq(matters.status, 'active'),
-        eq(matters.dirtype, 0),
-        gte(matters.createdAt, range.from),
-        lte(matters.createdAt, range.to),
-      ),
-    )
-    .groupBy(matters.orgId, orgQuotas.quota, organization.name, organization.slug, organization.metadata)
-    .orderBy(desc(sql`COALESCE(SUM(${matters.size}), 0)`))
-    .limit(8)
-
-  return rows.map((row) => {
-    const usedBytes = toNumber(row.usedBytes)
-    const quotaBytes = toNumber(row.quotaBytes)
-    return {
-      orgId: row.orgId,
-      orgName: row.orgName ?? row.orgId,
-      orgType: isPersonalOrgLike({ slug: row.slug ?? '', metadata: row.metadata ?? null }) ? 'personal' : 'team',
-      usedBytes,
-      quotaBytes,
-      utilization: percent(usedBytes, quotaBytes),
-    }
-  })
 }
 
 function percentRows<T extends { name: string }>(
@@ -1122,14 +1313,6 @@ function percentRows<T extends { name: string }>(
     const value = getValue(row)
     return { ...row, value, percent: percent(value, total) }
   })
-}
-
-function funnelRows<T extends { name: string; value: number }>(rows: T[]): Array<T & { percent: number }> {
-  const baseline = rows[0]?.value ?? 0
-  return rows.map((row, index) => ({
-    ...row,
-    percent: index === 0 ? (baseline > 0 ? 100 : 0) : percent(row.value, baseline),
-  }))
 }
 
 function isShareActive(
@@ -1200,6 +1383,17 @@ function incrementMap(map: Map<string, number>, key: string, value: number): voi
   map.set(key, (map.get(key) ?? 0) + value)
 }
 
+function incrementNestedMap(
+  map: Map<string, Map<string, number>>,
+  outerKey: string,
+  innerKey: string,
+  value: number,
+): void {
+  const inner = map.get(outerKey) ?? new Map<string, number>()
+  incrementMap(inner, innerKey, value)
+  map.set(outerKey, inner)
+}
+
 function addSetMap(map: Map<string, Set<string>>, key: string, value: string): void {
   const set = map.get(key) ?? new Set<string>()
   set.add(value)
@@ -1238,23 +1432,12 @@ function daysAgo(now: Date, days: number): Date {
   return date
 }
 
-function startOfDay(date: Date): Date {
-  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
+function startOfHour(date: Date): Date {
+  return new Date(Math.floor(date.getTime() / 3_600_000) * 3_600_000)
 }
 
 function dateKeyStart(date: string): Date {
   return new Date(`${date}T00:00:00.000Z`)
-}
-
-function dayKey(date: Date, timeZone = 'UTC'): string {
-  const parts = new Intl.DateTimeFormat('en-CA', {
-    timeZone,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).formatToParts(date)
-  const values = new Map(parts.map((part) => [part.type, part.value]))
-  return `${values.get('year')}-${values.get('month')}-${values.get('day')}`
 }
 
 function percent(part: number, total: number): number {

--- a/server/adapters/repos/admin-stats.ts
+++ b/server/adapters/repos/admin-stats.ts
@@ -809,7 +809,7 @@ type ActivityMetricSpec = {
   dimensionValues?: string[]
 }
 
-function metricSpec(actions: string[]): ActivityMetricSpec {
+export function metricSpec(actions: string[]): ActivityMetricSpec {
   const key = [...actions].sort().join(',')
   if (key === 'upload_confirm') {
     return { metric: ADMIN_STATS_METRICS.transferUpload, actions, dimensionKey: 'status', dimensionValues: ['success'] }

--- a/server/db/auth-schema.ts
+++ b/server/db/auth-schema.ts
@@ -1,26 +1,30 @@
 import { relations, sql } from 'drizzle-orm'
 import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
-export const user = sqliteTable('user', {
-  id: text('id').primaryKey(),
-  name: text('name').notNull(),
-  email: text('email').notNull().unique(),
-  emailVerified: integer('email_verified', { mode: 'boolean' }).default(false).notNull(),
-  image: text('image'),
-  role: text('role'),
-  banned: integer('banned', { mode: 'boolean' }).default(false),
-  banReason: text('ban_reason'),
-  banExpires: integer('ban_expires', { mode: 'timestamp_ms' }),
-  username: text('username').unique(),
-  displayUsername: text('display_username'),
-  createdAt: integer('created_at', { mode: 'timestamp_ms' })
-    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
-    .notNull(),
-  updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
-    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
-    .$onUpdate(() => /* @__PURE__ */ new Date())
-    .notNull(),
-})
+export const user = sqliteTable(
+  'user',
+  {
+    id: text('id').primaryKey(),
+    name: text('name').notNull(),
+    email: text('email').notNull().unique(),
+    emailVerified: integer('email_verified', { mode: 'boolean' }).default(false).notNull(),
+    image: text('image'),
+    role: text('role'),
+    banned: integer('banned', { mode: 'boolean' }).default(false),
+    banReason: text('ban_reason'),
+    banExpires: integer('ban_expires', { mode: 'timestamp_ms' }),
+    username: text('username').unique(),
+    displayUsername: text('display_username'),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+    updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [index('user_created_idx').on(table.createdAt)],
+)
 
 export const session = sqliteTable(
   'session',
@@ -42,7 +46,7 @@ export const session = sqliteTable(
     impersonatedBy: text('impersonated_by'),
     activeOrganizationId: text('active_organization_id'),
   },
-  (table) => [index('session_userId_idx').on(table.userId)],
+  (table) => [index('session_userId_idx').on(table.userId), index('session_created_idx').on(table.createdAt)],
 )
 
 export const account = sqliteTable(

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -2,22 +2,26 @@ import { sql } from 'drizzle-orm'
 import { index, integer, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core'
 import { organization } from './auth-schema'
 
-export const matters = sqliteTable('matters', {
-  id: text('id').primaryKey(),
-  orgId: text('org_id').notNull(),
-  alias: text('alias').notNull().unique(),
-  name: text('name').notNull(),
-  type: text('type').notNull(),
-  size: integer('size').default(0),
-  dirtype: integer('dirtype').default(0),
-  parent: text('parent').notNull().default(''),
-  object: text('object').notNull().default(''),
-  storageId: text('storage_id').notNull(),
-  status: text('status').notNull().default('draft'), // draft, active
-  trashedAt: integer('trashed_at'), // null = live, epoch ms = in trash (soft delete)
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
-})
+export const matters = sqliteTable(
+  'matters',
+  {
+    id: text('id').primaryKey(),
+    orgId: text('org_id').notNull(),
+    alias: text('alias').notNull().unique(),
+    name: text('name').notNull(),
+    type: text('type').notNull(),
+    size: integer('size').default(0),
+    dirtype: integer('dirtype').default(0),
+    parent: text('parent').notNull().default(''),
+    object: text('object').notNull().default(''),
+    storageId: text('storage_id').notNull(),
+    status: text('status').notNull().default('draft'), // draft, active
+    trashedAt: integer('trashed_at'), // null = live, epoch ms = in trash (soft delete)
+    createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+    updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
+  },
+  (t) => [index('matters_status_dir_created_idx').on(t.status, t.dirtype, t.createdAt)],
+)
 
 export const webdavDeadProperties = sqliteTable(
   'webdav_dead_properties',
@@ -108,6 +112,7 @@ export const cloudTrafficReports = sqliteTable(
     uniqueIndex('cloud_traffic_reports_event_uniq').on(t.eventId),
     index('cloud_traffic_reports_org_period_idx').on(t.orgId, t.period),
     index('cloud_traffic_reports_status_idx').on(t.status),
+    index('cloud_traffic_reports_updated_idx').on(t.updatedAt),
   ],
 )
 
@@ -156,6 +161,7 @@ export const webhookEvents = sqliteTable(
     uniqueIndex('webhook_events_source_event_uniq').on(t.source, t.eventId),
     index('webhook_events_source_created_idx').on(t.source, t.createdAt),
     index('webhook_events_status_idx').on(t.status),
+    index('webhook_events_processed_idx').on(t.processedAt),
   ],
 )
 
@@ -284,6 +290,7 @@ export const backgroundJobs = sqliteTable(
     index('background_jobs_org_created_idx').on(t.orgId, t.createdAt),
     index('background_jobs_org_status_idx').on(t.orgId, t.status),
     index('background_jobs_org_type_idx').on(t.orgId, t.type),
+    index('background_jobs_created_idx').on(t.createdAt),
   ],
 )
 
@@ -368,6 +375,8 @@ export const downloadTasks = sqliteTable(
     index('download_tasks_org_category_idx').on(t.orgId, t.category),
     index('download_tasks_org_tags_idx').on(t.orgId, t.tags),
     index('download_tasks_downloader_idx').on(t.assignedDownloaderId, t.status),
+    index('download_tasks_created_idx').on(t.createdAt),
+    index('download_tasks_finished_idx').on(t.finishedAt),
   ],
 )
 
@@ -414,6 +423,7 @@ export const remoteDownloadUsageReports = sqliteTable(
     uniqueIndex('remote_download_usage_task_unit_uniq').on(t.taskId, t.unitIndex),
     index('remote_download_usage_org_idx').on(t.orgId),
     index('remote_download_usage_status_idx').on(t.status),
+    index('remote_download_usage_created_idx').on(t.createdAt),
   ],
 )
 
@@ -457,11 +467,12 @@ export const activityEvents = sqliteTable(
     index('activity_events_user_created_idx').on(t.userId, t.createdAt),
     index('activity_events_action_created_idx').on(t.action, t.createdAt),
     index('activity_events_target_created_idx').on(t.targetType, t.targetId, t.createdAt),
+    index('activity_events_created_idx').on(t.createdAt),
   ],
 )
 
-export const statsRollupsDaily = sqliteTable(
-  'stats_rollups_daily',
+export const statsRollupsHourly = sqliteTable(
+  'stats_rollups_hourly',
   {
     id: text('id').primaryKey(),
     bucketStart: integer('bucket_start', { mode: 'timestamp_ms' }).notNull(),
@@ -476,14 +487,15 @@ export const statsRollupsDaily = sqliteTable(
     updatedAt: integer('updated_at', { mode: 'timestamp_ms' }).notNull(),
   },
   (t) => [
-    uniqueIndex('stats_rollups_daily_bucket_metric_dim_uniq').on(
+    uniqueIndex('stats_rollups_hourly_bucket_metric_dim_uniq').on(
       t.bucketStart,
       t.orgId,
       t.metricKey,
       t.dimensionKey,
       t.dimensionValue,
     ),
-    index('stats_rollups_daily_metric_bucket_idx').on(t.metricKey, t.bucketStart),
+    index('stats_rollups_hourly_metric_bucket_idx').on(t.metricKey, t.bucketStart),
+    index('stats_rollups_hourly_dimension_bucket_idx').on(t.metricKey, t.dimensionKey, t.bucketStart),
   ],
 )
 
@@ -504,7 +516,10 @@ export const shares = sqliteTable(
     status: text('status').notNull().default('active'), // 'active' | 'revoked'
     createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
   },
-  (t) => [index('shares_creator_status_created_idx').on(t.creatorId, t.status, t.createdAt)],
+  (t) => [
+    index('shares_creator_status_created_idx').on(t.creatorId, t.status, t.createdAt),
+    index('shares_created_idx').on(t.createdAt),
+  ],
 )
 
 export const shareRecipients = sqliteTable(

--- a/server/domain/admin-stats-metrics.ts
+++ b/server/domain/admin-stats-metrics.ts
@@ -1,0 +1,151 @@
+export const ROLLUP_VERSION = 1
+
+export type AdminStatsMetricKind = 'counter' | 'gauge' | 'distinct'
+
+export const ADMIN_STATS_DIMENSIONS = {
+  actorType: 'actor_type',
+  ageBucket: 'age_bucket',
+  category: 'category',
+  downloader: 'downloader_id',
+  direction: 'direction',
+  fileType: 'file_type_group',
+  jobType: 'job_type',
+  kind: 'kind',
+  lifecycle: 'lifecycle',
+  orgType: 'org_type',
+  outcome: 'outcome',
+  provider: 'provider',
+  reason: 'reason',
+  routeFamily: 'route_family',
+  share: 'share_id',
+  sizeBucket: 'size_bucket',
+  source: 'source',
+  status: 'status',
+  storage: 'storage_id',
+} as const
+
+export type AdminStatsDimension = (typeof ADMIN_STATS_DIMENSIONS)[keyof typeof ADMIN_STATS_DIMENSIONS]
+
+export const ADMIN_STATS_METRICS = {
+  backgroundJobFinished: 'background_job.finished',
+  backgroundJobSnapshot: 'background_job.snapshot',
+  downloaderSnapshot: 'downloader.snapshot',
+  licenseRefresh: 'license.refresh',
+  remoteDownloadTaskCreated: 'remote_download.task_created',
+  remoteDownloadTaskFinished: 'remote_download.task_finished',
+  remoteDownloadTaskSnapshot: 'remote_download.task_snapshot',
+  remoteDownloadUsage: 'remote_download.usage',
+  shareCreated: 'share.created',
+  shareDownloadIssued: 'share.download_issued',
+  shareInventory: 'share.inventory',
+  sharePasswordPassed: 'share.password_passed',
+  shareSaved: 'share.saved',
+  shareView: 'share.view',
+  spaceCreated: 'space.created',
+  statsMissingBytes: 'stats.quality_missing_bytes',
+  statsRollupRun: 'stats.rollup_run',
+  storageIngress: 'storage.ingress',
+  storageInventory: 'storage.inventory',
+  storageQuota: 'storage.quota',
+  storageRemoved: 'storage.removed',
+  storageRestored: 'storage.restored',
+  storageUsed: 'storage.used',
+  teamMembershipChange: 'team.membership_change',
+  trafficCreditConsumed: 'traffic.credit_consumed',
+  trafficQuota: 'traffic.quota',
+  trafficQuotaBlocked: 'traffic.quota_blocked',
+  trafficQuotaUsed: 'traffic.quota_used',
+  trafficReportSync: 'traffic.report_sync',
+  transferDownloadFailed: 'transfer.download_failed',
+  transferDownloadIssued: 'transfer.download_issued',
+  transferUpload: 'transfer.upload',
+  userActiveHour: 'user.active_hour',
+  userSessionStarted: 'user.session_started',
+  userSignup: 'user.signup',
+  webhookProcessed: 'webhook.processed',
+} as const
+
+export type AdminStatsMetric = (typeof ADMIN_STATS_METRICS)[keyof typeof ADMIN_STATS_METRICS]
+
+export interface AdminStatsMetricDefinition {
+  kind: AdminStatsMetricKind
+  dimensions: readonly AdminStatsDimension[]
+  countUnit: 'events' | 'entities' | 'credits' | null
+  bytesUnit: 'bytes' | null
+}
+
+const D = ADMIN_STATS_DIMENSIONS
+const M = ADMIN_STATS_METRICS
+
+export const ADMIN_STATS_METRIC_REGISTRY = {
+  [M.backgroundJobFinished]: counter(['job_type', 'outcome']),
+  [M.backgroundJobSnapshot]: gauge(['job_type', 'status'], 'entities'),
+  [M.downloaderSnapshot]: gauge(['downloader_id', 'status'], 'entities'),
+  [M.licenseRefresh]: counter(['outcome']),
+  [M.remoteDownloadTaskCreated]: counter(['category', 'source']),
+  [M.remoteDownloadTaskFinished]: counter(['category', 'downloader_id', 'outcome'], true),
+  [M.remoteDownloadTaskSnapshot]: gauge(['downloader_id', 'status'], 'entities'),
+  [M.remoteDownloadUsage]: {
+    kind: 'counter',
+    dimensions: [D.downloader, D.status],
+    countUnit: 'credits',
+    bytesUnit: 'bytes',
+  },
+  [M.shareCreated]: counter(['kind']),
+  [M.shareDownloadIssued]: counter(['actor_type', 'kind', 'share_id', 'source'], true),
+  [M.shareInventory]: gauge(['kind', 'lifecycle'], 'entities'),
+  [M.sharePasswordPassed]: counter(['share_id']),
+  [M.shareSaved]: counter(['actor_type', 'share_id'], true),
+  [M.shareView]: counter(['actor_type', 'share_id']),
+  [M.spaceCreated]: counter(['org_type']),
+  [M.statsMissingBytes]: counter(['direction', 'source']),
+  [M.statsRollupRun]: counter(['outcome']),
+  [M.storageIngress]: counter(['source', 'status', 'storage_id'], true),
+  [M.storageInventory]: gauge(['age_bucket', 'file_type_group', 'size_bucket', 'storage_id'], 'entities', true),
+  [M.storageQuota]: gauge([], null, true),
+  [M.storageRemoved]: counter(['reason'], true),
+  [M.storageRestored]: counter(['source'], true),
+  [M.storageUsed]: gauge(['storage_id'], null, true),
+  [M.teamMembershipChange]: counter(['outcome']),
+  [M.trafficCreditConsumed]: {
+    kind: 'counter',
+    dimensions: [D.source, D.storage],
+    countUnit: 'credits',
+    bytesUnit: 'bytes',
+  },
+  [M.trafficQuota]: gauge([], null, true),
+  [M.trafficQuotaBlocked]: counter(['source'], true),
+  [M.trafficQuotaUsed]: gauge([], null, true),
+  [M.trafficReportSync]: counter(['source', 'status'], true),
+  [M.transferDownloadFailed]: counter(['reason', 'source'], true),
+  [M.transferDownloadIssued]: counter(['actor_type', 'source', 'storage_id'], true),
+  [M.transferUpload]: counter(['reason', 'source', 'status', 'storage_id'], true),
+  [M.userActiveHour]: { kind: 'distinct', dimensions: [], countUnit: 'entities', bytesUnit: null },
+  [M.userSessionStarted]: counter([]),
+  [M.userSignup]: counter(['provider']),
+  [M.webhookProcessed]: counter(['outcome']),
+} satisfies Record<AdminStatsMetric, AdminStatsMetricDefinition>
+
+function counter(dimensions: readonly AdminStatsDimension[], bytes = false): AdminStatsMetricDefinition {
+  return { kind: 'counter', dimensions, countUnit: 'events', bytesUnit: bytes ? 'bytes' : null }
+}
+
+function gauge(
+  dimensions: readonly AdminStatsDimension[],
+  countUnit: AdminStatsMetricDefinition['countUnit'],
+  bytes = false,
+): AdminStatsMetricDefinition {
+  return { kind: 'gauge', dimensions, countUnit, bytesUnit: bytes ? 'bytes' : null }
+}
+
+export function metricDefinition(metric: AdminStatsMetric): AdminStatsMetricDefinition {
+  return ADMIN_STATS_METRIC_REGISTRY[metric]
+}
+
+export function assertMetricDimension(
+  metric: AdminStatsMetric,
+  dimension: string,
+): asserts dimension is AdminStatsDimension | '' {
+  if (dimension === '' || metricDefinition(metric).dimensions.includes(dimension as AdminStatsDimension)) return
+  throw new Error(`Unsupported stats dimension: ${metric}/${dimension}`)
+}

--- a/server/domain/admin-stats-time.ts
+++ b/server/domain/admin-stats-time.ts
@@ -1,0 +1,32 @@
+const HOUR_MS = 3_600_000
+
+export function statsDayKey(date: Date, timeZone = 'UTC'): string {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date)
+  const values = new Map(parts.map((part) => [part.type, part.value]))
+  return `${values.get('year')}-${values.get('month')}-${values.get('day')}`
+}
+
+export function localDateStart(date: string, timeZone: string): Date {
+  const center = Date.parse(`${date}T00:00:00.000Z`)
+  if (!Number.isFinite(center)) throw new Error(`Invalid local date: ${date}`)
+  let low = center - 18 * HOUR_MS
+  let high = center + 18 * HOUR_MS
+  while (low + 1 < high) {
+    const middle = Math.floor((low + high) / 2)
+    if (statsDayKey(new Date(middle), timeZone) < date) low = middle
+    else high = middle
+  }
+  if (statsDayKey(new Date(high), timeZone) !== date) throw new Error(`Local date does not exist: ${date}/${timeZone}`)
+  return new Date(high)
+}
+
+export function addCalendarDays(date: string, days: number): string {
+  const value = new Date(`${date}T00:00:00.000Z`)
+  value.setUTCDate(value.getUTCDate() + days)
+  return value.toISOString().slice(0, 10)
+}

--- a/server/entry-node.ts
+++ b/server/entry-node.ts
@@ -24,7 +24,7 @@ const TRAFFIC_SYNC_INTERVAL_MS = 10 * 60 * 1000 // 10 minutes
 const INSTANCE_TELEMETRY_INTERVAL_MS = 12 * 60 * 60 * 1000 // 12 hours
 const QUOTA_RESET_INTERVAL_MS = 24 * 60 * 60 * 1000 // daily; idempotent, resets only stale periods
 const TRASH_PURGE_INTERVAL_MS = 24 * 60 * 60 * 1000 // daily; purges trash past the retention window
-const STATS_ROLLUP_INTERVAL_MS = 24 * 60 * 60 * 1000 // daily; updates the current UTC storage snapshot
+const STATS_ROLLUP_INTERVAL_MS = 10 * 60 * 1000
 const appVersionGlobalKey = '__ZPAN_APP_VERSION__'
 const appCommitGlobalKey = '__ZPAN_APP_COMMIT__'
 
@@ -153,12 +153,21 @@ function purgeExpiredTrashJob(): void {
 purgeExpiredTrashJob()
 setInterval(purgeExpiredTrashJob, TRASH_PURGE_INTERVAL_MS)
 
-console.log('stats.rollup.scheduler.started interval=24h')
+console.log('stats.rollup.scheduler.started interval=10m')
 function writeStatsRollup(): void {
   void (async () => {
     try {
-      const result = await deps.adminStats.writeStorageUsedRollup(new Date())
-      console.log(`stats.rollup.done bucket=${result.bucketStart.toISOString()} bytes=${result.bytes}`)
+      const results = await deps.adminStats.refreshHourlyRollups(new Date())
+      console.log(
+        JSON.stringify({
+          message: 'stats.rollup.done',
+          buckets: results.map((result) => ({
+            start: result.bucketStart.toISOString(),
+            rows: result.rows,
+            lowerBoundRows: result.lowerBoundRows,
+          })),
+        }),
+      )
     } catch (err) {
       console.error(`stats.rollup.error code=${err instanceof Error ? err.message : String(err)}`)
     }

--- a/server/http/admin-stats.integration.test.ts
+++ b/server/http/admin-stats.integration.test.ts
@@ -21,9 +21,11 @@ describe('site stats routes', () => {
 
     const coreRes = await app.request('/api/site/stats/core', { headers })
     const detailsRes = await app.request('/api/site/stats/details', { headers })
+    const rankingRes = await app.request('/api/site/stats/ranking', { headers })
 
     expect(coreRes.status).toBe(404)
     expect(detailsRes.status).toBe(404)
+    expect(rankingRes.status).toBe(404)
   })
 
   it('gates advanced dashboard stats behind the analytics feature', async () => {
@@ -76,6 +78,52 @@ describe('site stats routes', () => {
     expect(body.trends.map((point) => point.date)).toEqual(['2026-07-01'])
   })
 
+  it('interprets date-only ranges in the requested time zone', async () => {
+    const { app } = await createTestApp()
+    const headers = await adminHeaders(app)
+
+    const res = await app.request('/api/site/stats/overview?from=2026-07-01&to=2026-07-01&timeZone=America%2FToronto', {
+      headers,
+    })
+    const body = (await res.json()) as { from: string; to: string; trends: Array<{ date: string }> }
+
+    expect(res.status).toBe(200)
+    expect(body.from).toBe('2026-07-01T04:00:00.000Z')
+    expect(body.to).toBe('2026-07-02T03:59:59.999Z')
+    expect(body.trends.map((point) => point.date)).toEqual(['2026-07-01'])
+  })
+
+  it('supports non-whole-hour time zones and daylight-saving day lengths', async () => {
+    const { app } = await createTestApp()
+    const headers = await adminHeaders(app)
+
+    const kathmandu = await app.request(
+      '/api/site/stats/overview?from=2026-07-01&to=2026-07-01&timeZone=Asia%2FKathmandu',
+      { headers },
+    )
+    const spring = await app.request(
+      '/api/site/stats/overview?from=2026-03-08&to=2026-03-08&timeZone=America%2FToronto',
+      { headers },
+    )
+    const fall = await app.request(
+      '/api/site/stats/overview?from=2026-11-01&to=2026-11-01&timeZone=America%2FToronto',
+      { headers },
+    )
+
+    expect(await kathmandu.json()).toMatchObject({
+      from: '2026-06-30T18:15:00.000Z',
+      to: '2026-07-01T18:14:59.999Z',
+    })
+    expect(await spring.json()).toMatchObject({
+      from: '2026-03-08T05:00:00.000Z',
+      to: '2026-03-09T03:59:59.999Z',
+    })
+    expect(await fall.json()).toMatchObject({
+      from: '2026-11-01T04:00:00.000Z',
+      to: '2026-11-02T04:59:59.999Z',
+    })
+  })
+
   it('rejects dashboard ranges longer than one year', async () => {
     const { app } = await createTestApp()
     const headers = await adminHeaders(app)
@@ -113,19 +161,19 @@ describe('site stats routes', () => {
     expect(Object.keys(body.paths).some((path) => path.startsWith('/api/site/stats'))).toBe(false)
   })
 
-  it('reads storage waterline trends from daily rollups when present', async () => {
+  it('reads storage waterline trends from hourly rollups when present', async () => {
     const { app, db } = await createTestApp()
     const headers = await adminHeaders(app)
     await seedProLicense(db)
     await seedStatsFixture(db)
 
     await db.run(sql`
-      INSERT INTO stats_rollups_daily (
+      INSERT INTO stats_rollups_hourly (
         id, bucket_start, org_id, metric_key, dimension_key, dimension_value,
         count, bytes, unique_count, metadata, updated_at
       )
       VALUES (
-        'storage-used-2026-01-01', ${Date.UTC(2026, 0, 1)}, '', 'storage.used.bytes', '', '',
+        'storage-used-2026-01-01', ${Date.UTC(2026, 0, 1)}, 'org-1', 'storage.used', '', '',
         0, 4096, 0, NULL, ${Date.UTC(2026, 0, 2)}
       )
     `)
@@ -139,8 +187,50 @@ describe('site stats routes', () => {
     expect(body.storageTrend).toEqual([{ date: '2026-01-01', usedBytes: 4096, newBytes: 0, newFiles: 0 }])
   })
 
-  it('upserts one exact storage rollup per UTC day', async () => {
-    const { db } = await createTestApp()
+  it('uses completed hourly event rollups and falls back to raw events when the marker is missing', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+    await seedProLicense(db)
+    const [{ id: orgId }] = await db.all<{ id: string }>(sql`SELECT id FROM organization LIMIT 1`)
+    const at = Date.UTC(2026, 6, 1, 10)
+    await db.run(sql`
+      INSERT INTO activity_events (
+        id, org_id, user_id, actor_type, action, target_type, target_id, target_name, metadata, created_at
+      ) VALUES (
+        'hourly-reader-raw', ${orgId}, NULL, 'system', 'upload_confirm', 'file', 'old-file', 'old.bin',
+        '{"bytes":111,"source":"upload"}', ${Math.floor(at / 1000) + 60}
+      )
+    `)
+    await db.run(sql`
+      INSERT INTO stats_rollups_hourly (
+        id, bucket_start, org_id, metric_key, dimension_key, dimension_value,
+        count, bytes, unique_count, metadata, updated_at
+      ) VALUES
+        ('hourly-reader-marker', ${at}, '', 'stats.rollup_run', '', '', 1, 0, 0,
+          '{"version":1,"quality":"exact"}', ${at + 3_600_000}),
+        ('hourly-reader-upload', ${at}, ${orgId}, 'transfer.upload', 'status', 'success', 1, 999, 0,
+          '{"version":1,"quality":"exact"}', ${at + 3_600_000})
+    `)
+
+    const query =
+      '/api/site/stats/traffic?from=2026-07-01T10%3A00%3A00.000Z&to=2026-07-01T10%3A59%3A59.999Z&timeZone=UTC'
+    const rollupRes = await app.request(query, { headers })
+    const rollupBody = (await rollupRes.json()) as { summary: { totalBytes: { value: number } } }
+
+    await db.run(sql`DELETE FROM stats_rollups_hourly WHERE id = 'hourly-reader-marker'`)
+    const fallbackRes = await app.request(query, { headers })
+    const fallbackBody = (await fallbackRes.json()) as { summary: { totalBytes: { value: number } } }
+
+    expect(rollupRes.status).toBe(200)
+    expect(rollupBody.summary.totalBytes.value).toBe(999)
+    expect(fallbackRes.status).toBe(200)
+    expect(fallbackBody.summary.totalBytes.value).toBe(111)
+  })
+
+  it('refreshes exact hourly storage snapshots', async () => {
+    const { app, db } = await createTestApp()
+    await adminHeaders(app)
+    await seedStatsFixture(db)
     const [{ expected }] = await db.all<{ expected: number }>(
       sql`SELECT COALESCE(SUM(used), 0) AS expected FROM org_quotas`,
     )
@@ -148,17 +238,22 @@ describe('site stats routes', () => {
     const firstNow = new Date('2026-07-10T04:05:00.000Z')
     const secondNow = new Date('2026-07-10T18:05:00.000Z')
 
-    await repo.writeStorageUsedRollup(firstNow)
-    await repo.writeStorageUsedRollup(secondNow)
+    await repo.refreshHourlyRollups(firstNow)
+    await repo.refreshHourlyRollups(secondNow)
     const rows = await db.all<{ bucketStart: number; bytes: number; metadata: string }>(sql`
       SELECT bucket_start AS bucketStart, bytes, metadata
-      FROM stats_rollups_daily
-      WHERE metric_key = 'storage.used.bytes'
+      FROM stats_rollups_hourly
+      WHERE metric_key = 'storage.used' AND dimension_key = ''
+      ORDER BY bucket_start, org_id
     `)
 
-    expect(rows).toHaveLength(1)
-    expect(rows[0]).toMatchObject({ bucketStart: Date.UTC(2026, 6, 10), bytes: expected })
-    expect(JSON.parse(rows[0].metadata)).toEqual({ source: 'org_quotas.used', quality: 'exact_snapshot' })
+    expect(rows.map((row) => Number(row.bucketStart))).toContain(Date.UTC(2026, 6, 10, 18))
+    expect(
+      rows
+        .filter((row) => Number(row.bucketStart) === Date.UTC(2026, 6, 10, 18))
+        .reduce((sum, row) => sum + row.bytes, 0),
+    ).toBe(expected)
+    expect(JSON.parse(rows.at(-1)?.metadata ?? '{}')).toMatchObject({ version: 1, quality: 'exact' })
   })
 
   it('does not write rollups while serving storage stats fallback data', async () => {
@@ -167,9 +262,9 @@ describe('site stats routes', () => {
     await seedProLicense(db)
     await seedStatsFixture(db)
 
-    const before = await db.all<{ count: number }>(sql`SELECT COUNT(*) AS count FROM stats_rollups_daily`)
+    const before = await db.all<{ count: number }>(sql`SELECT COUNT(*) AS count FROM stats_rollups_hourly`)
     const res = await app.request('/api/site/stats/storage?from=2000-01-01&to=2000-01-02', { headers })
-    const after = await db.all<{ count: number }>(sql`SELECT COUNT(*) AS count FROM stats_rollups_daily`)
+    const after = await db.all<{ count: number }>(sql`SELECT COUNT(*) AS count FROM stats_rollups_hourly`)
     const body = (await res.json()) as { storageTrend: Array<{ usedBytes: number | null }> }
 
     expect(res.status).toBe(200)
@@ -308,7 +403,40 @@ describe('site stats routes', () => {
     expect(body.failureReasons).toEqual([])
   })
 
-  it('applies dashboard ranges to sharing and ranking drill-down data', async () => {
+  it('separates operational health from transfer analytics', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+    await seedProLicense(db)
+    await seedStatsFixture(db)
+    await db.run(sql`UPDATE download_tasks SET finished_at = updated_at WHERE id IN ('task-1', 'task-2')`)
+
+    const res = await app.request('/api/site/stats/operations', { headers })
+    const body = (await res.json()) as {
+      summary: {
+        onlineDownloaders: number
+        backgroundJobFailureRate: number | null
+        remoteDownloadSuccessRate: number | null
+      }
+      backgroundJobOutcomes: Array<{ name: string; value: number }>
+      remoteDownloadOutcomes: Array<{ name: string; value: number }>
+    }
+
+    expect(res.status).toBe(200)
+    expect(body.summary.onlineDownloaders).toBe(1)
+    expect(body.summary.backgroundJobFailureRate).toBe(100)
+    expect(body.summary.remoteDownloadSuccessRate).toBe(50)
+    expect(body.backgroundJobOutcomes).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'failed', value: 1 })]),
+    )
+    expect(body.remoteDownloadOutcomes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'completed', value: 1 }),
+        expect.objectContaining({ name: 'failed', value: 1 }),
+      ]),
+    )
+  })
+
+  it('applies dashboard ranges to sharing drill-down data', async () => {
     const { app, db } = await createTestApp()
     const headers = await adminHeaders(app)
     await seedProLicense(db)
@@ -330,19 +458,6 @@ describe('site stats routes', () => {
       summary: { views: { value: number }; downloads: { value: number } }
       topShares: unknown[]
     }
-    const currentRankingRes = await app.request('/api/site/stats/ranking', { headers })
-    const currentRanking = (await currentRankingRes.json()) as {
-      topSpaces: unknown[]
-      storageByType: unknown[]
-      topShares: unknown[]
-    }
-    const oldRankingRes = await app.request('/api/site/stats/ranking?from=2000-01-01&to=2000-01-02', { headers })
-    const oldRanking = (await oldRankingRes.json()) as {
-      topSpaces: unknown[]
-      storageByType: unknown[]
-      topShares: unknown[]
-    }
-
     expect(currentSharingRes.status).toBe(200)
     expect(currentSharing.summary.views.value).toBe(1)
     expect(currentSharing.summary.downloads.value).toBe(1)
@@ -356,12 +471,6 @@ describe('site stats routes', () => {
     expect(oldSharing.summary.views.value).toBe(0)
     expect(oldSharing.summary.downloads.value).toBe(0)
     expect(oldSharing.topShares).toEqual([])
-    expect(currentRanking.topSpaces.length).toBeGreaterThan(0)
-    expect(currentRanking.storageByType.length).toBeGreaterThan(0)
-    expect(currentRanking.topShares.length).toBeGreaterThan(0)
-    expect(oldRanking.topSpaces).toEqual([])
-    expect(oldRanking.storageByType).toEqual([])
-    expect(oldRanking.topShares).toEqual([])
   })
 
   it('orders top share rankings by views before downloads', async () => {
@@ -384,7 +493,7 @@ describe('site stats routes', () => {
         ('activity-download-heavy-3', ${orgId}, NULL, 'anonymous', 'share_download', 'share', 'share-download-heavy', 'report.pdf', '{"bytes":512,"source":"landing_share","anonymous":true}', ${nowSec})
     `)
 
-    const res = await app.request('/api/site/stats/ranking', { headers })
+    const res = await app.request('/api/site/stats/sharing', { headers })
     const body = (await res.json()) as { topShares: Array<{ token: string; views: number; downloads: number }> }
 
     expect(res.status).toBe(200)
@@ -411,7 +520,7 @@ describe('site stats routes', () => {
       `)
     }
 
-    const res = await app.request('/api/site/stats/ranking', { headers })
+    const res = await app.request('/api/site/stats/sharing', { headers })
     const body = (await res.json()) as { topShares: Array<{ viewPercent: number }> }
 
     expect(res.status).toBe(200)

--- a/server/http/admin-stats.integration.test.ts
+++ b/server/http/admin-stats.integration.test.ts
@@ -1,7 +1,7 @@
 import type { AdminDashboardOverviewStats } from '@shared/types'
 import { sql } from 'drizzle-orm'
 import { describe, expect, it } from 'vitest'
-import { createAdminStatsRepo } from '../adapters/repos/admin-stats'
+import { createAdminStatsRepo, metricSpec } from '../adapters/repos/admin-stats'
 import { currentTrafficPeriod } from '../domain/quota'
 import { adminHeaders, createTestApp, seedProLicense } from '../test/setup.js'
 
@@ -26,6 +26,10 @@ describe('site stats routes', () => {
     expect(coreRes.status).toBe(404)
     expect(detailsRes.status).toBe(404)
     expect(rankingRes.status).toBe(404)
+  })
+
+  it('rejects unsupported hourly activity metric definitions', () => {
+    expect(() => metricSpec(['unknown_action'])).toThrow('Unsupported hourly activity metric: unknown_action')
   })
 
   it('gates advanced dashboard stats behind the analytics feature', async () => {
@@ -452,7 +456,7 @@ describe('site stats routes', () => {
     await db.run(sql`
       INSERT INTO activity_events (id, org_id, user_id, actor_type, action, target_type, target_name, metadata, created_at)
       VALUES ('upload-cancel-rate', ${orgId}, ${userId}, 'user', 'upload_cancel', 'file', 'cancel.bin',
-        '{"source":"upload","status":"canceled"}', ${nowSec})
+        '{', ${nowSec})
     `)
 
     const current = await app.request('/api/site/stats/traffic', { headers })

--- a/server/http/admin-stats.integration.test.ts
+++ b/server/http/admin-stats.integration.test.ts
@@ -227,6 +227,62 @@ describe('site stats routes', () => {
     expect(fallbackBody.summary.totalBytes.value).toBe(111)
   })
 
+  it('hydrates completed-hour dashboard dimensions from rollups', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+    await seedProLicense(db)
+    const [{ id: orgId }] = await db.all<{ id: string }>(sql`SELECT id FROM organization LIMIT 1`)
+    const at = Date.UTC(2026, 6, 1, 10)
+    await db.run(sql`
+      INSERT INTO stats_rollups_hourly
+        (id, bucket_start, org_id, metric_key, dimension_key, dimension_value,
+          count, bytes, unique_count, metadata, updated_at)
+      VALUES
+        ('dimensions-marker', ${at}, '', 'stats.rollup_run', '', '', 1, 0, 0, '{"quality":"exact"}', ${at}),
+        ('dimensions-share-total', ${at}, ${orgId}, 'share.created', '', '', 1, 0, 0, '{"quality":"exact"}', ${at}),
+        ('dimensions-share-kind', ${at}, ${orgId}, 'share.created', 'kind', 'landing', 1, 0, 0, '{"quality":"exact"}', ${at}),
+        ('dimensions-job-total', ${at}, ${orgId}, 'background_job.finished', '', '', 1, 0, 0, '{"quality":"exact"}', ${at}),
+        ('dimensions-job-outcome', ${at}, ${orgId}, 'background_job.finished', 'outcome', 'failed', 1, 0, 0, '{"quality":"exact"}', ${at}),
+        ('dimensions-download-total', ${at}, ${orgId}, 'transfer.download_issued', '', '', 1, 10, 0, '{"quality":"exact"}', ${at}),
+        ('dimensions-download-source', ${at}, ${orgId}, 'transfer.download_issued', 'source', 'object_download', 1, 10, 0, '{"quality":"exact"}', ${at}),
+        ('dimensions-failure-total', ${at}, ${orgId}, 'transfer.download_failed', '', '', 1, 4, 0, '{"quality":"exact"}', ${at}),
+        ('dimensions-failure-reason', ${at}, ${orgId}, 'transfer.download_failed', 'reason', 'network', 1, 4, 0, '{"quality":"exact"}', ${at}),
+        ('dimensions-quality-total', ${at}, ${orgId}, 'stats.quality_missing_bytes', '', '', 5, 0, 0, '{"quality":"exact"}', ${at}),
+        ('dimensions-quality-upload', ${at}, ${orgId}, 'stats.quality_missing_bytes', 'direction', 'upload', 2, 0, 0, '{"quality":"exact"}', ${at}),
+        ('dimensions-quality-download', ${at}, ${orgId}, 'stats.quality_missing_bytes', 'direction', 'download', 3, 0, 0, '{"quality":"exact"}', ${at})
+    `)
+    const query = 'from=2026-07-01T10%3A00%3A00.000Z&to=2026-07-01T10%3A59%3A59.999Z&timeZone=UTC'
+
+    const [overviewRes, operationsRes, sharingRes, trafficRes] = await Promise.all([
+      app.request(`/api/site/stats/overview?${query}`, { headers }),
+      app.request(`/api/site/stats/operations?${query}`, { headers }),
+      app.request(`/api/site/stats/sharing?${query}`, { headers }),
+      app.request(`/api/site/stats/traffic?${query}`, { headers }),
+    ])
+    const overview = (await overviewRes.json()) as { dataQuality: AdminDashboardOverviewStats['dataQuality'] }
+    const operations = (await operationsRes.json()) as { backgroundJobOutcomes: Array<{ name: string; value: number }> }
+    const sharing = (await sharingRes.json()) as {
+      summary: { createdShares: { value: number } }
+      typeBreakdown: Array<{ name: string; value: number }>
+    }
+    const traffic = (await trafficRes.json()) as {
+      sourceBreakdown: Array<{ name: string; requests: number; bytes: number }>
+      failureReasons: Array<{ name: string; value: number }>
+    }
+
+    expect([overviewRes.status, operationsRes.status, sharingRes.status, trafficRes.status]).toEqual([
+      200, 200, 200, 200,
+    ])
+    expect(overview.dataQuality).toMatchObject({ missingUploadBytesEvents: 2, missingDownloadBytesEvents: 3 })
+    expect(operations.backgroundJobOutcomes).toContainEqual(expect.objectContaining({ name: 'failed', value: 1 }))
+    expect(sharing.summary.createdShares.value).toBe(1)
+    expect(sharing.typeBreakdown).toContainEqual(expect.objectContaining({ name: 'landing', value: 1 }))
+    expect(traffic.sourceBreakdown).toContainEqual(
+      expect.objectContaining({ name: 'object_download', requests: 1, bytes: 10 }),
+    )
+    expect(traffic.failureReasons).toContainEqual(expect.objectContaining({ name: 'network', value: 1 }))
+  })
+
   it('refreshes exact hourly storage snapshots', async () => {
     const { app, db } = await createTestApp()
     await adminHeaders(app)
@@ -501,8 +557,15 @@ describe('site stats routes', () => {
     const { app, db } = await createTestApp()
     const headers = await adminHeaders(app)
     await seedProLicense(db)
-    await seedStatsFixture(db)
+    const { orgId } = await seedStatsFixture(db)
+    const now = Date.now()
     await db.run(sql`UPDATE download_tasks SET finished_at = updated_at WHERE id IN ('task-1', 'task-2')`)
+    await db.run(sql`
+      INSERT INTO cloud_traffic_reports
+        (id, org_id, period, source, source_id, event_id, bytes, status, created_at, updated_at)
+      VALUES ('operations-cloud-report', ${orgId}, '2026-07', 'object_download', 'stats-file',
+        'operations-cloud-report', 64, 'pending', ${now}, ${now})
+    `)
 
     const res = await app.request('/api/site/stats/operations', { headers })
     const body = (await res.json()) as {
@@ -513,6 +576,7 @@ describe('site stats routes', () => {
       }
       backgroundJobOutcomes: Array<{ name: string; value: number }>
       remoteDownloadOutcomes: Array<{ name: string; value: number }>
+      cloudReportStatus: Array<{ name: string; value: number }>
     }
 
     expect(res.status).toBe(200)
@@ -528,6 +592,7 @@ describe('site stats routes', () => {
         expect.objectContaining({ name: 'failed', value: 1 }),
       ]),
     )
+    expect(body.cloudReportStatus).toContainEqual(expect.objectContaining({ name: 'pending', value: 1 }))
   })
 
   it('applies dashboard ranges to sharing drill-down data', async () => {

--- a/server/http/admin-stats.integration.test.ts
+++ b/server/http/admin-stats.integration.test.ts
@@ -273,6 +273,39 @@ describe('site stats routes', () => {
     expect(body.storageTrend.every((point) => point.usedBytes === null)).toBe(true)
   })
 
+  it('returns growth lifecycle metrics from the hourly-aware repository', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+    await seedProLicense(db)
+    await seedStatsFixture(db)
+
+    const res = await app.request('/api/site/stats/growth', { headers })
+    const body = (await res.json()) as {
+      summary: {
+        totalUsers: number
+        newUsers: { value: number }
+        activeUsers: { value: number }
+        verifiedUsers: number
+        bannedUsers: number
+        silentUsers: number
+      }
+      userScaleTrend: Array<{ date: string; newUsers: number; totalUsers: number }>
+      activeUserTrend: Array<{ date: string; dau: number; wau: number; mau: number }>
+      userStatus: Array<{ name: string; value: number; percent: number }>
+      registrationSources: Array<{ name: string; value: number; percent: number }>
+    }
+
+    expect(res.status).toBe(200)
+    expect(body.summary.totalUsers).toBeGreaterThanOrEqual(1)
+    expect(body.summary.newUsers.value).toBeGreaterThanOrEqual(1)
+    expect(body.summary.activeUsers.value).toBeGreaterThanOrEqual(1)
+    expect(body.summary.verifiedUsers + body.summary.bannedUsers + body.summary.silentUsers).toBeGreaterThanOrEqual(0)
+    expect(body.userScaleTrend.length).toBeGreaterThan(0)
+    expect(body.activeUserTrend.length).toBeGreaterThan(0)
+    expect(body.userStatus.map((row) => row.name)).toEqual(['normal', 'unverified', 'banned', 'silent'])
+    expect(body.registrationSources.length).toBeGreaterThan(0)
+  })
+
   it('excludes orphan actors and uses immutable session creation time for historical active users', async () => {
     const { app, db } = await createTestApp()
     const headers = await adminHeaders(app)

--- a/server/http/admin-stats.integration.test.ts
+++ b/server/http/admin-stats.integration.test.ts
@@ -306,6 +306,67 @@ describe('site stats routes', () => {
     expect(body.registrationSources.length).toBeGreaterThan(0)
   })
 
+  it('reads historical signup totals, trends, and providers from completed hourly rollups', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+    await seedProLicense(db)
+    const at = Date.UTC(2026, 0, 1, 10)
+    await db.run(sql`
+      INSERT INTO stats_rollups_hourly
+        (id, bucket_start, org_id, metric_key, dimension_key, dimension_value,
+          count, bytes, unique_count, metadata, updated_at)
+      VALUES
+        ('growth-rollup-marker', ${at}, '', 'stats.rollup_run', '', '', 1, 0, 0,
+          '{"version":1,"quality":"exact"}', ${at + 3_600_000}),
+        ('growth-rollup-total', ${at}, '', 'user.signup', '', '', 2, 0, 0,
+          '{"version":1,"quality":"exact"}', ${at + 3_600_000}),
+        ('growth-rollup-credential', ${at}, '', 'user.signup', 'provider', 'credential', 1, 0, 0,
+          '{"version":1,"quality":"exact"}', ${at + 3_600_000}),
+        ('growth-rollup-github', ${at}, '', 'user.signup', 'provider', 'github', 1, 0, 0,
+          '{"version":1,"quality":"exact"}', ${at + 3_600_000})
+    `)
+
+    const res = await app.request('/api/site/stats/growth?from=2026-01-01&to=2026-01-01', { headers })
+    const body = (await res.json()) as {
+      summary: { newUsers: { value: number } }
+      userScaleTrend: Array<{ newUsers: number; totalUsers: number }>
+      registrationSources: Array<{ name: string; value: number; percent: number }>
+    }
+
+    expect(res.status).toBe(200)
+    expect(body.summary.newUsers.value).toBe(2)
+    expect(body.userScaleTrend).toEqual([{ date: '2026-01-01', newUsers: 2, totalUsers: 2 }])
+    expect(body.registrationSources).toEqual(
+      expect.arrayContaining([
+        { name: 'credential', value: 1, percent: 50 },
+        { name: 'github', value: 1, percent: 50 },
+      ]),
+    )
+  })
+
+  it('groups storage file types beyond the top eight into other', async () => {
+    const { app, db } = await createTestApp()
+    const headers = await adminHeaders(app)
+    await seedProLicense(db)
+    const { orgId } = await seedStatsFixture(db)
+    const nowSec = Math.floor(Date.now() / 1000)
+    for (let index = 0; index < 9; index += 1) {
+      await db.run(sql`
+        INSERT INTO matters
+          (id, org_id, alias, name, type, size, dirtype, parent, object, storage_id, status, created_at, updated_at)
+        VALUES (${`file-type-${index}`}, ${orgId}, ${`file-type-alias-${index}`}, ${`file-${index}`},
+          ${`custom/type-${index}`}, ${index + 1}, 0, '', ${`file-${index}`}, 'stats-storage', 'active', ${nowSec}, ${nowSec})
+      `)
+    }
+
+    const res = await app.request('/api/site/stats/storage', { headers })
+    const body = (await res.json()) as { typeBreakdown: Array<{ type: string; files: number; bytes: number }> }
+
+    expect(res.status).toBe(200)
+    expect(body.typeBreakdown).toHaveLength(9)
+    expect(body.typeBreakdown.at(-1)).toMatchObject({ type: 'other', files: 2 })
+  })
+
   it('excludes orphan actors and uses immutable session creation time for historical active users', async () => {
     const { app, db } = await createTestApp()
     const headers = await adminHeaders(app)

--- a/server/http/admin-stats.ts
+++ b/server/http/admin-stats.ts
@@ -1,13 +1,14 @@
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { z } from 'zod'
+import { addCalendarDays, localDateStart } from '../domain/admin-stats-time'
 import { requireAdmin } from '../middleware/auth'
 import type { Env } from '../middleware/platform'
 import { requireFeature } from '../middleware/require-feature'
 import {
   getAdminDashboardGrowthStats,
+  getAdminDashboardOperationsStats,
   getAdminDashboardOverviewStats,
-  getAdminDashboardRankingStats,
   getAdminDashboardSharingStats,
   getAdminDashboardStorageStats,
   getAdminDashboardTrafficStats,
@@ -24,10 +25,11 @@ const rangeQuerySchema = z.object({
 })
 
 function parseRange(query: z.infer<typeof rangeQuerySchema>): { from?: Date; to?: Date; timeZone?: string } {
+  const timeZone = query.timeZone ?? 'UTC'
   return {
-    from: query.from ? parseDashboardDate(query.from, 'start') : undefined,
-    to: query.to ? parseDashboardDate(query.to, 'end') : undefined,
-    timeZone: query.timeZone,
+    from: query.from ? parseDashboardDate(query.from, 'start', timeZone) : undefined,
+    to: query.to ? parseDashboardDate(query.to, 'end', timeZone) : undefined,
+    timeZone,
   }
 }
 
@@ -46,9 +48,10 @@ function isValidDashboardDate(value: string): boolean {
   return !Number.isNaN(date.getTime()) && date.toISOString().startsWith(value)
 }
 
-function parseDashboardDate(value: string, boundary: 'start' | 'end'): Date {
+function parseDashboardDate(value: string, boundary: 'start' | 'end', timeZone: string): Date {
   if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
-    return new Date(`${value}T${boundary === 'start' ? '00:00:00.000' : '23:59:59.999'}Z`)
+    if (boundary === 'start') return localDateStart(value, timeZone)
+    return new Date(localDateStart(addCalendarDays(value, 1), timeZone).getTime() - 1)
   }
   return new Date(value)
 }
@@ -56,6 +59,9 @@ function parseDashboardDate(value: string, boundary: 'start' | 'end'): Date {
 export const adminStats = new Hono<Env>()
   .get('/overview', requireAdmin, zValidator('query', rangeQuerySchema), async (c) =>
     c.json(await getAdminDashboardOverviewStats(c.get('deps'), parseRange(c.req.valid('query'))), 200),
+  )
+  .get('/operations', requireAdmin, requireFeature('analytics'), zValidator('query', rangeQuerySchema), async (c) =>
+    c.json(await getAdminDashboardOperationsStats(c.get('deps'), parseRange(c.req.valid('query'))), 200),
   )
   .get('/growth', requireAdmin, requireFeature('analytics'), zValidator('query', rangeQuerySchema), async (c) =>
     c.json(await getAdminDashboardGrowthStats(c.get('deps'), parseRange(c.req.valid('query'))), 200),
@@ -68,7 +74,4 @@ export const adminStats = new Hono<Env>()
   )
   .get('/sharing', requireAdmin, requireFeature('analytics'), zValidator('query', rangeQuerySchema), async (c) =>
     c.json(await getAdminDashboardSharingStats(c.get('deps'), parseRange(c.req.valid('query'))), 200),
-  )
-  .get('/ranking', requireAdmin, requireFeature('analytics'), zValidator('query', rangeQuerySchema), async (c) =>
-    c.json(await getAdminDashboardRankingStats(c.get('deps'), parseRange(c.req.valid('query'))), 200),
   )

--- a/server/scheduled-worker.test.ts
+++ b/server/scheduled-worker.test.ts
@@ -11,8 +11,8 @@ vi.mock('../server/platform/cloudflare', () => ({
   }),
 }))
 
-const writeStorageUsedRollup = vi.fn()
-const fakeDeps = { instance: 'instance', systemOptions: 'system-options', adminStats: { writeStorageUsedRollup } }
+const refreshHourlyRollups = vi.fn()
+const fakeDeps = { instance: 'instance', systemOptions: 'system-options', adminStats: { refreshHourlyRollups } }
 vi.mock('../server/composition', () => ({
   createDeps: vi.fn(() => fakeDeps),
 }))
@@ -53,7 +53,7 @@ describe('handleScheduled', () => {
     vi.mocked(reportInstanceTelemetry).mockReset()
     vi.mocked(runLicensingRefresh).mockReset()
     mockResetExpiredTrafficQuotas.mockReset()
-    writeStorageUsedRollup.mockReset()
+    refreshHourlyRollups.mockReset()
   })
 
   it('syncs usage reports on the traffic cron only', async () => {
@@ -63,6 +63,7 @@ describe('handleScheduled', () => {
     expect(syncPendingRemoteDownloadUsageReports).toHaveBeenCalledWith(fakeDeps, {
       cloudBaseUrl: 'https://cloud.example',
     })
+    expect(refreshHourlyRollups).toHaveBeenCalledOnce()
     expect(runLicensingRefresh).not.toHaveBeenCalled()
     expect(reportInstanceTelemetry).not.toHaveBeenCalled()
   })
@@ -111,12 +112,5 @@ describe('handleScheduled', () => {
     expect(runLicensingRefresh).not.toHaveBeenCalled()
     expect(syncPendingCloudTrafficReports).not.toHaveBeenCalled()
     expect(syncPendingRemoteDownloadUsageReports).not.toHaveBeenCalled()
-  })
-
-  it('writes the storage rollup on the daily stats cron only', async () => {
-    await handleScheduled({ cron: '5 4 * * *' }, { DB: {} as D1Database })
-
-    expect(writeStorageUsedRollup).toHaveBeenCalledOnce()
-    expect(runLicensingRefresh).not.toHaveBeenCalled()
   })
 })

--- a/server/scripts/backfill-admin-stats.test.ts
+++ b/server/scripts/backfill-admin-stats.test.ts
@@ -1,16 +1,20 @@
 import Database from 'better-sqlite3'
 import { describe, expect, it } from 'vitest'
-import { buildBackfillSql, VALIDATION_SQL } from '../../scripts/backfill-admin-stats'
+import { buildBackfillSql, splitSqlStatements, VALIDATION_SQL } from '../../scripts/backfill-admin-stats'
 
 describe('admin stats backfill', () => {
   it('recovers exact available facts and is idempotent', () => {
     const db = new Database(':memory:')
     db.exec(`
-      CREATE TABLE user (id TEXT PRIMARY KEY);
+      CREATE TABLE user (id TEXT PRIMARY KEY, created_at INTEGER NOT NULL DEFAULT 0);
+      CREATE TABLE account (id TEXT PRIMARY KEY, user_id TEXT NOT NULL, provider_id TEXT NOT NULL, created_at INTEGER NOT NULL);
+      CREATE TABLE session (id TEXT PRIMARY KEY, user_id TEXT NOT NULL, created_at INTEGER NOT NULL);
+      CREATE TABLE organization (id TEXT PRIMARY KEY, created_at INTEGER NOT NULL);
       CREATE TABLE matters (id TEXT PRIMARY KEY, size INTEGER, dirtype INTEGER);
       CREATE TABLE shares (
-        id TEXT PRIMARY KEY, kind TEXT NOT NULL, matter_id TEXT NOT NULL,
-        status TEXT NOT NULL, expires_at INTEGER, download_limit INTEGER, downloads INTEGER NOT NULL
+        id TEXT PRIMARY KEY, kind TEXT NOT NULL, matter_id TEXT NOT NULL, org_id TEXT NOT NULL,
+        status TEXT NOT NULL, expires_at INTEGER, download_limit INTEGER, downloads INTEGER NOT NULL,
+        created_at INTEGER NOT NULL
       );
       CREATE TABLE activity_events (
         id TEXT PRIMARY KEY, org_id TEXT NOT NULL, user_id TEXT, actor_type TEXT, actor_ref TEXT,
@@ -19,11 +23,28 @@ describe('admin stats backfill', () => {
       );
       CREATE TABLE cloud_traffic_reports (
         id TEXT PRIMARY KEY, org_id TEXT NOT NULL, source TEXT NOT NULL, source_id TEXT NOT NULL,
-        event_id TEXT NOT NULL UNIQUE, bytes INTEGER NOT NULL, status TEXT NOT NULL, error TEXT,
-        created_at INTEGER NOT NULL
+        event_id TEXT NOT NULL UNIQUE, bytes INTEGER NOT NULL, storage_id TEXT, unit_bytes INTEGER,
+        credits_per_unit INTEGER, status TEXT NOT NULL, error TEXT,
+        created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+      );
+      CREATE TABLE download_tasks (
+        id TEXT PRIMARY KEY, org_id TEXT NOT NULL, category TEXT, source_type TEXT NOT NULL,
+        assigned_downloader_id TEXT, status TEXT NOT NULL, billing_charged_bytes INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL, finished_at INTEGER
+      );
+      CREATE TABLE background_jobs (
+        id TEXT PRIMARY KEY, org_id TEXT NOT NULL, type TEXT NOT NULL, status TEXT NOT NULL,
+        created_at INTEGER NOT NULL, finished_at INTEGER
+      );
+      CREATE TABLE remote_download_usage_reports (
+        id TEXT PRIMARY KEY, org_id TEXT NOT NULL, downloader_id TEXT NOT NULL, status TEXT NOT NULL,
+        unit_bytes INTEGER NOT NULL, credits_per_unit INTEGER NOT NULL, created_at INTEGER NOT NULL
+      );
+      CREATE TABLE webhook_events (
+        id TEXT PRIMARY KEY, status TEXT NOT NULL, created_at INTEGER NOT NULL, processed_at INTEGER
       );
       CREATE TABLE org_quotas (id TEXT PRIMARY KEY, used INTEGER NOT NULL);
-      CREATE TABLE stats_rollups_daily (
+      CREATE TABLE stats_rollups_hourly (
         id TEXT PRIMARY KEY, bucket_start INTEGER NOT NULL, org_id TEXT NOT NULL,
         metric_key TEXT NOT NULL, dimension_key TEXT NOT NULL, dimension_value TEXT NOT NULL,
         count INTEGER NOT NULL, bytes INTEGER NOT NULL, unique_count INTEGER NOT NULL,
@@ -31,26 +52,38 @@ describe('admin stats backfill', () => {
         UNIQUE(bucket_start, org_id, metric_key, dimension_key, dimension_value)
       );
 
-      INSERT INTO user VALUES ('u1');
+      INSERT INTO user VALUES ('u1', 1);
       INSERT INTO matters VALUES ('f1', 512, 0);
-      INSERT INTO shares VALUES ('s1', 'landing', 'f1', 'active', NULL, 10, 1);
+      INSERT INTO shares VALUES ('s1', 'landing', 'f1', 'o1', 'active', NULL, 10, 1, 1);
       INSERT INTO activity_events VALUES
         ('upload-1', 'o1', 'u1', NULL, NULL, 'upload_confirm', 'file', 'f1', 'file.bin', NULL, 1),
-        ('share-1', 'o1', NULL, NULL, NULL, 'share_download', 'share', 's1', 'file.bin', '{"anonymous":true}', 1);
+        ('share-1', 'o1', NULL, NULL, NULL, 'share_download', 'share', 's1', 'file.bin', '{"anonymous":true}', 1),
+        ('image-1', 'o1', NULL, NULL, NULL, 'image_hosting_download', 'image', 'img1', 'image.png', NULL, 1);
       INSERT INTO cloud_traffic_reports VALUES
-        ('r1', 'o1', 'direct_share', 's1', 'traffic-1', 512, 'reported', NULL, 1000);
+        ('r1', 'o1', 'direct_share', 's1', 'traffic-1', 512, NULL, NULL, NULL, 'reported', NULL, 1000, 1000),
+        ('r2', 'o1', 'image_hosting', 'img1', 'traffic-2', 128, NULL, NULL, NULL, 'reported', NULL, 1000, 1000);
       INSERT INTO org_quotas VALUES ('q1', 512);
     `)
 
     const sql = buildBackfillSql(new Date('2026-07-10T12:00:00.000Z'))
-    db.transaction(() => db.exec(sql))()
+    const statements = splitSqlStatements(sql)
+    expect(statements.length).toBeGreaterThan(1)
+    db.transaction(() =>
+      statements.forEach((statement) => {
+        db.exec(statement)
+      }),
+    )()
     const firstChanges = db.prepare('SELECT total_changes() AS value').get() as { value: number }
     const firstSummary = JSON.parse((db.prepare(VALIDATION_SQL).get() as { summary: string }).summary) as Record<
       string,
       number
     >
 
-    db.transaction(() => db.exec(sql))()
+    db.transaction(() =>
+      statements.forEach((statement) => {
+        db.exec(statement)
+      }),
+    )()
     const secondChanges = db.prepare('SELECT total_changes() AS value').get() as { value: number }
 
     expect(firstChanges.value).toBeGreaterThan(0)
@@ -60,13 +93,16 @@ describe('admin stats backfill', () => {
       missingUploadBytes: 0,
       missingDownloadBytes: 0,
       trafficEvents: 2,
-      storageRollups: 1,
+      hourlyRollups: 2,
       rawActiveShares: 1,
       validActiveShares: 1,
     })
     expect(
       db.prepare("SELECT json_extract(metadata, '$.bytes') AS bytes FROM activity_events WHERE id = 'upload-1'").get(),
     ).toEqual({ bytes: 512 })
+    expect(db.prepare("SELECT COUNT(*) AS value FROM activity_events WHERE target_id = 'img1'").get()).toEqual({
+      value: 1,
+    })
     db.close()
   })
 })

--- a/server/scripts/backfill-admin-stats.test.ts
+++ b/server/scripts/backfill-admin-stats.test.ts
@@ -3,6 +3,15 @@ import { describe, expect, it } from 'vitest'
 import { buildBackfillSql, splitSqlStatements, VALIDATION_SQL } from '../../scripts/backfill-admin-stats'
 
 describe('admin stats backfill', () => {
+  it('splits SQL batches without breaking quoted semicolons', () => {
+    expect(splitSqlStatements("SELECT 'a;b'; SELECT 'it''s'; SELECT 3")).toEqual([
+      "SELECT 'a;b'",
+      "SELECT 'it''s'",
+      'SELECT 3',
+    ])
+    expect(() => splitSqlStatements("SELECT 'unterminated")).toThrow('admin_stats_backfill_unterminated_sql_string')
+  })
+
   it('recovers exact available facts and is idempotent', () => {
     const db = new Database(':memory:')
     db.exec(`

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -301,7 +301,7 @@ const APP_SCHEMA_SQL = `
 	  CREATE INDEX IF NOT EXISTS activity_events_user_created_idx ON activity_events(user_id, created_at);
 	  CREATE INDEX IF NOT EXISTS activity_events_action_created_idx ON activity_events(action, created_at);
 	  CREATE INDEX IF NOT EXISTS activity_events_target_created_idx ON activity_events(target_type, target_id, created_at);
-		  CREATE TABLE IF NOT EXISTS stats_rollups_daily (
+		  CREATE TABLE IF NOT EXISTS stats_rollups_hourly (
 		    id TEXT PRIMARY KEY NOT NULL,
 		    bucket_start INTEGER NOT NULL,
 	    org_id TEXT NOT NULL DEFAULT '',
@@ -314,8 +314,9 @@ const APP_SCHEMA_SQL = `
 	    metadata TEXT,
 	    updated_at INTEGER NOT NULL
 		  );
-		  CREATE UNIQUE INDEX IF NOT EXISTS stats_rollups_daily_bucket_metric_dim_uniq ON stats_rollups_daily(bucket_start, org_id, metric_key, dimension_key, dimension_value);
-		  CREATE INDEX IF NOT EXISTS stats_rollups_daily_metric_bucket_idx ON stats_rollups_daily(metric_key, bucket_start);
+		  CREATE UNIQUE INDEX IF NOT EXISTS stats_rollups_hourly_bucket_metric_dim_uniq ON stats_rollups_hourly(bucket_start, org_id, metric_key, dimension_key, dimension_value);
+		  CREATE INDEX IF NOT EXISTS stats_rollups_hourly_metric_bucket_idx ON stats_rollups_hourly(metric_key, bucket_start);
+		  CREATE INDEX IF NOT EXISTS stats_rollups_hourly_dimension_bucket_idx ON stats_rollups_hourly(metric_key, dimension_key, bucket_start);
 	  CREATE TABLE IF NOT EXISTS shares (
     id TEXT PRIMARY KEY,
     token TEXT NOT NULL UNIQUE,

--- a/server/usecases/admin-stats.ts
+++ b/server/usecases/admin-stats.ts
@@ -1,11 +1,12 @@
 import type {
   AdminDashboardGrowthStats,
+  AdminDashboardOperationsStats,
   AdminDashboardOverviewStats,
-  AdminDashboardRankingStats,
   AdminDashboardSharingStats,
   AdminDashboardStorageStats,
   AdminDashboardTrafficStats,
 } from '@shared/types'
+import { addCalendarDays, localDateStart, statsDayKey } from '../domain/admin-stats-time'
 import { type AdminStatsDateRange, type AdminStatsRepo, badRequest } from './ports'
 
 export type AdminStatsDeps = {
@@ -19,16 +20,16 @@ export interface AdminStatsRangeInput {
 }
 
 const MAX_DASHBOARD_RANGE_DAYS = 366
-const DAY_MS = 86_400_000
-
 export function normalizeStatsRange(input: AdminStatsRangeInput, now = new Date()): AdminStatsDateRange {
-  const to = input.to ?? endOfDay(now)
-  const from = input.from ?? startOfDay(daysAgo(to, 29))
+  const timeZone = input.timeZone ?? 'UTC'
+  const today = statsDayKey(now, timeZone)
+  const to = input.to ?? new Date(localDateStart(addCalendarDays(today, 1), timeZone).getTime() - 1)
+  const from = input.from ?? localDateStart(addCalendarDays(statsDayKey(to, timeZone), -29), timeZone)
   if (from > to) throw badRequest('from must be before to', 'INVALID_TIME_RANGE')
-  if (inclusiveDayCount(from, to) > MAX_DASHBOARD_RANGE_DAYS) {
+  if (calendarDayCount(from, to, timeZone) > MAX_DASHBOARD_RANGE_DAYS) {
     throw badRequest(`time range cannot exceed ${MAX_DASHBOARD_RANGE_DAYS} days`, 'TIME_RANGE_TOO_LARGE')
   }
-  return { from, to, timeZone: input.timeZone ?? 'UTC' }
+  return { from, to, timeZone }
 }
 
 export function getAdminDashboardOverviewStats(
@@ -37,6 +38,14 @@ export function getAdminDashboardOverviewStats(
   now = new Date(),
 ): Promise<AdminDashboardOverviewStats> {
   return deps.adminStats.getDashboardOverviewStats(now, normalizeStatsRange(input, now))
+}
+
+export function getAdminDashboardOperationsStats(
+  deps: AdminStatsDeps,
+  input: AdminStatsRangeInput,
+  now = new Date(),
+): Promise<AdminDashboardOperationsStats> {
+  return deps.adminStats.getDashboardOperationsStats(now, normalizeStatsRange(input, now))
 }
 
 export function getAdminDashboardGrowthStats(
@@ -71,30 +80,8 @@ export function getAdminDashboardSharingStats(
   return deps.adminStats.getDashboardSharingStats(now, normalizeStatsRange(input, now))
 }
 
-export function getAdminDashboardRankingStats(
-  deps: AdminStatsDeps,
-  input: AdminStatsRangeInput,
-  now = new Date(),
-): Promise<AdminDashboardRankingStats> {
-  return deps.adminStats.getDashboardRankingStats(now, normalizeStatsRange(input, now))
-}
-
-function daysAgo(now: Date, days: number): Date {
-  const date = new Date(now)
-  date.setUTCDate(date.getUTCDate() - days)
-  return date
-}
-
-function startOfDay(date: Date): Date {
-  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
-}
-
-function endOfDay(date: Date): Date {
-  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 23, 59, 59, 999))
-}
-
-function inclusiveDayCount(from: Date, to: Date): number {
-  const fromDay = startOfDay(from).getTime()
-  const toDay = startOfDay(to).getTime()
-  return Math.floor((toDay - fromDay) / DAY_MS) + 1
+function calendarDayCount(from: Date, to: Date, timeZone: string): number {
+  const fromDay = Date.parse(`${statsDayKey(from, timeZone)}T00:00:00.000Z`)
+  const toDay = Date.parse(`${statsDayKey(to, timeZone)}T00:00:00.000Z`)
+  return Math.floor((toDay - fromDay) / 86_400_000) + 1
 }

--- a/server/usecases/ports/admin-stats.ts
+++ b/server/usecases/ports/admin-stats.ts
@@ -1,20 +1,22 @@
 import type {
   AdminDashboardGrowthStats,
+  AdminDashboardOperationsStats,
   AdminDashboardOverviewStats,
-  AdminDashboardRankingStats,
   AdminDashboardSharingStats,
   AdminDashboardStorageStats,
   AdminDashboardTrafficStats,
 } from '@shared/types'
 
 export interface AdminStatsRepo {
-  writeStorageUsedRollup(now: Date): Promise<{ bucketStart: Date; bytes: number }>
+  refreshHourlyRollups(
+    now: Date,
+  ): Promise<Array<{ bucketStart: Date; bucketEnd: Date; rows: number; lowerBoundRows: number }>>
   getDashboardOverviewStats(now: Date, range: AdminStatsDateRange): Promise<AdminDashboardOverviewStats>
+  getDashboardOperationsStats(now: Date, range: AdminStatsDateRange): Promise<AdminDashboardOperationsStats>
   getDashboardGrowthStats(now: Date, range: AdminStatsDateRange): Promise<AdminDashboardGrowthStats>
   getDashboardStorageStats(now: Date, range: AdminStatsDateRange): Promise<AdminDashboardStorageStats>
   getDashboardTrafficStats(now: Date, range: AdminStatsDateRange): Promise<AdminDashboardTrafficStats>
   getDashboardSharingStats(now: Date, range: AdminStatsDateRange): Promise<AdminDashboardSharingStats>
-  getDashboardRankingStats(now: Date, range: AdminStatsDateRange): Promise<AdminDashboardRankingStats>
 }
 
 export interface AdminStatsDateRange {

--- a/shared/types/admin-stats.ts
+++ b/shared/types/admin-stats.ts
@@ -7,12 +7,6 @@ export interface AdminUsageBySpace {
   utilization: number
 }
 
-export interface AdminStorageByType {
-  type: string
-  bytes: number
-  files: number
-}
-
 export interface AdminTopShare {
   id: string
   token: string
@@ -92,11 +86,14 @@ export interface AdminDashboardStorageStats extends AdminStatsRange {
     newFiles: AdminStatsDelta
     newBytes: AdminStatsDelta
     coldFileBytes: number
+    nearQuotaSpaces: number
+    overQuotaSpaces: number
   }
   storageTrend: Array<{ date: string; usedBytes: number | null; newBytes: number; newFiles: number }>
   typeBreakdown: Array<{ type: string; bytes: number; files: number; percent: number }>
   sizeBreakdown: Array<{ name: string; bytes: number; files: number; percent: number }>
   ageBreakdown: Array<{ name: string; bytes: number; files: number; percent: number }>
+  topSpaces: AdminUsageBySpace[]
 }
 
 export interface AdminDashboardTrafficStats extends AdminStatsRange {
@@ -112,7 +109,6 @@ export interface AdminDashboardTrafficStats extends AdminStatsRange {
   trafficTrend: Array<{ date: string; uploadBytes: number; downloadBytes: number; requests: number }>
   sourceBreakdown: Array<{ name: string; bytes: number; requests: number; percent: number }>
   issueStatus: Array<{ status: string; count: number; percent: number }>
-  bandwidthTrend: Array<{ date: string; bytes: number }>
   successTrend: Array<{ date: string; uploadSuccessRate: number | null; downloadSuccessRate: number | null }>
   failureReasons: Array<{ name: string; value: number; percent: number }>
 }
@@ -127,15 +123,32 @@ export interface AdminDashboardSharingStats extends AdminStatsRange {
     downloadConversionRate: number | null
     passwordPasses: number
   }
-  funnel: Array<{ name: string; value: number; percent: number }>
   trend: Array<{ date: string; views: number; downloads: number; saves: number }>
   typeBreakdown: Array<{ name: string; value: number; percent: number }>
   sourceBreakdown: Array<{ name: string; value: number; percent: number }>
   topShares: Array<AdminTopShare & { viewPercent: number; downloadPercent: number }>
 }
 
-export interface AdminDashboardRankingStats extends AdminStatsRange {
-  topShares: Array<AdminTopShare & { viewPercent: number; downloadPercent: number }>
-  topSpaces: AdminUsageBySpace[]
-  storageByType: AdminStorageByType[]
+export interface AdminDashboardOperationsStats extends AdminStatsRange {
+  summary: {
+    activeBackgroundJobs: number
+    activeRemoteDownloads: number
+    onlineDownloaders: number
+    offlineDownloaders: number
+    backgroundJobFailureRate: number | null
+    remoteDownloadSuccessRate: number | null
+    cloudReportBacklog: number
+    webhookFailures: number
+  }
+  trend: Array<{
+    date: string
+    completedJobs: number
+    failedJobs: number
+    completedRemoteDownloads: number
+    failedRemoteDownloads: number
+  }>
+  backgroundJobOutcomes: Array<{ name: string; value: number; percent: number }>
+  remoteDownloadOutcomes: Array<{ name: string; value: number; percent: number }>
+  downloaderStatus: Array<{ name: string; value: number; percent: number }>
+  cloudReportStatus: Array<{ name: string; value: number; percent: number }>
 }

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -211,14 +211,13 @@ export interface PaginatedResponse<T> {
 
 export type {
   AdminDashboardGrowthStats,
+  AdminDashboardOperationsStats,
   AdminDashboardOverviewStats,
-  AdminDashboardRankingStats,
   AdminDashboardSharingStats,
   AdminDashboardStorageStats,
   AdminDashboardTrafficStats,
   AdminStatsDelta,
   AdminStatsRange,
-  AdminStorageByType,
   AdminTopShare,
   AdminTransferDataQuality,
   AdminUsageBySpace,

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -40,8 +40,8 @@ import {
   enableIhostFeature,
   generateInviteCodes,
   getAdminDashboardGrowthStats,
+  getAdminDashboardOperationsStats,
   getAdminDashboardOverviewStats,
-  getAdminDashboardRankingStats,
   getAdminDashboardSharingStats,
   getAdminDashboardStorageStats,
   getAdminDashboardTrafficStats,
@@ -3828,11 +3828,15 @@ describe('api', () => {
     }
     const dashboardEndpoints = [
       { name: 'getAdminDashboardOverviewStats', path: '/api/site/stats/overview', fn: getAdminDashboardOverviewStats },
+      {
+        name: 'getAdminDashboardOperationsStats',
+        path: '/api/site/stats/operations',
+        fn: getAdminDashboardOperationsStats,
+      },
       { name: 'getAdminDashboardGrowthStats', path: '/api/site/stats/growth', fn: getAdminDashboardGrowthStats },
       { name: 'getAdminDashboardStorageStats', path: '/api/site/stats/storage', fn: getAdminDashboardStorageStats },
       { name: 'getAdminDashboardTrafficStats', path: '/api/site/stats/traffic', fn: getAdminDashboardTrafficStats },
       { name: 'getAdminDashboardSharingStats', path: '/api/site/stats/sharing', fn: getAdminDashboardSharingStats },
-      { name: 'getAdminDashboardRankingStats', path: '/api/site/stats/ranking', fn: getAdminDashboardRankingStats },
     ] as const
 
     for (const endpoint of dashboardEndpoints) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -26,8 +26,8 @@ import type {
   ActivityEvent,
   AdminAuditEvent,
   AdminDashboardGrowthStats,
+  AdminDashboardOperationsStats,
   AdminDashboardOverviewStats,
-  AdminDashboardRankingStats,
   AdminDashboardSharingStats,
   AdminDashboardStorageStats,
   AdminDashboardTrafficStats,
@@ -452,6 +452,10 @@ export function getAdminDashboardOverviewStats(filter: AdminStatsRangeFilter = {
   return unwrap<AdminDashboardOverviewStats>(siteStatsApi.overview.$get({ query: statsRangeQuery(filter) }))
 }
 
+export function getAdminDashboardOperationsStats(filter: AdminStatsRangeFilter = {}) {
+  return unwrap<AdminDashboardOperationsStats>(siteStatsApi.operations.$get({ query: statsRangeQuery(filter) }))
+}
+
 export function getAdminDashboardGrowthStats(filter: AdminStatsRangeFilter = {}) {
   return unwrap<AdminDashboardGrowthStats>(siteStatsApi.growth.$get({ query: statsRangeQuery(filter) }))
 }
@@ -466,10 +470,6 @@ export function getAdminDashboardTrafficStats(filter: AdminStatsRangeFilter = {}
 
 export function getAdminDashboardSharingStats(filter: AdminStatsRangeFilter = {}) {
   return unwrap<AdminDashboardSharingStats>(siteStatsApi.sharing.$get({ query: statsRangeQuery(filter) }))
-}
-
-export function getAdminDashboardRankingStats(filter: AdminStatsRangeFilter = {}) {
-  return unwrap<AdminDashboardRankingStats>(siteStatsApi.ranking.$get({ query: statsRangeQuery(filter) }))
 }
 
 // Admin Storages API

--- a/src/routes/_authenticated/admin/index.test.tsx
+++ b/src/routes/_authenticated/admin/index.test.tsx
@@ -1,13 +1,14 @@
-import type { AdminDashboardOverviewStats } from '@shared/types'
+import type { AdminDashboardOperationsStats, AdminDashboardOverviewStats } from '@shared/types'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useEntitlement } from '@/hooks/useEntitlement'
 import {
   getAdminDashboardGrowthStats,
+  getAdminDashboardOperationsStats,
   getAdminDashboardOverviewStats,
-  getAdminDashboardRankingStats,
   getAdminDashboardSharingStats,
   getAdminDashboardStorageStats,
   getAdminDashboardTrafficStats,
@@ -33,11 +34,11 @@ vi.mock('@/hooks/useEntitlement', () => ({
 
 vi.mock('@/lib/api', () => ({
   getAdminDashboardOverviewStats: vi.fn(),
+  getAdminDashboardOperationsStats: vi.fn(),
   getAdminDashboardGrowthStats: vi.fn(),
   getAdminDashboardStorageStats: vi.fn(),
   getAdminDashboardTrafficStats: vi.fn(),
   getAdminDashboardSharingStats: vi.fn(),
-  getAdminDashboardRankingStats: vi.fn(),
 }))
 
 const overviewStats: AdminDashboardOverviewStats = {
@@ -73,6 +74,27 @@ const overviewStats: AdminDashboardOverviewStats = {
       downloadBytes: 384,
     },
   ],
+}
+
+const operationsStats: AdminDashboardOperationsStats = {
+  generatedAt: '2026-07-09T00:00:00.000Z',
+  from: '2026-07-01T00:00:00.000Z',
+  to: '2026-07-09T00:00:00.000Z',
+  summary: {
+    activeBackgroundJobs: 2,
+    activeRemoteDownloads: 3,
+    onlineDownloaders: 4,
+    offlineDownloaders: 1,
+    backgroundJobFailureRate: 5,
+    remoteDownloadSuccessRate: 95,
+    cloudReportBacklog: 6,
+    webhookFailures: 7,
+  },
+  trend: [],
+  backgroundJobOutcomes: [],
+  remoteDownloadOutcomes: [],
+  downloaderStatus: [],
+  cloudReportStatus: [],
 }
 
 function renderOverviewPage() {
@@ -117,7 +139,7 @@ describe('Admin overview dashboard', () => {
     expect(getAdminDashboardStorageStats).not.toHaveBeenCalled()
     expect(getAdminDashboardTrafficStats).not.toHaveBeenCalled()
     expect(getAdminDashboardSharingStats).not.toHaveBeenCalled()
-    expect(getAdminDashboardRankingStats).not.toHaveBeenCalled()
+    expect(getAdminDashboardOperationsStats).not.toHaveBeenCalled()
   })
 
   it('warns when historical transfer bytes are incomplete', async () => {
@@ -140,5 +162,29 @@ describe('Admin overview dashboard', () => {
 
     expect(await screen.findByText('历史数据不完整')).toBeTruthy()
     expect(screen.getByText(/当前区间有 3条/)).toBeTruthy()
+  })
+
+  it('loads the operations dashboard only when an entitled admin expands it', async () => {
+    const user = userEvent.setup()
+    vi.mocked(useEntitlement).mockReturnValue({
+      bound: true,
+      active: true,
+      edition: 'pro',
+      licenseId: 'license-1',
+      cloudDashboardUrl: null,
+      hasFeature: (feature) => feature === 'analytics',
+      isLoading: false,
+      isError: false,
+    })
+    vi.mocked(getAdminDashboardOverviewStats).mockResolvedValue(overviewStats)
+    vi.mocked(getAdminDashboardOperationsStats).mockResolvedValue(operationsStats)
+
+    renderOverviewPage()
+    expect(getAdminDashboardOperationsStats).not.toHaveBeenCalled()
+
+    await user.click(screen.getByText('运行状态'))
+
+    expect(await screen.findByText('后台任务')).toBeTruthy()
+    expect(getAdminDashboardOperationsStats).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/routes/_authenticated/admin/index.tsx
+++ b/src/routes/_authenticated/admin/index.tsx
@@ -1,7 +1,7 @@
 import type {
   AdminDashboardGrowthStats,
+  AdminDashboardOperationsStats,
   AdminDashboardOverviewStats,
-  AdminDashboardRankingStats,
   AdminDashboardSharingStats,
   AdminDashboardStorageStats,
   AdminDashboardTrafficStats,
@@ -10,10 +10,6 @@ import type {
 import { useQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { endOfDay, endOfMonth, format, startOfDay, startOfMonth, subDays, subMonths } from 'date-fns'
-import { FunnelChart as EChartsFunnelChart } from 'echarts/charts'
-import { TooltipComponent } from 'echarts/components'
-import * as echarts from 'echarts/core'
-import { CanvasRenderer } from 'echarts/renderers'
 import {
   Activity,
   BarChart3,
@@ -32,7 +28,7 @@ import {
   UploadCloud,
   Users,
 } from 'lucide-react'
-import { type CSSProperties, type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
+import { type CSSProperties, type ReactNode, useMemo, useState } from 'react'
 import type { DateRange } from 'react-day-picker'
 import {
   Area,
@@ -65,8 +61,8 @@ import { useEntitlement } from '@/hooks/useEntitlement'
 import {
   type AdminStatsRangeFilter,
   getAdminDashboardGrowthStats,
+  getAdminDashboardOperationsStats,
   getAdminDashboardOverviewStats,
-  getAdminDashboardRankingStats,
   getAdminDashboardSharingStats,
   getAdminDashboardStorageStats,
   getAdminDashboardTrafficStats,
@@ -74,13 +70,11 @@ import {
 import { formatSize } from '@/lib/format'
 import { cn } from '@/lib/utils'
 
-echarts.use([EChartsFunnelChart, TooltipComponent, CanvasRenderer])
-
 export const Route = createFileRoute('/_authenticated/admin/')({
   component: OverviewPage,
 })
 
-type SectionId = 'overview' | 'growth' | 'storage' | 'traffic' | 'sharing' | 'ranking'
+type SectionId = 'overview' | 'growth' | 'storage' | 'traffic' | 'sharing' | 'operations'
 
 const COLORS = {
   blue: '#0369a1',
@@ -138,28 +132,28 @@ const SECTION_META: Array<{
   {
     id: 'storage',
     title: '存储与文件',
-    description: '观察容量增长、文件结构、冷文件和大对象占用。',
+    description: '观察容量水位、文件结构、文件年龄和大对象占用。',
     badges: ['Pro+'],
     icon: HardDrive,
   },
   {
     id: 'traffic',
     title: '流量与传输',
-    description: '观察上传下载流量、请求量、成功率和带宽压力。',
+    description: '观察确认上传、下载签发、失败率和计量状态。',
     badges: ['Pro+'],
     icon: UploadCloud,
   },
   {
     id: 'sharing',
     title: '分享与访问',
-    description: '观察分享创建、访问打开、下载完成和转存转化。',
+    description: '观察分享创建、访问、下载签发和转存行为。',
     badges: ['Pro+'],
     icon: Share2,
   },
   {
-    id: 'ranking',
-    title: '用户与空间排行',
-    description: '看资源消耗集中在哪些用户、空间和文件。',
+    id: 'operations',
+    title: '运行状态',
+    description: '检查后台任务、远程下载、下载器和计量上报健康。',
     badges: ['Pro+'],
     icon: Network,
   },
@@ -205,12 +199,12 @@ export function OverviewPage() {
     hasAnalytics,
     getAdminDashboardSharingStats,
   )
-  const rankingQuery = useDashboardSectionQuery(
-    'ranking',
-    ranges.ranking,
+  const operationsQuery = useDashboardSectionQuery(
+    'operations',
+    ranges.operations,
     openSections,
     hasAnalytics,
-    getAdminDashboardRankingStats,
+    getAdminDashboardOperationsStats,
   )
 
   function updateRange(section: SectionId, range: DateRange) {
@@ -259,7 +253,7 @@ export function OverviewPage() {
               ) : section.id === 'sharing' ? (
                 <QueryState query={sharingQuery}>{(data) => <SharingSection stats={data} />}</QueryState>
               ) : (
-                <QueryState query={rankingQuery}>{(data) => <RankingSection stats={data} />}</QueryState>
+                <QueryState query={operationsQuery}>{(data) => <OperationsSection stats={data} />}</QueryState>
               )}
             </DashboardSection>
           ))}
@@ -425,7 +419,7 @@ function DateRangePicker({ value, onChange }: { value: DateRange; onChange: (ran
 function OverviewSection({ stats }: { stats: AdminDashboardOverviewStats }) {
   const cards = [
     {
-      label: '注册用户',
+      label: '当前注册用户',
       value: formatNumber(stats.totals.users),
       delta: formatDelta(stats.totals.newUsers),
       icon: Users,
@@ -435,7 +429,7 @@ function OverviewSection({ stats }: { stats: AdminDashboardOverviewStats }) {
       ],
     },
     {
-      label: '活跃用户',
+      label: '周期活跃用户',
       value: formatNumber(stats.totals.activeUsers.value),
       delta: formatDelta(stats.totals.activeUsers),
       icon: TrendingUp,
@@ -445,7 +439,7 @@ function OverviewSection({ stats }: { stats: AdminDashboardOverviewStats }) {
       ],
     },
     {
-      label: '存储占用',
+      label: '当前存储占用',
       value: formatSize(stats.totals.storageUsedBytes),
       delta: formatDelta(stats.totals.uploadBytes, formatSize),
       icon: Database,
@@ -455,7 +449,7 @@ function OverviewSection({ stats }: { stats: AdminDashboardOverviewStats }) {
       ],
     },
     {
-      label: '流量统计',
+      label: '确认/签发字节',
       value: formatSize(stats.totals.trafficBytes.value),
       delta: formatDelta(stats.totals.trafficBytes, formatSize),
       icon: Network,
@@ -516,7 +510,7 @@ function OverviewSection({ stats }: { stats: AdminDashboardOverviewStats }) {
           </ComposedChart>
         </ResponsiveContainer>
       </ChartCard>
-      <ChartCard title="资源消耗趋势" subtitle="存储总量、上传量和下载流量使用双轴，保留容量水位与每日传输之间的关系。">
+      <ChartCard title="资源消耗趋势" subtitle="存储水位、确认上传字节和下载签发字节按用户所选时区聚合。">
         <ResponsiveContainer width="100%" height="100%">
           <ComposedChart data={stats.trends} margin={{ top: 12, right: 12, left: 0, bottom: 0 }}>
             <CartesianGrid stroke={CHART_GRID_COLOR} strokeDasharray="3 3" vertical={false} />
@@ -542,8 +536,8 @@ function OverviewSection({ stats }: { stats: AdminDashboardOverviewStats }) {
               formatter={chartTooltipFormatter}
             />
             <Legend iconType="circle" wrapperStyle={{ fontSize: 12 }} />
-            <Bar yAxisId="bytes" dataKey="uploadBytes" name="上传量" fill={CHART_COLORS[1]} radius={[4, 4, 0, 0]} />
-            <Bar yAxisId="bytes" dataKey="downloadBytes" name="下载流量" fill={CHART_COLORS[2]} radius={[4, 4, 0, 0]} />
+            <Bar yAxisId="bytes" dataKey="uploadBytes" name="确认上传" fill={CHART_COLORS[1]} radius={[4, 4, 0, 0]} />
+            <Bar yAxisId="bytes" dataKey="downloadBytes" name="下载签发" fill={CHART_COLORS[2]} radius={[4, 4, 0, 0]} />
             <Line
               yAxisId="bytes"
               type="monotone"
@@ -694,17 +688,17 @@ function StorageSection({ stats }: { stats: AdminDashboardStorageStats }) {
           ]}
         />
         <StatCard
-          label="新增容量"
+          label="确认写入字节"
           value={formatSize(stats.summary.newBytes.value)}
           delta={formatDelta(stats.summary.newBytes, formatSize)}
           icon={Upload}
           metrics={[
-            { label: '新增文件', value: formatNumber(stats.summary.newFiles.value) },
+            { label: '确认上传文件', value: formatNumber(stats.summary.newFiles.value) },
             { label: '上期容量', value: formatSize(stats.summary.newBytes.previousValue) },
           ]}
         />
         <StatCard
-          label="新增文件"
+          label="确认上传文件"
           value={formatNumber(stats.summary.newFiles.value)}
           delta={formatDelta(stats.summary.newFiles)}
           icon={Database}
@@ -714,12 +708,12 @@ function StorageSection({ stats }: { stats: AdminDashboardStorageStats }) {
           ]}
         />
         <StatCard
-          label="冷文件容量"
+          label="90 天以上文件"
           value={formatSize(stats.summary.coldFileBytes)}
           icon={FileClock}
           metrics={[
             {
-              label: '冷文件占比',
+              label: '年龄文件占比',
               value: formatPercent(ratio(stats.summary.coldFileBytes, stats.summary.storageUsedBytes)),
             },
             { label: '当前占用', value: formatSize(stats.summary.storageUsedBytes) },
@@ -727,8 +721,44 @@ function StorageSection({ stats }: { stats: AdminDashboardStorageStats }) {
         />
       </div>
       <TransferDataQualityNotice quality={stats.dataQuality} />
+      <ChartCard
+        title="空间配额压力"
+        subtitle={`全部空间中 ${stats.summary.nearQuotaSpaces} 个达到 80%，${stats.summary.overQuotaSpaces} 个达到或超过配额。`}
+        contentClassName="h-auto"
+      >
+        {stats.topSpaces.length === 0 ? (
+          <EmptyState />
+        ) : (
+          <div className="overflow-hidden rounded-lg border border-border/50">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>空间</TableHead>
+                  <TableHead>类型</TableHead>
+                  <TableHead className="text-right">占用</TableHead>
+                  <TableHead className="text-right">配额</TableHead>
+                  <TableHead className="text-right">使用率</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {stats.topSpaces.map((space) => (
+                  <TableRow key={space.orgId}>
+                    <TableCell className="max-w-60 truncate font-medium" title={space.orgName}>
+                      {space.orgName}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">{labelize(space.orgType)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{formatSize(space.usedBytes)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{formatSize(space.quotaBytes)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{formatPercent(space.utilization)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </ChartCard>
       <div className="grid gap-4 xl:grid-cols-2">
-        <ChartCard title="存储增长趋势" subtitle="柱形看新增文件，折线看总容量水位和新增容量。">
+        <ChartCard title="存储与写入趋势" subtitle="存储占用是水位；确认上传文件和字节是周期事件量，不代表净增长。">
           <ResponsiveContainer width="100%" height="100%">
             <ComposedChart data={stats.storageTrend}>
               <CartesianGrid stroke={CHART_GRID_COLOR} strokeDasharray="3 3" vertical={false} />
@@ -756,7 +786,13 @@ function StorageSection({ stats }: { stats: AdminDashboardStorageStats }) {
                 formatter={chartTooltipFormatter}
               />
               <Legend iconType="circle" wrapperStyle={{ fontSize: 12 }} />
-              <Bar yAxisId="files" dataKey="newFiles" name="新增文件" fill={CHART_COLORS[1]} radius={[4, 4, 0, 0]} />
+              <Bar
+                yAxisId="files"
+                dataKey="newFiles"
+                name="确认上传文件"
+                fill={CHART_COLORS[1]}
+                radius={[4, 4, 0, 0]}
+              />
               <Line
                 yAxisId="bytes"
                 type="monotone"
@@ -770,7 +806,7 @@ function StorageSection({ stats }: { stats: AdminDashboardStorageStats }) {
                 yAxisId="bytes"
                 type="monotone"
                 dataKey="newBytes"
-                name="新增容量"
+                name="确认写入字节"
                 stroke={CHART_COLORS[2]}
                 strokeWidth={2}
                 dot={false}
@@ -835,7 +871,7 @@ function StorageSection({ stats }: { stats: AdminDashboardStorageStats }) {
             </ComposedChart>
           </ResponsiveContainer>
         </ChartCard>
-        <ChartCard title="文件年龄分布" subtitle="区分近期文件和冷文件容量，判断清理与归档空间。">
+        <ChartCard title="文件年龄分布" subtitle="仅按创建时间划分，不代表文件最近是否被访问。">
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={stats.ageBreakdown} margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
               <CartesianGrid stroke={CHART_GRID_COLOR} strokeDasharray="3 3" vertical={false} />
@@ -865,12 +901,12 @@ function TrafficSection({ stats }: { stats: AdminDashboardTrafficStats }) {
     <div className="flex flex-col gap-4">
       <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
         <StatCard
-          label="总流量"
+          label="确认/签发字节"
           value={formatSize(stats.summary.totalBytes.value)}
           delta={formatDelta(stats.summary.totalBytes, formatSize)}
           icon={Network}
           metrics={[
-            { label: '峰值日流量', value: formatSize(stats.summary.peakDailyBytes) },
+            { label: '峰值日字节', value: formatSize(stats.summary.peakDailyBytes) },
             { label: '请求量', value: formatNumber(stats.summary.requestCount.value) },
           ]}
         />
@@ -881,31 +917,34 @@ function TrafficSection({ stats }: { stats: AdminDashboardTrafficStats }) {
           icon={Activity}
           metrics={[
             { label: '下载签发', value: formatNumber(stats.summary.issuedDownloads) },
-            { label: '拦截请求', value: formatNumber(stats.summary.blockedDownloads) },
+            { label: '签发失败', value: formatNumber(stats.summary.blockedDownloads) },
           ]}
         />
         <StatCard
-          label="签发放行率"
+          label="下载签发成功率"
           value={formatPercent(stats.summary.issueRate)}
           icon={Download}
           metrics={[
             { label: '签发成功', value: formatNumber(stats.summary.issuedDownloads) },
-            { label: '计量拦截', value: formatNumber(stats.summary.blockedDownloads) },
+            { label: '签发失败', value: formatNumber(stats.summary.blockedDownloads) },
           ]}
         />
         <StatCard
-          label="峰值日流量"
+          label="峰值日字节"
           value={formatSize(stats.summary.peakDailyBytes)}
           icon={TrendingUp}
           metrics={[
-            { label: '统计口径', value: '签发/计费流量' },
-            { label: '总流量', value: formatSize(stats.summary.totalBytes.value) },
+            { label: '统计口径', value: '确认上传 + 下载签发' },
+            { label: '周期总量', value: formatSize(stats.summary.totalBytes.value) },
           ]}
         />
       </div>
       <TransferDataQualityNotice quality={stats.dataQuality} />
       <div className="grid gap-4 xl:grid-cols-2">
-        <ChartCard title="流量与请求趋势" subtitle="柱形看请求量，折线看上传下载流量。">
+        <ChartCard
+          title="传输事件趋势"
+          subtitle="上传为确认完成字节，下载为链接签发对象字节，不代表客户端实际完成传输。"
+        >
           <ResponsiveContainer width="100%" height="100%">
             <ComposedChart data={stats.trafficTrend}>
               <CartesianGrid stroke={CHART_GRID_COLOR} strokeDasharray="3 3" vertical={false} />
@@ -938,7 +977,7 @@ function TrafficSection({ stats }: { stats: AdminDashboardTrafficStats }) {
                 yAxisId="bytes"
                 type="monotone"
                 dataKey="uploadBytes"
-                name="上传流量"
+                name="确认上传字节"
                 stroke={CHART_COLORS[0]}
                 strokeWidth={2}
                 dot={false}
@@ -947,7 +986,7 @@ function TrafficSection({ stats }: { stats: AdminDashboardTrafficStats }) {
                 yAxisId="bytes"
                 type="monotone"
                 dataKey="downloadBytes"
-                name="下载流量"
+                name="下载签发字节"
                 stroke={CHART_COLORS[2]}
                 strokeWidth={2}
                 dot={false}
@@ -955,31 +994,17 @@ function TrafficSection({ stats }: { stats: AdminDashboardTrafficStats }) {
             </ComposedChart>
           </ResponsiveContainer>
         </ChartCard>
-        <ChartCard title="带宽压力趋势" subtitle="按日流量水位观察带宽和成本压力。">
-          <ResponsiveContainer width="100%" height="100%">
-            <AreaChart data={stats.bandwidthTrend}>
-              <CartesianGrid stroke={CHART_GRID_COLOR} strokeDasharray="3 3" vertical={false} />
-              <XAxis dataKey="date" tickLine={false} axisLine={false} fontSize={12} tickFormatter={formatChartDate} />
-              <YAxis tickLine={false} axisLine={false} fontSize={12} width={58} tickFormatter={formatCompactSize} />
-              <RechartsTooltip
-                contentStyle={tooltipContentStyle}
-                labelStyle={tooltipLabelStyle}
-                formatter={chartTooltipFormatter}
-              />
-              <Area
-                type="monotone"
-                dataKey="bytes"
-                name="日流量"
-                stroke={CHART_COLORS[0]}
-                fill={CHART_COLORS[0]}
-                fillOpacity={0.1}
-              />
-            </AreaChart>
-          </ResponsiveContainer>
-        </ChartCard>
+        <BreakdownChart
+          title="传输来源分布"
+          rows={stats.sourceBreakdown.map((row) => ({ name: row.name, value: row.bytes, percent: row.percent }))}
+          valueFormatter={formatSize}
+        />
       </div>
       <div className="grid gap-4 xl:grid-cols-2">
-        <ChartCard title="传输成功率" subtitle="成功率适合趋势图，而不是排行或占比图。">
+        <ChartCard
+          title="签发与确认成功率"
+          subtitle="上传成功指完成确认；下载成功指成功签发链接，不代表客户端下载完成。"
+        >
           <ResponsiveContainer width="100%" height="100%">
             <AreaChart data={stats.successTrend} margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
               <CartesianGrid stroke={CHART_GRID_COLOR} strokeDasharray="3 3" vertical={false} />
@@ -1129,15 +1154,8 @@ function SharingSection({ stats }: { stats: AdminDashboardSharingStats }) {
           ]}
         />
       </div>
-      <div className="grid gap-4 xl:grid-cols-2">
-        <ChartCard
-          title="分享转化漏斗"
-          subtitle="按访问、落地页下载、转存展示同一条分享链路；密码通过单独统计。"
-          contentClassName="h-auto min-h-[22rem]"
-        >
-          <FunnelChart data={stats.funnel} />
-        </ChartCard>
-        <ChartCard title="访问行为趋势" subtitle="访问、下载和转存放在同一时间轴看转化变化。">
+      <div className="grid gap-4">
+        <ChartCard title="访问行为趋势" subtitle="这些是独立事件量，不表示同一访客完成了连续漏斗。">
           <ResponsiveContainer width="100%" height="100%">
             <AreaChart data={stats.trend}>
               <CartesianGrid stroke={CHART_GRID_COLOR} strokeDasharray="3 3" vertical={false} />
@@ -1186,44 +1204,84 @@ function SharingSection({ stats }: { stats: AdminDashboardSharingStats }) {
   )
 }
 
-function RankingSection({ stats }: { stats: AdminDashboardRankingStats }) {
-  const totalTypeBytes = stats.storageByType.reduce((sum, row) => sum + row.bytes, 0)
-
+function OperationsSection({ stats }: { stats: AdminDashboardOperationsStats }) {
   return (
-    <div className="grid gap-4 xl:grid-cols-3">
-      <TopRankingCard
-        title="新增容量 Top 空间"
-        description="每项显示统计周期内新增容量。"
-        items={stats.topSpaces.map((space) => ({
-          name: space.orgName,
-          detail: space.orgType,
-          value: formatSize(space.usedBytes),
-          percent: space.utilization,
-        }))}
-        totalLabel={`Top ${Math.min(4, stats.topSpaces.length)} 空间`}
-      />
-      <TopRankingCard
-        title="访问 Top 分享"
-        description="每项占统计周期内分享访问百分比。"
-        items={stats.topShares.map((share) => ({
-          name: share.name,
-          detail: share.creatorName,
-          value: formatNumber(share.views),
-          percent: share.viewPercent,
-        }))}
-        totalLabel={`Top ${Math.min(4, stats.topShares.length)} 分享`}
-      />
-      <TopRankingCard
-        title="文件类型排行"
-        description="每项占统计周期内新增文件容量百分比。"
-        items={stats.storageByType.map((row) => ({
-          name: labelize(row.type),
-          detail: `${formatNumber(row.files)} files`,
-          value: formatSize(row.bytes),
-          percent: ratio(row.bytes, totalTypeBytes),
-        }))}
-        totalLabel={`Top ${Math.min(4, stats.storageByType.length)} 类型`}
-      />
+    <div className="flex flex-col gap-4">
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <StatCard
+          label="后台任务"
+          value={formatNumber(stats.summary.activeBackgroundJobs)}
+          icon={Activity}
+          metrics={[
+            { label: '运行中', value: formatNumber(stats.summary.activeBackgroundJobs) },
+            { label: '失败率', value: formatPercent(stats.summary.backgroundJobFailureRate) },
+          ]}
+        />
+        <StatCard
+          label="远程下载"
+          value={formatNumber(stats.summary.activeRemoteDownloads)}
+          icon={Download}
+          metrics={[
+            { label: '活跃任务', value: formatNumber(stats.summary.activeRemoteDownloads) },
+            { label: '成功率', value: formatPercent(stats.summary.remoteDownloadSuccessRate) },
+          ]}
+        />
+        <StatCard
+          label="下载器在线"
+          value={formatNumber(stats.summary.onlineDownloaders)}
+          icon={Network}
+          metrics={[
+            { label: '在线', value: formatNumber(stats.summary.onlineDownloaders) },
+            { label: '离线/禁用', value: formatNumber(stats.summary.offlineDownloaders) },
+          ]}
+        />
+        <StatCard
+          label="待处理异常"
+          value={formatNumber(stats.summary.cloudReportBacklog + stats.summary.webhookFailures)}
+          icon={FileClock}
+          metrics={[
+            { label: '计量积压', value: formatNumber(stats.summary.cloudReportBacklog) },
+            { label: 'Webhook 失败', value: formatNumber(stats.summary.webhookFailures) },
+          ]}
+        />
+      </div>
+      <ChartCard title="任务完成趋势" subtitle="完成与失败分别统计，快速定位后台任务或远程下载异常。">
+        <ResponsiveContainer width="100%" height="100%">
+          <ComposedChart data={stats.trend}>
+            <CartesianGrid stroke={CHART_GRID_COLOR} strokeDasharray="3 3" vertical={false} />
+            <XAxis dataKey="date" tickLine={false} axisLine={false} fontSize={12} tickFormatter={formatChartDate} />
+            <YAxis tickLine={false} axisLine={false} fontSize={12} width={48} tickFormatter={formatCompactNumber} />
+            <RechartsTooltip
+              contentStyle={tooltipContentStyle}
+              labelStyle={tooltipLabelStyle}
+              formatter={chartTooltipFormatter}
+            />
+            <Legend iconType="circle" wrapperStyle={{ fontSize: 12 }} />
+            <Bar dataKey="completedJobs" name="后台任务完成" fill={CHART_COLORS[1]} radius={[4, 4, 0, 0]} />
+            <Bar dataKey="failedJobs" name="后台任务失败" fill={CHART_COLORS[4]} radius={[4, 4, 0, 0]} />
+            <Line
+              dataKey="completedRemoteDownloads"
+              name="远程下载完成"
+              stroke={CHART_COLORS[0]}
+              strokeWidth={2}
+              dot={false}
+            />
+            <Line
+              dataKey="failedRemoteDownloads"
+              name="远程下载失败"
+              stroke={CHART_COLORS[2]}
+              strokeWidth={2}
+              dot={false}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </ChartCard>
+      <div className="grid gap-4 xl:grid-cols-2">
+        <BarBreakdownChart title="后台任务结果" rows={stats.backgroundJobOutcomes} valueFormatter={formatNumber} />
+        <BarBreakdownChart title="远程下载结果" rows={stats.remoteDownloadOutcomes} valueFormatter={formatNumber} />
+        <BreakdownChart title="下载器状态" rows={stats.downloaderStatus} valueFormatter={formatNumber} />
+        <BreakdownChart title="计量上报状态" rows={stats.cloudReportStatus} valueFormatter={formatNumber} />
+      </div>
     </div>
   )
 }
@@ -1407,121 +1465,6 @@ function PercentList({ items }: { items: Array<{ name: string; percent: number; 
   )
 }
 
-function FunnelChart({ data }: { data: Array<{ name: string; value: number; percent: number }> }) {
-  return (
-    <div className="grid min-h-[22rem] min-w-0 gap-4 lg:grid-cols-[minmax(0,1fr)_220px]">
-      <EChartsFunnel data={data} />
-      <FunnelStageList data={data} />
-    </div>
-  )
-}
-
-function EChartsFunnel({ data }: { data: Array<{ name: string; value: number; percent: number }> }) {
-  const ref = useRef<HTMLDivElement | null>(null)
-  useEffect(() => {
-    if (!ref.current) return
-    const chart = echarts.init(ref.current, null, { renderer: 'canvas' })
-    chart.setOption({
-      backgroundColor: 'transparent',
-      color: data.map((_, index) => CHART_COLORS[index % CHART_COLORS.length]),
-      tooltip: {
-        trigger: 'item',
-        confine: true,
-        backgroundColor: 'var(--color-popover)',
-        borderColor: 'var(--color-border)',
-        borderWidth: 1,
-        padding: [8, 10],
-        textStyle: {
-          color: '#0f172a',
-          fontSize: 12,
-        },
-        formatter: ({ data: item }: { data: { name: string; value: number; percent: number } }) =>
-          `${labelize(item.name)}<br/>${formatCompactNumber(item.value)} · ${formatPercent(item.percent)}`,
-      },
-      series: [
-        {
-          type: 'funnel',
-          sort: 'none',
-          left: '8%',
-          top: 10,
-          bottom: 10,
-          width: '82%',
-          minSize: '26%',
-          maxSize: '100%',
-          gap: 3,
-          label: {
-            show: true,
-            position: 'inside',
-            color: '#ffffff',
-            fontSize: 12,
-            fontWeight: 700,
-            formatter: ({ data: item }: { data: { name: string } }) => labelize(item.name),
-          },
-          labelLine: {
-            show: false,
-          },
-          itemStyle: {
-            borderColor: '#ffffff',
-            borderWidth: 1.5,
-            borderRadius: 4,
-          },
-          emphasis: {
-            focus: 'self',
-            label: {
-              fontSize: 13,
-            },
-          },
-          data: data.map((item, index) => ({
-            name: item.name,
-            value: item.value,
-            percent: item.percent,
-            itemStyle: { color: CHART_COLORS[index % CHART_COLORS.length] },
-          })),
-        },
-      ],
-    })
-
-    const resizeObserver = new ResizeObserver(() => chart.resize())
-    resizeObserver.observe(ref.current)
-
-    return () => {
-      resizeObserver.disconnect()
-      chart.dispose()
-    }
-  }, [data])
-
-  return <div ref={ref} className="h-56 min-w-0 lg:h-auto lg:min-h-0" />
-}
-
-function FunnelStageList({ data }: { data: Array<{ name: string; value: number; percent: number }> }) {
-  return (
-    <div className="flex min-w-0 flex-col gap-2 lg:justify-center">
-      {data.map((item, index) => {
-        const previous = data[index - 1]
-        const stepRate = previous && previous.value > 0 ? (item.value / previous.value) * 100 : index === 0 ? 100 : 0
-
-        return (
-          <div key={item.name} className="rounded-lg border border-border/70 bg-canvas/55 px-3 py-1.5">
-            <div className="flex items-start justify-between gap-3">
-              <div className="min-w-0">
-                <p className="truncate text-sm font-medium">{labelize(item.name)}</p>
-                <p className="mt-0.5 text-xs text-muted-foreground">
-                  {index === 0 ? '入口基准' : `上一步 ${formatPercent(stepRate)}`}
-                </p>
-              </div>
-              <div className="shrink-0 text-right">
-                <p className="text-sm font-semibold tabular-nums">{formatCompactNumber(item.value)}</p>
-                <p className="text-xs text-muted-foreground">{formatPercent(item.percent)}</p>
-              </div>
-            </div>
-            <Progress value={clampPercent(item.percent)} className="mt-2 h-1.5 bg-muted" />
-          </div>
-        )
-      })}
-    </div>
-  )
-}
-
 function TopSharesTable({ rows }: { rows: AdminDashboardSharingStats['topShares'] }) {
   return (
     <ChartCard title="Top 分享" contentClassName="h-auto">
@@ -1558,52 +1501,6 @@ function TopSharesTable({ rows }: { rows: AdminDashboardSharingStats['topShares'
         </div>
       )}
     </ChartCard>
-  )
-}
-
-function TopRankingCard({
-  title,
-  description,
-  items,
-  totalLabel,
-}: {
-  title: string
-  description: string
-  totalLabel: string
-  items: Array<{ name: string; detail: string; value: string; percent: number }>
-}) {
-  return (
-    <div className="rounded-xl border border-border/70 bg-background/95 p-4 shadow-[0_14px_36px_-34px_rgba(15,23,42,0.6)] sm:p-5">
-      <div className="mb-4 flex items-start justify-between gap-3">
-        <div>
-          <h3 className="text-[15px] font-semibold tracking-tight">{title}</h3>
-          <p className="mt-1 text-[13px] leading-5 text-muted-foreground">{description}</p>
-        </div>
-        <Badge variant="outline" className="shrink-0">
-          {totalLabel}
-        </Badge>
-      </div>
-      <div className="flex flex-col gap-4">
-        {items.map((item, index) => (
-          <div key={item.name} className="flex flex-col gap-2">
-            <div className="flex items-start justify-between gap-3 text-sm">
-              <div className="min-w-0">
-                <p className="truncate font-medium">
-                  <span className="mr-2 text-muted-foreground">#{index + 1}</span>
-                  {item.name}
-                </p>
-                <p className="mt-0.5 truncate text-xs text-muted-foreground">{item.detail}</p>
-              </div>
-              <div className="shrink-0 text-right">
-                <p className="font-semibold tabular-nums">{item.value}</p>
-                <p className="text-xs text-muted-foreground">{formatPercent(item.percent)}</p>
-              </div>
-            </div>
-            <Progress value={clampPercent(item.percent)} className="h-1.5 bg-muted" />
-          </div>
-        ))}
-      </div>
-    </div>
   )
 }
 
@@ -1675,7 +1572,7 @@ function initialRanges(today: Date): Record<SectionId, DateRange> {
     storage: { from: startOfDay(subDays(today, 89)), to: endOfDay(today) },
     traffic: { from: startOfDay(subDays(today, 6)), to: endOfDay(today) },
     sharing: last30,
-    ranking: last30,
+    operations: last30,
   }
 }
 

--- a/workers/scheduled.ts
+++ b/workers/scheduled.ts
@@ -23,7 +23,6 @@ export interface ScheduledEnv {
 const TRAFFIC_SYNC_CRON = '*/10 * * * *'
 const QUOTA_RESET_CRON = '0 0 1 * *'
 const TRASH_PURGE_CRON = '0 4 * * *'
-const STATS_ROLLUP_CRON = '5 4 * * *'
 type ScheduledTrigger = Pick<ScheduledEvent, 'cron'>
 
 function envAllowsIp(value: string | undefined): boolean {
@@ -35,8 +34,11 @@ export async function handleScheduled(event: ScheduledTrigger, env: ScheduledEnv
   const deps = createDeps(platform)
   const cloudBaseUrl = env.ZPAN_CLOUD_URL ?? ZPAN_CLOUD_URL_DEFAULT
   if (event.cron === TRAFFIC_SYNC_CRON) {
-    await syncPendingCloudTrafficReports(deps, { cloudBaseUrl })
-    await syncPendingRemoteDownloadUsageReports(deps, { cloudBaseUrl })
+    await Promise.all([
+      syncPendingCloudTrafficReports(deps, { cloudBaseUrl }),
+      syncPendingRemoteDownloadUsageReports(deps, { cloudBaseUrl }),
+      deps.adminStats.refreshHourlyRollups(new Date()),
+    ])
     return
   }
 
@@ -47,11 +49,6 @@ export async function handleScheduled(event: ScheduledTrigger, env: ScheduledEnv
 
   if (event.cron === TRASH_PURGE_CRON) {
     await purgeExpiredTrash(deps, resolveTrashRetentionDays(env.ZPAN_TRASH_RETENTION_DAYS))
-    return
-  }
-
-  if (event.cron === STATS_ROLLUP_CRON) {
-    await deps.adminStats.writeStorageUsedRollup(new Date())
     return
   }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -38,7 +38,7 @@ bucket_name = "zpan-public-images"
 enabled = true
 
 [triggers]
-crons = ["*/10 * * * *", "0 */6 * * *", "0 */12 * * *", "0 0 1 * *", "0 4 * * *", "5 4 * * *"]
+crons = ["*/10 * * * *", "0 */6 * * *", "0 */12 * * *", "0 0 1 * *", "0 4 * * *"]
 
 # ----------------------------------------------------------------------------
 # Staging environment — used by non-production branch builds.


### PR DESCRIPTION
## What changed

- replace the daily stats table with one UTC hourly rollup table and a typed metric/dimension registry
- rebuild current/previous hours every ten minutes on Workers and Node, with atomic idempotent writes and completion markers
- route additive historical dashboard queries through hourly rollups, with exact raw fallback for incomplete and time-zone boundary hours
- interpret date-only ranges in the requested IANA time zone, including DST and non-whole-hour offsets
- add an Operations dashboard, move quota pressure into Storage, and remove the misleading Ranking, funnel, and duplicate bandwidth surfaces
- add an idempotent historical backfill that recovers audit metadata where possible and hard-fails on raw/rollup reconciliation mismatches
- document metric semantics, live-query exceptions, and the backfill/validation workflow

## Root cause

The previous implementation persisted only a narrow daily storage snapshot while most historical charts still scanned raw tables. It also mixed event outcomes with cloud metering state and interpreted date-only ranges as UTC, so long ranges were slow and local-day results could be wrong.

## Impact

Historical additive metrics now scale with hourly aggregate rows. Current-state metrics and exact DAU/WAU/MAU remain live by design. Existing daily rows are migrated in place; the backfill converts recoverable history without adding another table.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 194 files / 4,764 tests passed
- `pnpm test:cf` — 14 files / 61 tests passed
- `pnpm test:libsql` — full migration chain passed
- `pnpm build`
- `pnpm lint:arch && pnpm lint:http && pnpm lint:spec`
- isolated SQLite migration + dry-run/apply/re-apply backfill; reconciliation passed and the second run made no changes
- `pnpm e2e` — 82 passed; unrelated environment failures remain for missing local S3/Cloud credentials, announcement entitlement state, and two pre-existing preview route teardown races

Preview screenshots and the required PR verification comment will be added after the preview deployment is ready.