### PR TITLE
fix(stats): reject ranges without closed buckets

### DIFF
--- a/server/http/admin-stats.integration.test.ts
+++ b/server/http/admin-stats.integration.test.ts
@@ -94,6 +94,18 @@ describe('site stats routes', () => {
     expect(res.status).toBe(400)
   })
 
+  it('rejects ranges with no closed offline result bucket', async () => {
+    const { app } = await createTestApp()
+    const headers = await adminHeaders(app)
+    const nextHour = Math.floor(Date.now() / 3_600_000) * 3_600_000 + 3_600_000
+    const from = encodeURIComponent(new Date(nextHour).toISOString())
+    const to = encodeURIComponent(new Date(nextHour + 3_600_000 - 1).toISOString())
+
+    const res = await app.request(`/api/site/stats/overview?from=${from}&to=${to}&timeZone=UTC`, { headers })
+
+    expect(res.status).toBe(400)
+  })
+
   it('rejects local reporting zones because offline result buckets are UTC-only', async () => {
     const { app } = await createTestApp()
     const headers = await adminHeaders(app)

--- a/server/usecases/admin-stats.ts
+++ b/server/usecases/admin-stats.ts
@@ -37,6 +37,10 @@ export function normalizeStatsRange(input: AdminStatsRangeInput, now = new Date(
   if (calendarDayCount(from, to) > MAX_DASHBOARD_RANGE_DAYS) {
     throw badRequest(`time range cannot exceed ${MAX_DASHBOARD_RANGE_DAYS} days`, 'TIME_RANGE_TOO_LARGE')
   }
+  const currentHourStart = Math.floor(now.getTime() / 3_600_000) * 3_600_000
+  if (from.getTime() >= currentHourStart) {
+    throw badRequest('time range must include a closed UTC hour', 'INVALID_TIME_RANGE')
+  }
   return { from, to, timeZone }
 }
 


### PR DESCRIPTION
## What changed

- reject analytics ranges whose first hour is current or future
- guarantee every accepted range contains at least one closed offline result bucket
- add an HTTP integration regression for a future-only aligned range

## Root cause

Range normalization validated ordering, alignment, and duration but did not require a closed hour. The repository later clamped `to` to the current-hour boundary; for a current/future-only request this produced an effective frame whose `to` was one millisecond before `from`.

## Impact

The API now returns `400 INVALID_TIME_RANGE` instead of a malformed `from > to` statistics response. Queries containing historical closed hours continue to use offline rollups and may still clamp a future `to` safely.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (197 files, 4,802 tests)
- `pnpm test:cf` (14 files, 61 tests)

Screenshots intentionally skipped per maintainer instruction; validation is data/API-only.
