### PR TITLE
fix(stats): populate share inventory base rows

### DIFF
--- a/server/adapters/repos/admin-stats-rollup.integration.test.ts
+++ b/server/adapters/repos/admin-stats-rollup.integration.test.ts
@@ -231,6 +231,8 @@ describe('admin hourly stats rollup', () => {
     expect(row(M.storageQuota, 'status', 'invalid', '')).toMatchObject({ count: 1 })
     expect(row(M.storageTrashSnapshot)).toMatchObject({ count: 1, bytes: 800 })
     expect(row(M.statsDataQualitySnapshot, 'kind', 'storage_usage_drift', '')).toMatchObject({ count: 0, bytes: 0 })
+    expect(row(M.shareInventory)).toMatchObject({ count: 4 })
+    expect(row(M.shareInventory, '', '', '')).toMatchObject({ count: 4 })
     expect(row(M.shareInventory, 'lifecycle', 'usable')).toMatchObject({ count: 1 })
     expect(row(M.shareInventory, 'lifecycle', 'revoked')).toMatchObject({ count: 1 })
     expect(row(M.shareInventory, 'lifecycle', 'expired')).toMatchObject({ count: 1 })

--- a/server/adapters/repos/admin-stats-rollup.ts
+++ b/server/adapters/repos/admin-stats-rollup.ts
@@ -597,7 +597,9 @@ async function addSnapshotMetrics(db: Database, rollups: RollupAccumulator, now:
     rollups.incrementGauge(M.storageTrashSnapshot, '', row.files, row.bytes, 'storage_id', row.storageId)
   }
   for (const row of shareRows) {
+    rollups.incrementGauge(M.shareInventory, row.orgId, Number(row.count), 0)
     rollups.incrementGauge(M.shareInventory, row.orgId, Number(row.count), 0, 'lifecycle', row.lifecycle)
+    rollups.incrementGauge(M.shareInventory, '', Number(row.count), 0)
     rollups.incrementGauge(M.shareInventory, '', Number(row.count), 0, 'lifecycle', row.lifecycle)
   }
   for (const row of jobRows) {


### PR DESCRIPTION
## What changed

- populate `share.inventory` base rows for every organization
- aggregate the same lifecycle groups into the global base row
- assert both organization and global base counts in the rollup integration test

## Root cause

Snapshot construction wrote lifecycle dimension rows but never incremented their base rows. The global base row remained the initialized zero and organization base rows were absent, while lifecycle dimensions and the source table both contained 43 shares.

## Production evidence

- only `share.inventory/lifecycle` failed the required-dimension reconciliation audit
- 50 affected bucket/org groups across the 14:00 and 15:00 snapshot buckets
- 48 missing organization base rows and 2 global base rows fixed at zero
- lifecycle dimensions are exact, so historical base rows can be reconstructed without guessing

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (197 files, 4,802 tests)
- `pnpm test:cf` (14 files, 61 tests)

Screenshots intentionally skipped per maintainer instruction; validation is data-only.
