### PR TITLE
fix(stats): validate snapshot rollup markers by scope

### DIFF
--- a/scripts/backfill-admin-stats.ts
+++ b/scripts/backfill-admin-stats.ts
@@ -866,11 +866,15 @@ export function buildValidationSql(now = new Date()): string {
       AND json_extract(metadata, '$.quality') IN ('exact', 'lower_bound')
     ELSE 0 END = 1
 ),
-counter_markers AS MATERIALIZED (
-  SELECT bucket_start
+completion_markers AS MATERIALIZED (
+  SELECT bucket_start, json_extract(metadata, '$.scope') AS scope
   FROM valid_rollups
   WHERE metric_key = 'stats.rollup_run' AND org_id = '' AND dimension_key = '' AND dimension_value = ''
-    AND json_extract(metadata, '$.scope') IN ('counters', 'full')
+),
+counter_markers AS MATERIALIZED (
+  SELECT bucket_start
+  FROM completion_markers
+  WHERE scope IN ('counters', 'full')
 ),
 counter_rows AS MATERIALIZED (
   SELECT result.*
@@ -903,7 +907,16 @@ SELECT json_object(
     SELECT COUNT(DISTINCT r.bucket_start)
     FROM valid_rollups r
     WHERE r.metric_key <> 'stats.rollup_run'
-      AND NOT EXISTS (SELECT 1 FROM counter_markers marker WHERE marker.bucket_start = r.bucket_start)
+      AND NOT EXISTS (
+        SELECT 1
+        FROM completion_markers marker
+        WHERE marker.bucket_start = r.bucket_start
+          AND (
+            (json_extract(r.metadata, '$.scope') = 'counters' AND marker.scope IN ('counters', 'full'))
+            OR (json_extract(r.metadata, '$.scope') = 'snapshots' AND marker.scope IN ('snapshots', 'full'))
+            OR (json_extract(r.metadata, '$.scope') = 'full' AND marker.scope = 'full')
+          )
+      )
   ),
   'lowerBoundRollups', (
     SELECT COUNT(*) FROM valid_rollups WHERE json_extract(metadata, '$.quality') = 'lower_bound'

--- a/server/scripts/backfill-admin-stats.test.ts
+++ b/server/scripts/backfill-admin-stats.test.ts
@@ -225,6 +225,30 @@ describe('admin stats backfill', () => {
       { outcome: 'completed', bytes: 512, value: 1 },
       { outcome: 'failed', bytes: 0, value: 1 },
     ])
+
+    db.exec(`
+      INSERT INTO stats_rollups_hourly VALUES
+        ('current-snapshot-marker', ${currentHourMs}, '', 'stats.rollup_run', '', '', 1, 0, 0,
+          '{"version":3,"scope":"snapshots","quality":"exact"}', ${currentHourMs}),
+        ('current-snapshot-gauge', ${currentHourMs}, '', 'storage.used', '', '', 0, 1024, 0,
+          '{"version":3,"scope":"snapshots","quality":"exact"}', ${currentHourMs});
+    `)
+    const snapshotSummary = Object.assign(
+      {},
+      ...splitSqlStatements(validationSql).map((statement) =>
+        JSON.parse((db.prepare(statement).get() as { summary: string }).summary),
+      ),
+    ) as Record<string, number>
+    expect(snapshotSummary.orphanRollupBuckets).toBe(0)
+
+    db.prepare("DELETE FROM stats_rollups_hourly WHERE id = 'current-snapshot-marker'").run()
+    const missingMarkerSummary = Object.assign(
+      {},
+      ...splitSqlStatements(validationSql).map((statement) =>
+        JSON.parse((db.prepare(statement).get() as { summary: string }).summary),
+      ),
+    ) as Record<string, number>
+    expect(missingMarkerSummary.orphanRollupBuckets).toBe(1)
     db.close()
   })
 })


### PR DESCRIPTION
## What changed

- validate rollup completion markers against each row's own scope
- accept snapshot-only current-hour buckets when a snapshot completion marker exists
- keep rejecting true orphan rows when the compatible marker is missing

## Root cause

The backfill validator only loaded counter/full completion markers. A valid current-hour snapshot bucket therefore appeared orphaned even though it had an exact snapshot marker. Production data was correct, but repeated backfill validation reported a false failure after the scheduled snapshot ran.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (197 files, 4,801 tests)
- `pnpm test:cf` (14 files, 61 tests)
- production read-only dry run: raw facts equal rollups, `orphanRollupBuckets=0`, `legacyRollupRows=0`, `counterMissingBuckets=0`, `openCounterMarkers=0`

Preview screenshots intentionally skipped per maintainer instruction; this script-only change is verified through production-shaped data checks.
