### PR TITLE
fix(downloads): protect remote download target folders

### DIFF
--- a/server/adapters/repos/download-task.ts
+++ b/server/adapters/repos/download-task.ts
@@ -1,6 +1,6 @@
 import { downloadTaskRuntimeSchema } from '@shared/schemas'
 import type { DownloadTask, DownloadTaskRuntime } from '@shared/types'
-import { and, asc, count, desc, eq, gte, inArray, isNull, like, notInArray, or, type SQL, sql } from 'drizzle-orm'
+import { and, asc, count, desc, eq, gte, inArray, isNull, like, ne, notInArray, or, type SQL, sql } from 'drizzle-orm'
 import { downloaders, downloadTasks } from '../../db/schema'
 import type { Database } from '../../platform/interface'
 import {
@@ -219,6 +219,28 @@ export function createDownloadTaskRepo(db: Database): DownloadTaskRepo {
     async findRecord(id) {
       const row = await findRow(id)
       return row ? toRecord(row) : null
+    },
+
+    async findActiveTargetWithin(orgId, folderPath) {
+      if (!folderPath) return null
+      const prefix = `${folderPath}/`
+      const rows = await db
+        .select()
+        .from(downloadTasks)
+        .where(
+          and(
+            eq(downloadTasks.orgId, orgId),
+            notInArray(downloadTasks.status, ['completed', 'failed', 'canceled']),
+            ne(downloadTasks.targetFolder, ''),
+            or(
+              eq(downloadTasks.targetFolder, folderPath),
+              sql`substr(${downloadTasks.targetFolder}, 1, length(${prefix})) = ${prefix}`,
+            ),
+          ),
+        )
+        .orderBy(asc(downloadTasks.createdAt))
+        .limit(1)
+      return rows[0] ? toRecord(rows[0]) : null
     },
 
     async setFields(id, fields: UpdateDownloadTaskFields) {

--- a/server/http/downloads/download-tasks.integration.test.ts
+++ b/server/http/downloads/download-tasks.integration.test.ts
@@ -700,6 +700,15 @@ describe('Download tasks API integration', () => {
     expect(recoverDownloadingTask?.status.assignment?.uploadToken).toBeTruthy()
     expect(recoverDownloadingTask?.status.assignment?.uploadToken).toBe(assignedTask?.status.assignment?.uploadToken)
 
+    // Simulate an out-of-band deletion between task creation and ingestion. The
+    // task upload preflight must recreate the target instead of producing an
+    // orphan path.
+    await db.run(sql`
+      UPDATE matters
+      SET trashed_at = ${Date.now()}
+      WHERE org_id = ${createdTask.orgId} AND parent = '' AND name = 'Remote Downloads'
+    `)
+
     const createFolderRes = await app.request('/api/objects', {
       method: 'POST',
       headers: uploadHeaders,
@@ -715,6 +724,16 @@ describe('Download tasks API integration', () => {
     expect(folder.status).toBe('active')
     expect(folder.name).toBe('fixture-dir')
     expect(folder.dirtype).toBe(1)
+    const liveTargets = await db.all<{ count: number }>(sql`
+      SELECT count(*) AS count
+      FROM matters
+      WHERE org_id = ${createdTask.orgId}
+        AND parent = ''
+        AND name = 'Remote Downloads'
+        AND status = 'active'
+        AND trashed_at IS NULL
+    `)
+    expect(liveTargets[0].count).toBe(1)
 
     const createNestedObjectRes = await app.request('/api/objects', {
       method: 'POST',
@@ -1359,7 +1378,8 @@ describe('Download tasks API integration', () => {
     })
 
     expect(createTaskRes.status).toBe(201)
-    await expect(createTaskRes.json()).resolves.toMatchObject({
+    const task = (await createTaskRes.json()) as DownloadTask
+    expect(task).toMatchObject({
       spec: { destination: { folder: 'media/Movies' } },
     })
 
@@ -1367,6 +1387,101 @@ describe('Download tasks API integration', () => {
       sql`SELECT target_folder FROM download_tasks ORDER BY created_at DESC LIMIT 1`,
     )
     expect(rows[0].target_folder).toBe('media/Movies')
+
+    const folders = await db.all<{ name: string; parent: string; status: string }>(sql`
+      SELECT name, parent, status
+      FROM matters
+      WHERE org_id = ${task.orgId} AND dirtype = 1
+      ORDER BY parent, name
+    `)
+    expect(folders).toEqual([
+      { name: 'media', parent: '', status: 'active' },
+      { name: 'Movies', parent: 'media', status: 'active' },
+    ])
+  })
+
+  it('rejects a target folder path that contains a file', async () => {
+    const { app, db } = await createTestApp()
+    await insertStorage(db)
+    const email = 'target-folder-file-user@example.com'
+    const user = await authedHeaders(app, email)
+    const orgRows = await db.all<{ orgId: string }>(sql`
+      SELECT m.organization_id AS orgId
+      FROM member m
+      JOIN user u ON u.id = m.user_id
+      WHERE u.email = ${email}
+      LIMIT 1
+    `)
+    const now = Math.floor(Date.now() / 1000)
+    await db.run(sql`
+      INSERT INTO matters (
+        id, org_id, alias, name, type, size, dirtype, parent, object,
+        storage_id, status, created_at, updated_at
+      ) VALUES (
+        'target-file', ${orgRows[0].orgId}, 'target-file-alias', 'media',
+        'text/plain', 1, 0, '', 'target-file-key', 'remote-download-storage',
+        'active', ${now}, ${now}
+      )
+    `)
+
+    const res = await app.request('/api/downloads/tasks', {
+      method: 'POST',
+      headers: { ...user, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        source: { type: 'http', uri: 'https://example.com/fixture.txt' },
+        targetFolder: 'media/Movies',
+      }),
+    })
+
+    expect(res.status).toBe(409)
+    const body = (await res.json()) as { error: { details: Array<{ reason: string }> } }
+    expect(body.error.details[0].reason).toBe('TARGET_FOLDER_NOT_DIRECTORY')
+    const tasks = await db.all<{ count: number }>(sql`SELECT count(*) AS count FROM download_tasks`)
+    expect(tasks[0].count).toBe(0)
+  })
+
+  it('blocks changes to an active task target folder and its ancestors', async () => {
+    const { app, db } = await createTestApp()
+    await insertStorage(db)
+    const user = await authedHeaders(app, 'occupied-target-user@example.com')
+    const createTaskRes = await app.request('/api/downloads/tasks', {
+      method: 'POST',
+      headers: { ...user, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        source: { type: 'http', uri: 'https://example.com/fixture.txt' },
+        targetFolder: 'media/Movies',
+      }),
+    })
+    expect(createTaskRes.status).toBe(201)
+    const task = (await createTaskRes.json()) as DownloadTask
+    const folders = await db.all<{ id: string; name: string }>(sql`
+      SELECT id, name FROM matters WHERE org_id = ${task.orgId} AND dirtype = 1
+    `)
+    const media = folders.find((folder) => folder.name === 'media')
+    const movies = folders.find((folder) => folder.name === 'Movies')
+    expect(media).toBeTruthy()
+    expect(movies).toBeTruthy()
+
+    const deleteAncestor = await app.request(`/api/objects/${media?.id}`, { method: 'DELETE', headers: user })
+    expect(deleteAncestor.status).toBe(409)
+    const deleteBody = (await deleteAncestor.json()) as {
+      error: { details: Array<{ reason: string; metadata: Record<string, string> }> }
+    }
+    expect(deleteBody.error.details[0]).toMatchObject({
+      reason: 'DIRECTORY_IN_USE',
+      metadata: { taskId: task.id, targetFolder: 'media/Movies' },
+    })
+
+    const renameTarget = await app.request(`/api/objects/${movies?.id}`, {
+      method: 'PATCH',
+      headers: { ...user, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Films' }),
+    })
+    expect(renameTarget.status).toBe(409)
+
+    await db.run(sql`UPDATE download_tasks SET status = 'completed' WHERE id = ${task.id}`)
+    const deleteAfterCompletion = await app.request(`/api/objects/${media?.id}`, { method: 'DELETE', headers: user })
+    expect(deleteAfterCompletion.status).toBe(204)
   })
 
   it('returns storage failure details when multipart upload completion fails [spec: download-tasks/upload-completion-failure]', async () => {

--- a/server/lib/http-errors.test.ts
+++ b/server/lib/http-errors.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  AppError,
   BackgroundJobError,
   DownloadError,
   NameConflictError,
@@ -50,6 +51,18 @@ describe('buildErrorBody', () => {
 
 describe('mapDomainError', () => {
   const reasonOf = (m: ReturnType<typeof mapDomainError>) => m?.json.error.details?.[0]?.reason
+
+  it('preserves AppError status, reason, and metadata for protocol handlers', () => {
+    const m = mapDomainError(
+      new AppError(409, 'Folder is in use by a download task', {
+        reason: 'DIRECTORY_IN_USE',
+        metadata: { taskId: 'task-1' },
+      }),
+    )
+    expect(m?.status).toBe(409)
+    expect(reasonOf(m)).toBe('DIRECTORY_IN_USE')
+    expect(m?.json.error.details?.[0]?.metadata).toEqual({ taskId: 'task-1' })
+  })
 
   it('maps StorageQuotaExceededError to 422 / RESOURCE_EXHAUSTED', () => {
     const m = mapDomainError(new StorageQuotaExceededError())

--- a/server/lib/http-errors.ts
+++ b/server/lib/http-errors.ts
@@ -8,6 +8,7 @@ import {
 } from '@shared/schemas'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import {
+  AppError,
   BackgroundJobError,
   DownloadError,
   NameConflictError,
@@ -67,6 +68,13 @@ const mapping = (status: ContentfulStatusCode, message: string, opts?: ErrorOpti
 // per-route try/catch. Returns null for errors we don't translate; `onError` then
 // falls back to a generic 500. To support a new domain error: add a branch here.
 export function mapDomainError(error: unknown): DomainErrorMapping | null {
+  if (error instanceof AppError) {
+    return mapping(error.httpStatus as ContentfulStatusCode, error.message, {
+      reason: error.meta.reason,
+      status: error.meta.canonicalStatus,
+      metadata: error.meta.metadata,
+    })
+  }
   if (error instanceof StorageQuotaExceededError) {
     return mapping(422, 'Quota exceeded', { reason: ErrorReason.QUOTA_EXCEEDED, status: 'RESOURCE_EXHAUSTED' })
   }

--- a/server/usecases/downloads/download-folders.test.ts
+++ b/server/usecases/downloads/download-folders.test.ts
@@ -1,0 +1,160 @@
+import { DirType } from '@shared/constants'
+import { describe, expect, it, vi } from 'vitest'
+import type { Deps } from '../deps'
+import type { Matter, MatterRepo, StorageRepo } from '../ports'
+import { NameConflictError } from '../ports'
+import { assertFolderNotUsedByDownload, ensureDownloadTargetFolder } from './download-folders'
+
+const folder = (name: string, parent = ''): Matter => ({
+  id: `${parent}/${name}`,
+  orgId: 'org-1',
+  alias: `${parent}/${name}-alias`,
+  name,
+  type: 'folder',
+  size: 0,
+  dirtype: DirType.USER_FOLDER,
+  parent,
+  object: '',
+  storageId: 'storage-1',
+  status: 'active',
+  trashedAt: null,
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+})
+
+function ensureDeps(
+  overrides: {
+    findActiveConflict?: MatterRepo['findActiveConflict']
+    create?: MatterRepo['create']
+    select?: StorageRepo['select']
+  } = {},
+): Pick<Deps, 'matter' | 'storages'> {
+  return {
+    matter: {
+      findActiveConflict: overrides.findActiveConflict ?? (async () => null),
+      create: overrides.create ?? (async (input) => folder(input.name, input.parent)),
+    } as MatterRepo,
+    storages: {
+      select: overrides.select ?? (async () => ({ id: 'storage-1' }) as never),
+    } as StorageRepo,
+  }
+}
+
+describe('download target folders', () => {
+  it('returns root without touching repositories', async () => {
+    const findActiveConflict = vi.fn()
+    const select = vi.fn()
+    await expect(
+      ensureDownloadTargetFolder(ensureDeps({ findActiveConflict, select }), {
+        orgId: 'org-1',
+        targetFolder: '',
+        actorId: 'user-1',
+      }),
+    ).resolves.toBe('')
+    expect(findActiveConflict).not.toHaveBeenCalled()
+    expect(select).not.toHaveBeenCalled()
+  })
+
+  it('reuses the winner when concurrent creation reports a name conflict', async () => {
+    const findActiveConflict = vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(folder('Downloads'))
+    const create = vi.fn(async () => {
+      throw new NameConflictError('Downloads', 'winner')
+    })
+
+    await expect(
+      ensureDownloadTargetFolder(ensureDeps({ findActiveConflict, create }), {
+        orgId: 'org-1',
+        targetFolder: 'Downloads',
+        actorId: 'user-1',
+      }),
+    ).resolves.toBe('Downloads')
+  })
+
+  it('reuses the winner after a database unique constraint race', async () => {
+    const findActiveConflict = vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(folder('Downloads'))
+    const create = vi.fn(async () => {
+      throw new Error('UNIQUE constraint failed: matters_active_name_uniq')
+    })
+
+    await expect(
+      ensureDownloadTargetFolder(ensureDeps({ findActiveConflict, create }), {
+        orgId: 'org-1',
+        targetFolder: 'Downloads',
+        actorId: 'user-1',
+      }),
+    ).resolves.toBe('Downloads')
+  })
+
+  it('preserves unexpected create failures and unresolved conflicts', async () => {
+    const unexpected = new Error('database unavailable')
+    await expect(
+      ensureDownloadTargetFolder(
+        ensureDeps({
+          create: async () => {
+            throw unexpected
+          },
+        }),
+        {
+          orgId: 'org-1',
+          targetFolder: 'Downloads',
+          actorId: 'user-1',
+        },
+      ),
+    ).rejects.toBe(unexpected)
+
+    const conflict = new NameConflictError('Downloads', 'winner')
+    await expect(
+      ensureDownloadTargetFolder(
+        ensureDeps({
+          create: async () => {
+            throw conflict
+          },
+        }),
+        {
+          orgId: 'org-1',
+          targetFolder: 'Downloads',
+          actorId: 'user-1',
+        },
+      ),
+    ).rejects.toBe(conflict)
+  })
+
+  it('rejects a file in the target path', async () => {
+    const file = { ...folder('Downloads'), type: 'text/plain', dirtype: DirType.FILE }
+    await expect(
+      ensureDownloadTargetFolder(ensureDeps({ findActiveConflict: async () => file }), {
+        orgId: 'org-1',
+        targetFolder: 'Downloads/Movies',
+        actorId: 'user-1',
+      }),
+    ).rejects.toMatchObject({
+      httpStatus: 409,
+      meta: { reason: 'TARGET_FOLDER_NOT_DIRECTORY', metadata: { path: 'Downloads' } },
+    })
+  })
+
+  it('skips files and rejects folders held by an active task', async () => {
+    const findActiveTargetWithin = vi.fn(async () => ({ id: 'task-1', targetFolder: 'Downloads/Movies' }) as never)
+    const deps = { downloadTasks: { findActiveTargetWithin } as unknown as Deps['downloadTasks'] }
+    await expect(
+      assertFolderNotUsedByDownload(deps, {
+        orgId: 'org-1',
+        folder: { ...folder('movie.mkv'), dirtype: DirType.FILE },
+      }),
+    ).resolves.toBeUndefined()
+    expect(findActiveTargetWithin).not.toHaveBeenCalled()
+
+    await expect(
+      assertFolderNotUsedByDownload(deps, {
+        orgId: 'org-1',
+        folder: folder('Downloads'),
+      }),
+    ).rejects.toMatchObject({
+      httpStatus: 409,
+      meta: {
+        reason: 'DIRECTORY_IN_USE',
+        metadata: { taskId: 'task-1', targetFolder: 'Downloads/Movies' },
+      },
+    })
+  })
+})

--- a/server/usecases/downloads/download-folders.ts
+++ b/server/usecases/downloads/download-folders.ts
@@ -1,0 +1,69 @@
+import { DirType, ObjectStatus } from '@shared/constants'
+import { formatError } from '../../lib/errors'
+import type { Deps } from '../deps'
+import { AppError, type Matter, NameConflictError } from '../ports'
+
+function joinPath(parent: string, name: string): string {
+  return parent ? `${parent}/${name}` : name
+}
+
+function targetIsFile(path: string): AppError {
+  return new AppError(409, 'Target folder path contains a file', {
+    reason: 'TARGET_FOLDER_NOT_DIRECTORY',
+    metadata: { path },
+  })
+}
+
+export async function ensureDownloadTargetFolder(
+  deps: Pick<Deps, 'matter' | 'storages'>,
+  params: { orgId: string; targetFolder: string; actorId: string },
+): Promise<string> {
+  const parts = params.targetFolder.split('/').filter(Boolean)
+  if (parts.length === 0) return ''
+
+  let parent = ''
+  let storageId: string | null = null
+  for (const name of parts) {
+    const path = joinPath(parent, name)
+    let existing = await deps.matter.findActiveConflict(params.orgId, parent, name)
+    if (!existing) {
+      storageId ??= (await deps.storages.select()).id
+      try {
+        existing = await deps.matter.create({
+          orgId: params.orgId,
+          userId: params.actorId,
+          name,
+          type: 'folder',
+          size: 0,
+          dirtype: DirType.USER_FOLDER,
+          parent,
+          object: '',
+          storageId,
+          status: ObjectStatus.ACTIVE,
+        })
+      } catch (error) {
+        if (!(error instanceof NameConflictError) && !formatError(error).includes('UNIQUE constraint failed'))
+          throw error
+        existing = await deps.matter.findActiveConflict(params.orgId, parent, name)
+        if (!existing) throw error
+      }
+    }
+    if (existing.dirtype === DirType.FILE) throw targetIsFile(path)
+    parent = joinPath(parent, existing.name)
+  }
+  return parent
+}
+
+export async function assertFolderNotUsedByDownload(
+  deps: Pick<Deps, 'downloadTasks'>,
+  params: { orgId: string; folder: Matter },
+): Promise<void> {
+  if (params.folder.dirtype === DirType.FILE) return
+  const folderPath = joinPath(params.folder.parent, params.folder.name)
+  const task = await deps.downloadTasks.findActiveTargetWithin(params.orgId, folderPath)
+  if (!task) return
+  throw new AppError(409, 'Folder is in use by a download task', {
+    reason: 'DIRECTORY_IN_USE',
+    metadata: { taskId: task.id, targetFolder: task.targetFolder },
+  })
+}

--- a/server/usecases/downloads/downloads.ts
+++ b/server/usecases/downloads/downloads.ts
@@ -24,11 +24,14 @@ import type {
   LicenseBindingRepo,
   LicensingCloudGateway,
   ListDownloadTasksFilters,
+  MatterRepo,
   RemoteDownloadUsageRepo,
+  StorageRepo,
   UpdateDownloadTaskFields,
 } from '../ports'
 import { DownloadError, featureBlocked } from '../ports'
 import { loadBindingState } from '../site/licensing'
+import { ensureDownloadTargetFolder } from './download-folders'
 import { RemoteDownloadBillingBlockedError, reportRemoteDownloadUnit } from './remote-download-usage'
 
 // Pure orchestration over the downloader / download-task repos: registration,
@@ -45,6 +48,8 @@ export type DownloadsDeps = {
   licensingCloud: LicensingCloudGateway
   remoteDownloadUsage: RemoteDownloadUsageRepo
   activity: ActivityRepo
+  matter: MatterRepo
+  storages: StorageRepo
 }
 
 const DEFAULT_REMOTE_DOWNLOAD_UNIT_BYTES = 100 * 1024 * 1024
@@ -252,6 +257,11 @@ export async function createDownloadTask(
   userId: string,
   input: CreateDownloadTaskInput,
 ): Promise<DownloadTask> {
+  const targetFolder = await ensureDownloadTargetFolder(deps, {
+    orgId,
+    targetFolder: input.targetFolder,
+    actorId: userId,
+  })
   const now = new Date()
   const id = nanoid()
   await deps.downloadTasks.insert({
@@ -261,7 +271,7 @@ export async function createDownloadTask(
     sourceType: input.source.type,
     sourceUri: input.source.uri,
     displayName: input.name ?? null,
-    targetFolder: input.targetFolder,
+    targetFolder,
     category: input.category ?? null,
     tags: input.tags ?? [],
     assignedDownloaderId: null,
@@ -278,7 +288,7 @@ export async function createDownloadTask(
       sourceUri: input.source.uri,
     },
     action: 'download_task_created',
-    metadata: { sourceType: input.source.type, targetFolder: input.targetFolder },
+    metadata: { sourceType: input.source.type, targetFolder },
   })
   return deps.downloadTasks.get(orgId, id)
 }

--- a/server/usecases/object.test.ts
+++ b/server/usecases/object.test.ts
@@ -118,6 +118,7 @@ function makeDeps(
         finalName: name,
         toTrash: null,
       }),
+      findActiveConflict: async (_orgId: string, parent: string, name: string) => folder('target', { name, parent }),
       commitConflictPlan: async () => {},
       activateDraft: async () => true,
       ...overrides.matter,
@@ -184,6 +185,7 @@ function makeDeps(
     downloadTasks: {
       findRecord: async () =>
         ({ id: 't1', assignedDownloaderId: 'd1', status: 'uploading' }) as unknown as DownloadTaskRecord,
+      findActiveTargetWithin: async () => null,
       ...overrides.downloadTasks,
     } as unknown as DownloadTaskRepo,
   }
@@ -852,7 +854,7 @@ describe('object usecase', () => {
   describe('updateObject', () => {
     it('renames and returns the matter', async () => {
       const update = vi.fn(async () => file('m1', { name: 'New.txt' }))
-      const { deps } = makeDeps({ matter: { update } })
+      const { deps } = makeDeps({ matter: { get: async () => file('m1'), update } })
       const out = await updateObject(deps, {
         orgId: 'o1',
         objectId: 'm1',
@@ -883,7 +885,12 @@ describe('object usecase', () => {
   describe('trashObject / restoreObject', () => {
     it('trashes a matter', async () => {
       // Trash = active row with trashedAt set (no 'trashed' status).
-      const { deps } = makeDeps({ matter: { trash: async () => file('m1', { status: 'active', trashedAt: 1 }) } })
+      const { deps } = makeDeps({
+        matter: {
+          get: async () => file('m1'),
+          trash: async () => file('m1', { status: 'active', trashedAt: 1 }),
+        },
+      })
       const out = await trashObject(deps, { orgId: 'o1', objectId: 'm1', actorId: 'u1' })
       expect(out.ok).toBe(true)
       if (out.ok) {

--- a/server/usecases/object.ts
+++ b/server/usecases/object.ts
@@ -22,6 +22,7 @@ import type {
 import type { ObjectUploadInstructions } from '@shared/types'
 import { buildObjectKey, fileExt } from '../lib/path-template'
 import type { Deps } from './deps'
+import { assertFolderNotUsedByDownload, ensureDownloadTargetFolder } from './downloads/download-folders'
 import { assertTaskUploadAllowed } from './downloads/downloads'
 import {
   type ActivityRepo,
@@ -170,6 +171,11 @@ export async function createObject(
       return { ok: false, error: forbidden('Target folder is outside task authorization') }
     }
     await assertTaskUploadAllowed(deps as Deps, { taskId: actor.taskId, downloaderId: actor.downloaderId })
+    await ensureDownloadTargetFolder(deps, {
+      orgId,
+      targetFolder: actor.targetFolder,
+      actorId: actor.createdByUserId,
+    })
   }
 
   // Reject oversize before creating anything, so no orphan draft is left behind.
@@ -593,10 +599,15 @@ export async function getTrashObject(
 export type UpdateObjectOutcome = { ok: true; matter: Matter } | { ok: false; error: AppError }
 
 export async function updateObject(
-  deps: Pick<Deps, 'matter'>,
+  deps: Pick<Deps, 'matter' | 'downloadTasks'>,
   params: { orgId: string; objectId: string; actorId: string; input: PatchMatterInput },
 ): Promise<UpdateObjectOutcome> {
   const { name, parent, onConflict } = params.input
+  const existing = await deps.matter.get(params.objectId, params.orgId)
+  if (!existing) return { ok: false, error: notFound() }
+  if ((name !== undefined && name !== existing.name) || (parent !== undefined && parent !== existing.parent)) {
+    await assertFolderNotUsedByDownload(deps, { orgId: params.orgId, folder: existing })
+  }
   const matter = await deps.matter.update(params.objectId, params.orgId, { name, parent, onConflict }, params.actorId)
   return matter ? { ok: true, matter } : { ok: false, error: notFound() }
 }
@@ -604,9 +615,12 @@ export async function updateObject(
 export type TrashObjectOutcome = { ok: true; matter: Matter } | { ok: false; error: AppError }
 
 export async function trashObject(
-  deps: Pick<Deps, 'matter'>,
+  deps: Pick<Deps, 'matter' | 'downloadTasks'>,
   params: { orgId: string; objectId: string; actorId: string },
 ): Promise<TrashObjectOutcome> {
+  const existing = await deps.matter.get(params.objectId, params.orgId)
+  if (!existing) return { ok: false, error: notFound() }
+  await assertFolderNotUsedByDownload(deps, { orgId: params.orgId, folder: existing })
   const matter = await deps.matter.trash(params.orgId, params.objectId, params.actorId)
   return matter ? { ok: true, matter } : { ok: false, error: notFound() }
 }

--- a/server/usecases/ports/downloads.ts
+++ b/server/usecases/ports/downloads.ts
@@ -188,6 +188,8 @@ export interface DownloadTaskRepo {
   /** Raw record scoped to org; throws DownloadError('not_found') when missing. */
   getRecord(orgId: string, id: string): Promise<DownloadTaskRecord>
   findRecord(id: string): Promise<DownloadTaskRecord | null>
+  /** Active task whose target is `folderPath` or a descendant of it. */
+  findActiveTargetWithin(orgId: string, folderPath: string): Promise<DownloadTaskRecord | null>
   setFields(id: string, fields: UpdateDownloadTaskFields): Promise<void>
   claimQueued(id: string, downloaderId: string, now: Date): Promise<boolean>
   delete(id: string): Promise<void>

--- a/server/usecases/webdav.test.ts
+++ b/server/usecases/webdav.test.ts
@@ -6,6 +6,8 @@ import type {
   ApiKeyGateway,
   CloudTrafficReportRepo,
   DavLock,
+  DownloadTaskRecord,
+  DownloadTaskRepo,
   LicenseBindingRepo,
   LicensingCloudGateway,
   Matter,
@@ -105,6 +107,7 @@ function makeDeps(
     storageUsage?: Partial<StorageUsageRepo>
     webdavPath?: Partial<WebDavPathRepo>
     webdavState?: Partial<WebDavStateRepo>
+    downloadTasks?: Partial<DownloadTaskRepo>
   } = {},
 ) {
   const deps = {
@@ -127,6 +130,7 @@ function makeDeps(
       touch: async () => {},
       applyUpload: async () => {},
       listActiveDescendants: async () => [],
+      get: async () => null,
       ...overrides.matter,
     } as unknown as MatterRepo,
     storages: {
@@ -179,6 +183,10 @@ function makeDeps(
       removeLock: async () => true,
       ...overrides.webdavState,
     } as unknown as WebDavStateRepo,
+    downloadTasks: {
+      findActiveTargetWithin: async () => null,
+      ...overrides.downloadTasks,
+    } as unknown as DownloadTaskRepo,
   }
   return deps
 }
@@ -563,6 +571,36 @@ describe('webdav usecase', () => {
       expect(deleteWebDavState).toHaveBeenCalledWith('ws-1', 'gone.txt')
       expect(trash).toHaveBeenCalledWith('ws-1', 'm1', 'u1')
       expect(order).toEqual(['state', 'trash'])
+    })
+
+    it('rejects deleting a folder used by an active download task before changing dav state', async () => {
+      const deleteWebDavState = vi.fn(async () => {})
+      const trash = vi.fn(async () => folder('target'))
+      const deps = makeDeps({
+        matter: { get: async () => folder('target', { name: 'Downloads' }), trash },
+        webdavState: { deleteWebDavState },
+        downloadTasks: {
+          findActiveTargetWithin: async () =>
+            ({ id: 'task-1', targetFolder: 'Downloads/Movies' }) as DownloadTaskRecord,
+        },
+      })
+
+      await expect(
+        deleteWebDavMatter(deps, {
+          orgId: 'ws-1',
+          resourcePath: 'Downloads',
+          matterId: 'target',
+          userId: 'u1',
+        }),
+      ).rejects.toMatchObject({
+        httpStatus: 409,
+        meta: {
+          reason: 'DIRECTORY_IN_USE',
+          metadata: { taskId: 'task-1', targetFolder: 'Downloads/Movies' },
+        },
+      })
+      expect(deleteWebDavState).not.toHaveBeenCalled()
+      expect(trash).not.toHaveBeenCalled()
     })
   })
 

--- a/server/usecases/webdav.ts
+++ b/server/usecases/webdav.ts
@@ -17,6 +17,7 @@ import { joinMatterPath } from '../domain/webdav'
 import { buildObjectKey, fileExt } from '../lib/path-template'
 import type { Database } from '../platform/interface'
 import type { Deps } from './deps'
+import { assertFolderNotUsedByDownload } from './downloads/download-folders'
 import {
   type ApiKeyAuth,
   ApiKeyRateLimitError,
@@ -416,9 +417,11 @@ export async function createWebDavCollection(
 // ─── DELETE ────────────────────────────────────────────────────────────────────
 
 export async function deleteWebDavMatter(
-  deps: Pick<Deps, 'webdavState' | 'matter'>,
+  deps: Pick<Deps, 'webdavState' | 'matter' | 'downloadTasks'>,
   params: { orgId: string; resourcePath: string; matterId: string; userId: string },
 ): Promise<void> {
+  const matter = await deps.matter.get(params.matterId, params.orgId)
+  if (matter) await assertFolderNotUsedByDownload(deps, { orgId: params.orgId, folder: matter })
   await deps.webdavState.deleteWebDavState(params.orgId, params.resourcePath)
   await deps.matter.trash(params.orgId, params.matterId, params.userId)
 }
@@ -430,7 +433,7 @@ export async function deleteWebDavMatter(
 // already validated workspace scope, locks, If/preconditions, and the
 // self/descendant guards.
 export async function moveWebDavMatter(
-  deps: Pick<Deps, 'webdavState' | 'matter'>,
+  deps: Pick<Deps, 'webdavState' | 'matter' | 'downloadTasks'>,
   params: {
     orgId: string
     userId: string
@@ -442,8 +445,12 @@ export async function moveWebDavMatter(
     replacedMatterId: string | null
   },
 ): Promise<void> {
+  const source = await deps.matter.get(params.sourceMatterId, params.orgId)
+  if (source) await assertFolderNotUsedByDownload(deps, { orgId: params.orgId, folder: source })
   const newPath = joinMatterPath(params.targetParent, params.targetName)
   if (params.replacedMatterId) {
+    const replaced = await deps.matter.get(params.replacedMatterId, params.orgId)
+    if (replaced) await assertFolderNotUsedByDownload(deps, { orgId: params.orgId, folder: replaced })
     await deps.webdavState.deleteWebDavState(params.orgId, params.targetResourcePath)
     await deps.matter.trash(params.orgId, params.replacedMatterId, params.userId)
   }
@@ -467,7 +474,7 @@ export type CopyWebDavFileOutcome =
 // copies the matter row + its dead properties. Returns the new resource path so
 // the handler can build the Location header. Conflict/quota errors throw.
 export async function copyWebDavFile(
-  deps: Pick<Deps, 'matter' | 'storages' | 's3' | 'quota' | 'storageUsage' | 'webdavState'>,
+  deps: Pick<Deps, 'matter' | 'storages' | 's3' | 'quota' | 'storageUsage' | 'webdavState' | 'downloadTasks'>,
   params: {
     orgId: string
     userId: string
@@ -484,6 +491,11 @@ export async function copyWebDavFile(
   const storage = sourceMatter.object ? await deps.storages.get(sourceMatter.storageId) : null
   if (sourceMatter.object && !storage) return { ok: false, reason: 'storage_not_found' }
   const bytes = sourceMatter.size ?? 0
+
+  if (params.replacedMatterId) {
+    const replaced = await deps.matter.get(params.replacedMatterId, params.orgId)
+    if (replaced) await assertFolderNotUsedByDownload(deps, { orgId: params.orgId, folder: replaced })
+  }
 
   return withStorageUsageReservation(deps, { orgId, storageId: sourceMatter.storageId, bytes }, async (ctx) => {
     let newObject = ''
@@ -520,7 +532,10 @@ export type CopyWebDavCollectionOutcome =
 // overwritten destination rows. The handler validated depth, locks, and the
 // self/descendant guard. depth='0' copies only the root (ordered is empty).
 export async function copyWebDavCollection(
-  deps: Pick<Deps, 'matter' | 'storages' | 's3' | 'quota' | 'storageUsage' | 'webdavPath' | 'webdavState'>,
+  deps: Pick<
+    Deps,
+    'matter' | 'storages' | 's3' | 'quota' | 'storageUsage' | 'webdavPath' | 'webdavState' | 'downloadTasks'
+  >,
   params: {
     orgId: string
     userId: string
@@ -535,6 +550,7 @@ export async function copyWebDavCollection(
   },
 ): Promise<CopyWebDavCollectionOutcome> {
   const { orgId, userId, sourceMatter, sourceRoot, targetMatter } = params
+  if (targetMatter) await assertFolderNotUsedByDownload(deps, { orgId, folder: targetMatter })
   const targetRoot = joinMatterPath(params.targetParent, params.targetName)
   const children = await deps.webdavPath.listChildren(orgId, sourceRoot)
   const descendants = await deps.matter.listActiveDescendants(orgId, sourceRoot)


### PR DESCRIPTION
## Summary

- automatically create missing remote-download target folders on task creation
- recheck the target before downloader ingestion to prevent orphaned object paths
- block deleting, moving, or renaming active task targets and their ancestors through the object API and WebDAV

## Root cause

Remote download tasks accepted arbitrary target-folder paths, while object creation only checked that uploads stayed under the authorized path. Missing parent folder matters were never validated or created, so completed uploads could be stored under paths that were invisible from the root listing.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:cf`
- `go test ./...` from `cmd/`
- focused remote-download, object, WebDAV, and error-mapping regression tests

Full Playwright run: 82 passed; unrelated environment/flaky suites failed because local S3 and ZPan Cloud services were unavailable, plus existing announcement/preview timing failures.