### PR TITLE
fix(stats): validate required rollup dimensions

### DIFF
--- a/docs/design/admin-analytics.md
+++ b/docs/design/admin-analytics.md
@@ -87,6 +87,7 @@ Validation must cover:
 - UTC range alignment and exclusion of the current open hour;
 - rollup idempotency and database-side grouping;
 - version and scope rejection, including counter-only versus full coverage;
+- required dimension reconciliation with base rows, including missing base and missing dimension groups;
 - missing-bucket repair and lower-bound byte quality;
 - dashboard endpoints never writing results or falling back to raw data;
 - browser rendering without metric calculations.

--- a/scripts/backfill-admin-stats.ts
+++ b/scripts/backfill-admin-stats.ts
@@ -1272,7 +1272,7 @@ function apply(target: Target, sql: string): void {
   }
 }
 
-function assertBackfillValidation(summary: ValidationSummary): void {
+export function assertBackfillValidation(summary: ValidationSummary): void {
   const mismatches = [
     ['upload events', summary.rawUploadEvents, summary.rollupUploadEvents],
     ['upload bytes', summary.rawUploadBytes, summary.rollupUploadBytes],

--- a/scripts/backfill-admin-stats.ts
+++ b/scripts/backfill-admin-stats.ts
@@ -59,6 +59,7 @@ interface ValidationSummary {
   rawMissingByteEvents: number
   rollupMissingByteEvents: number
   orphanRollupBuckets: number
+  requiredDimensionMismatchGroups: number
   lowerBoundRollups: number
   legacyRollupRows: number
   counterExpectedBuckets: number
@@ -881,6 +882,50 @@ counter_rows AS MATERIALIZED (
   FROM valid_rollups result
   WHERE result.metric_key <> 'stats.rollup_run'
     AND EXISTS (SELECT 1 FROM counter_markers marker WHERE marker.bucket_start = result.bucket_start)
+),
+required_dimensions(metric_key, dimension_key, check_bytes) AS (
+  VALUES
+    ('transfer.upload', 'source', 1),
+    ('transfer.upload', 'status', 1),
+    ('transfer.download_issued', 'actor_type', 1),
+    ('transfer.download_issued', 'source', 1),
+    ('share.download_issued', 'actor_type', 1),
+    ('share.download_issued', 'source', 1),
+    ('user.signup', 'provider', 0),
+    ('share.created', 'kind', 0),
+    ('remote_download.task_finished', 'category', 1),
+    ('remote_download.task_finished', 'outcome', 1),
+    ('background_job.finished', 'job_type', 0),
+    ('background_job.finished', 'outcome', 0),
+    ('storage.inventory', 'file_type_group', 1),
+    ('storage.inventory', 'size_bucket', 1),
+    ('storage.inventory', 'age_bucket', 1),
+    ('storage.trash_snapshot', 'storage_id', 1),
+    ('share.inventory', 'lifecycle', 0),
+    ('traffic.report_snapshot', 'status', 1),
+    ('webhook.snapshot', 'status', 0),
+    ('downloader.snapshot', 'status', 0)
+),
+base_rows AS MATERIALIZED (
+  SELECT bucket_start, org_id, metric_key, count, bytes
+  FROM valid_rollups
+  WHERE dimension_key = ''
+),
+dimension_rows AS MATERIALIZED (
+  SELECT bucket_start, org_id, metric_key, dimension_key, SUM(count) AS count, SUM(bytes) AS bytes
+  FROM valid_rollups
+  WHERE dimension_key <> ''
+  GROUP BY bucket_start, org_id, metric_key, dimension_key
+),
+required_dimension_keys AS MATERIALIZED (
+  SELECT required.metric_key, required.dimension_key, required.check_bytes, base.bucket_start, base.org_id
+  FROM required_dimensions required
+  JOIN base_rows base ON base.metric_key = required.metric_key
+  UNION
+  SELECT required.metric_key, required.dimension_key, required.check_bytes, dimension.bucket_start, dimension.org_id
+  FROM required_dimensions required
+  JOIN dimension_rows dimension
+    ON dimension.metric_key = required.metric_key AND dimension.dimension_key = required.dimension_key
 )
 SELECT json_object(
   'rollupUploadEvents', (
@@ -916,6 +961,28 @@ SELECT json_object(
             OR (json_extract(r.metadata, '$.scope') = 'snapshots' AND marker.scope IN ('snapshots', 'full'))
             OR (json_extract(r.metadata, '$.scope') = 'full' AND marker.scope = 'full')
           )
+      )
+  ),
+  'requiredDimensionMismatchGroups', (
+    SELECT COUNT(*)
+    FROM required_dimension_keys required
+    LEFT JOIN base_rows base
+      ON base.bucket_start = required.bucket_start
+      AND base.org_id = required.org_id
+      AND base.metric_key = required.metric_key
+    LEFT JOIN dimension_rows dimension
+      ON dimension.bucket_start = required.bucket_start
+      AND dimension.org_id = required.org_id
+      AND dimension.metric_key = required.metric_key
+      AND dimension.dimension_key = required.dimension_key
+    WHERE base.metric_key IS NULL
+      OR (
+        dimension.metric_key IS NULL
+        AND (base.count <> 0 OR (required.check_bytes = 1 AND base.bytes <> 0))
+      )
+      OR (
+        dimension.metric_key IS NOT NULL
+        AND (base.count <> dimension.count OR (required.check_bytes = 1 AND base.bytes <> dimension.bytes))
       )
   ),
   'lowerBoundRollups', (
@@ -1226,6 +1293,7 @@ function assertBackfillValidation(summary: ValidationSummary): void {
   if (
     mismatches.length > 0 ||
     summary.orphanRollupBuckets > 0 ||
+    summary.requiredDimensionMismatchGroups > 0 ||
     summary.legacyRollupRows > 0 ||
     summary.counterMissingBuckets > 0 ||
     summary.openCounterMarkers > 0
@@ -1234,6 +1302,7 @@ function assertBackfillValidation(summary: ValidationSummary): void {
       `admin_stats_validation_failed:${JSON.stringify({
         mismatches,
         orphanRollupBuckets: summary.orphanRollupBuckets,
+        requiredDimensionMismatchGroups: summary.requiredDimensionMismatchGroups,
         legacyRollupRows: summary.legacyRollupRows,
         counterMissingBuckets: summary.counterMissingBuckets,
         openCounterMarkers: summary.openCounterMarkers,

--- a/server/scripts/backfill-admin-stats.test.ts
+++ b/server/scripts/backfill-admin-stats.test.ts
@@ -1,6 +1,11 @@
 import Database from 'better-sqlite3'
 import { describe, expect, it } from 'vitest'
-import { buildBackfillSql, buildValidationSql, splitSqlStatements } from '../../scripts/backfill-admin-stats'
+import {
+  assertBackfillValidation,
+  buildBackfillSql,
+  buildValidationSql,
+  splitSqlStatements,
+} from '../../scripts/backfill-admin-stats'
 
 describe('admin stats backfill', () => {
   it('splits SQL batches without breaking quoted semicolons', () => {
@@ -10,6 +15,14 @@ describe('admin stats backfill', () => {
       'SELECT 3',
     ])
     expect(() => splitSqlStatements("SELECT 'unterminated")).toThrow('admin_stats_backfill_unterminated_sql_string')
+  })
+
+  it('rejects required dimension mismatches', () => {
+    expect(() =>
+      assertBackfillValidation({ requiredDimensionMismatchGroups: 1 } as Parameters<
+        typeof assertBackfillValidation
+      >[0]),
+    ).toThrow('"requiredDimensionMismatchGroups":1')
   })
 
   it('recovers exact available facts and is idempotent', () => {

--- a/server/scripts/backfill-admin-stats.test.ts
+++ b/server/scripts/backfill-admin-stats.test.ts
@@ -123,6 +123,13 @@ describe('admin stats backfill', () => {
 
     const sql = buildBackfillSql(now)
     const validationSql = buildValidationSql(now)
+    const readValidationSummary = () =>
+      Object.assign(
+        {},
+        ...splitSqlStatements(validationSql).map((statement) =>
+          JSON.parse((db.prepare(statement).get() as { summary: string }).summary),
+        ),
+      ) as Record<string, number>
     const statements = splitSqlStatements(sql)
     expect(statements.length).toBeGreaterThan(1)
     db.transaction(() =>
@@ -130,12 +137,7 @@ describe('admin stats backfill', () => {
         db.exec(statement)
       }),
     )()
-    const firstSummary = Object.assign(
-      {},
-      ...splitSqlStatements(validationSql).map((statement) =>
-        JSON.parse((db.prepare(statement).get() as { summary: string }).summary),
-      ),
-    ) as Record<string, number>
+    const firstSummary = readValidationSummary()
     const firstRows = db.prepare('SELECT * FROM stats_rollups_hourly ORDER BY id').all()
 
     db.transaction(() =>
@@ -160,6 +162,7 @@ describe('admin stats backfill', () => {
       counterCompletedBuckets: expectedBuckets,
       counterMissingBuckets: 0,
       openCounterMarkers: 0,
+      requiredDimensionMismatchGroups: 0,
       rawUploadAttempts: 1,
       rollupUploadAttempts: 1,
       rawUserSignups: 2,
@@ -233,21 +236,49 @@ describe('admin stats backfill', () => {
         ('current-snapshot-gauge', ${currentHourMs}, '', 'storage.used', '', '', 0, 1024, 0,
           '{"version":3,"scope":"snapshots","quality":"exact"}', ${currentHourMs});
     `)
-    const snapshotSummary = Object.assign(
-      {},
-      ...splitSqlStatements(validationSql).map((statement) =>
-        JSON.parse((db.prepare(statement).get() as { summary: string }).summary),
-      ),
-    ) as Record<string, number>
+    const snapshotSummary = readValidationSummary()
     expect(snapshotSummary.orphanRollupBuckets).toBe(0)
+    expect(snapshotSummary.requiredDimensionMismatchGroups).toBe(0)
+
+    db.exec(`
+      INSERT INTO stats_rollups_hourly VALUES
+        ('current-share-lifecycle', ${currentHourMs}, 'o1', 'share.inventory', 'lifecycle', 'usable', 3, 0, 0,
+          '{"version":3,"scope":"snapshots","quality":"exact"}', ${currentHourMs});
+    `)
+    expect(readValidationSummary().requiredDimensionMismatchGroups).toBe(1)
+
+    db.exec(`
+      INSERT INTO stats_rollups_hourly VALUES
+        ('current-share-base', ${currentHourMs}, 'o1', 'share.inventory', '', '', 3, 0, 0,
+          '{"version":3,"scope":"snapshots","quality":"exact"}', ${currentHourMs});
+    `)
+    expect(readValidationSummary().requiredDimensionMismatchGroups).toBe(0)
+
+    db.prepare("DELETE FROM stats_rollups_hourly WHERE id = 'current-share-lifecycle'").run()
+    expect(readValidationSummary().requiredDimensionMismatchGroups).toBe(1)
+    db.prepare("UPDATE stats_rollups_hourly SET count = 2 WHERE id = 'current-share-base'").run()
+    db.exec(`
+      INSERT INTO stats_rollups_hourly VALUES
+        ('current-share-lifecycle', ${currentHourMs}, 'o1', 'share.inventory', 'lifecycle', 'usable', 3, 0, 0,
+          '{"version":3,"scope":"snapshots","quality":"exact"}', ${currentHourMs});
+    `)
+    expect(readValidationSummary().requiredDimensionMismatchGroups).toBe(1)
+    db.prepare("UPDATE stats_rollups_hourly SET count = 3 WHERE id = 'current-share-base'").run()
+    expect(readValidationSummary().requiredDimensionMismatchGroups).toBe(0)
+
+    db.exec(`
+      INSERT INTO stats_rollups_hourly VALUES
+        ('current-traffic-base', ${currentHourMs}, '', 'traffic.report_snapshot', '', '', 1, 10, 0,
+          '{"version":3,"scope":"snapshots","quality":"exact"}', ${currentHourMs}),
+        ('current-traffic-status', ${currentHourMs}, '', 'traffic.report_snapshot', 'status', 'reported', 1, 9, 0,
+          '{"version":3,"scope":"snapshots","quality":"exact"}', ${currentHourMs});
+    `)
+    expect(readValidationSummary().requiredDimensionMismatchGroups).toBe(1)
+    db.prepare("UPDATE stats_rollups_hourly SET bytes = 10 WHERE id = 'current-traffic-status'").run()
+    expect(readValidationSummary().requiredDimensionMismatchGroups).toBe(0)
 
     db.prepare("DELETE FROM stats_rollups_hourly WHERE id = 'current-snapshot-marker'").run()
-    const missingMarkerSummary = Object.assign(
-      {},
-      ...splitSqlStatements(validationSql).map((statement) =>
-        JSON.parse((db.prepare(statement).get() as { summary: string }).summary),
-      ),
-    ) as Record<string, number>
+    const missingMarkerSummary = readValidationSummary()
     expect(missingMarkerSummary.orphanRollupBuckets).toBe(1)
     db.close()
   })


### PR DESCRIPTION
## What changed

- add required base/dimension reconciliation to the admin stats backfill validator
- detect missing base rows, missing non-zero required dimensions, count mismatches, and byte mismatches
- cover 20 metric/dimension contracts while leaving optional dimensions out of the invariant
- add positive/negative regression tests and document the validation requirement

## Root cause

The existing validator reconciled raw facts against counter bases and checked scope/markers, but it did not compare a metric's base row with required dimension totals. That allowed `share.inventory` lifecycle dimensions to be correct while its global base was zero and organization bases were absent.

## Zero-data semantics

A zero base with no dimension row is valid. A non-zero base without its required dimension, a dimension without a base, or unequal count/bytes is invalid and makes apply validation fail.

## Production evidence

After the round-4 exact repair, the new validator reports:

- `requiredDimensionMismatchGroups=0`
- `orphanRollupBuckets=0`
- `legacyRollupRows=0`
- `counterMissingBuckets=0`
- `openCounterMarkers=0`
- raw and rollup totals equal for every validated fact metric

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (197 files, 4,802 tests)
- `pnpm test:cf` (14 files, 61 tests)
- production read-only backfill dry run

Screenshots intentionally skipped per maintainer instruction; validation is data-only.
