### PR TITLE
feat(image-hosting): improve custom-domain image links

### DIFF
--- a/cmd/internal/openapi/client.gen.go
+++ b/cmd/internal/openapi/client.gen.go
@@ -4575,6 +4575,7 @@ type ImageHosting struct {
 	StorageId      string  `json:"storageId"`
 	StorageKey     string  `json:"storageKey"`
 	Token          string  `json:"token"`
+	Url            string  `json:"url"`
 	Width          *int    `json:"width"`
 }
 

--- a/e2e/image-host.spec.ts
+++ b/e2e/image-host.spec.ts
@@ -164,6 +164,16 @@ test.describe('Image Host gallery golden path @all', () => {
     const confirmResp = await page.request.put(`/api/image-hosting/images/${draftId}/status`)
     await expectApiOk(confirmResp, 'Confirm seeded image')
 
+    await page.route('**/api/image-hosting/images?*', async (route) => {
+      if (route.request().method() !== 'GET') return route.continue()
+      const response = await route.fetch()
+      const body = (await response.json()) as { items: Array<{ path: string; url: string }> }
+      for (const item of body.items) {
+        if (item.path === 'e2e-copy-test.png') item.url = 'https://images.example.com/e2e-copy-test.png'
+      }
+      await route.fulfill({ response, json: body })
+    })
+
     // Reload to see the seeded image
     await page.reload()
 
@@ -172,7 +182,7 @@ test.describe('Image Host gallery golden path @all', () => {
     await page.getByRole('menuitem', { name: /markdown/i }).click()
 
     const clipText = await page.evaluate(() => navigator.clipboard.readText())
-    expect(clipText).toMatch(/!\[\]\(/)
+    expect(clipText).toBe('![](https://images.example.com/e2e-copy-test.png)')
   })
 
   test('delete with Undo → cancel → item restored', async ({ page }) => {

--- a/server/adapters/repos/image-hosting.ts
+++ b/server/adapters/repos/image-hosting.ts
@@ -1,5 +1,5 @@
 import { and, asc, eq, gt, isNotNull, isNull, like, or, sql } from 'drizzle-orm'
-import { nanoid } from 'nanoid'
+import { customAlphabet, nanoid } from 'nanoid'
 import { imageHostingConfigs, imageHostings } from '../../db/schema'
 import { type AtomicQuery, executeWriteTransaction, executeWriteTransactionWithResults } from '../../db/transaction'
 import { mimeToExt } from '../../lib/mime-utils'
@@ -21,6 +21,7 @@ import { imageAddedProjectionQueries, imageRemovedProjectionQueries } from './st
 type ImageHostingRow = typeof imageHostings.$inferSelect
 
 const MAX_COLLISION_RETRIES = 5
+const imageTokenSuffix = customAlphabet('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz', 10)
 
 function toRecord(row: ImageHostingRow): ImageHostingRecord {
   return row as unknown as ImageHostingRecord
@@ -136,7 +137,7 @@ export function createImageHostingRepo(db: Database): ImageHostingRepo {
 
     async create(input: CreateImageHostingInput) {
       const id = nanoid(12)
-      const token = `ih_${nanoid(10)}`
+      const token = `ih${imageTokenSuffix()}`
       const ext = mimeToExt(input.mime)
       const storageKey = `ih/${input.orgId}/${id}.${ext}`
       const now = new Date()

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -666,7 +666,7 @@ export const imageHostings = sqliteTable(
     orgId: text('org_id')
       .notNull()
       .references(() => organization.id, { onDelete: 'cascade' }),
-    token: text('token').notNull().unique(), // "ih_" + nanoid(10)
+    token: text('token').notNull().unique(), // "ih" + 10 alphanumeric characters
     path: text('path').notNull(), // virtual path e.g. "blog/2026/04/shot.png"
     storageId: text('storage_id')
       .notNull()

--- a/server/domain/image-hosting.ts
+++ b/server/domain/image-hosting.ts
@@ -35,6 +35,10 @@ export interface ImageUrlConfig {
   domainVerifiedAt: Date | null
 }
 
+export function isImageHostingToken(token: string): boolean {
+  return token.startsWith('ih')
+}
+
 export function buildImageUrl(config: ImageUrlConfig | null, path: string, tokenUrl: string): string {
   if (config?.customDomain && config.domainVerifiedAt) {
     return `https://${config.customDomain}/${path}`

--- a/server/http/image-hosting-not-found.test.ts
+++ b/server/http/image-hosting-not-found.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { imageHostingNotFound } from './image-hosting-not-found'
+
+describe('imageHostingNotFound', () => {
+  it('returns an English HTML page for direct navigation', async () => {
+    const response = imageHostingNotFound(
+      new Request('https://images.example.com/missing.png', {
+        headers: { Accept: 'text/html,application/xhtml+xml,image/avif,image/webp,*/*;q=0.8' },
+      }),
+    )
+
+    expect(response.status).toBe(404)
+    expect(response.headers.get('content-type')).toBe('text/html; charset=utf-8')
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(response.headers.get('x-robots-tag')).toBe('noindex, nofollow')
+    const body = await response.text()
+    expect(body).toContain('<html lang="en">')
+    expect(body).toContain('Image not found')
+  })
+
+  it('returns a Chinese HTML page when Chinese is preferred', async () => {
+    const response = imageHostingNotFound(
+      new Request('https://images.example.com/missing.png', {
+        headers: { Accept: 'text/html', 'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8' },
+      }),
+    )
+
+    expect(response.headers.get('content-type')).toBe('text/html; charset=utf-8')
+    const body = await response.text()
+    expect(body).toContain('<html lang="zh-CN">')
+    expect(body).toContain('图片不存在')
+  })
+
+  it('returns an English SVG placeholder for an embedded image request', async () => {
+    const response = imageHostingNotFound(
+      new Request('https://images.example.com/missing.png', {
+        headers: {
+          Accept: 'image/avif,image/webp,image/svg+xml,image/*,*/*;q=0.8',
+          'Accept-Language': 'en-US,en;q=0.9',
+        },
+      }),
+    )
+
+    expect(response.status).toBe(404)
+    expect(response.headers.get('content-type')).toBe('image/svg+xml; charset=utf-8')
+    const body = await response.text()
+    expect(body).toContain('<svg')
+    expect(body).toContain('Image not found')
+  })
+})

--- a/server/http/image-hosting-not-found.ts
+++ b/server/http/image-hosting-not-found.ts
@@ -1,0 +1,92 @@
+type NotFoundCopy = {
+  title: string
+  description: string
+}
+
+const ENGLISH_COPY: NotFoundCopy = {
+  title: 'Image not found',
+  description: 'The image does not exist or has been removed.',
+}
+
+const CHINESE_COPY: NotFoundCopy = {
+  title: '图片不存在',
+  description: '这张图片不存在或已被删除。',
+}
+
+function notFoundCopy(request: Request): NotFoundCopy {
+  return request.headers.get('Accept-Language')?.trim().toLowerCase().startsWith('zh') ? CHINESE_COPY : ENGLISH_COPY
+}
+
+function responseHeaders(contentType: string): HeadersInit {
+  return {
+    'Cache-Control': 'no-store',
+    'Content-Type': contentType,
+    'X-Robots-Tag': 'noindex, nofollow',
+  }
+}
+
+function imagePlaceholder(copy: NotFoundCopy): Response {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="720" height="405" viewBox="0 0 720 405" role="img" aria-label="${copy.title}">
+  <rect width="720" height="405" fill="#f4f4f5"/>
+  <g fill="none" stroke="#a1a1aa" stroke-linecap="round" stroke-linejoin="round" stroke-width="10">
+    <rect x="270" y="86" width="180" height="150" rx="16"/>
+    <circle cx="326" cy="137" r="15"/>
+    <path d="m292 212 48-48 34 34 24-24 30 38"/>
+    <path d="m310 274 100-100"/>
+  </g>
+  <text x="360" y="306" fill="#3f3f46" font-family="system-ui, sans-serif" font-size="28" font-weight="600" text-anchor="middle">${copy.title}</text>
+  <text x="360" y="342" fill="#71717a" font-family="system-ui, sans-serif" font-size="17" text-anchor="middle">${copy.description}</text>
+</svg>`
+  return new Response(svg, {
+    status: 404,
+    headers: responseHeaders('image/svg+xml; charset=utf-8'),
+  })
+}
+
+function notFoundPage(copy: NotFoundCopy): Response {
+  const html = `<!doctype html>
+<html lang="${copy === CHINESE_COPY ? 'zh-CN' : 'en'}">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
+    <title>404 · ${copy.title}</title>
+    <style>
+      :root { color-scheme: light dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+      * { box-sizing: border-box; }
+      body { min-height: 100vh; margin: 0; display: grid; place-items: center; background: #fafafa; color: #18181b; }
+      main { width: min(90vw, 32rem); padding: 3rem; text-align: center; }
+      svg { width: 7rem; color: #a1a1aa; }
+      h1 { margin: 1.5rem 0 .5rem; font-size: clamp(1.75rem, 5vw, 2.5rem); }
+      p { margin: 0; color: #71717a; line-height: 1.6; }
+      .code { margin-top: 1.5rem; font-size: .875rem; font-weight: 600; letter-spacing: .12em; color: #a1a1aa; }
+      @media (prefers-color-scheme: dark) {
+        body { background: #09090b; color: #fafafa; }
+        p { color: #a1a1aa; }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <svg viewBox="0 0 96 96" fill="none" aria-hidden="true">
+        <rect x="16" y="18" width="64" height="54" rx="8" stroke="currentColor" stroke-width="5"/>
+        <circle cx="36" cy="36" r="6" fill="currentColor"/>
+        <path d="m24 64 18-18 13 13 9-9 10 10M30 80l40-40" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="5"/>
+      </svg>
+      <h1>${copy.title}</h1>
+      <p>${copy.description}</p>
+      <div class="code">404 · ZPAN IMAGE HOSTING</div>
+    </main>
+  </body>
+</html>`
+  return new Response(html, {
+    status: 404,
+    headers: responseHeaders('text/html; charset=utf-8'),
+  })
+}
+
+export function imageHostingNotFound(request: Request): Response {
+  const accept = request.headers.get('Accept') ?? ''
+  const copy = notFoundCopy(request)
+  return accept.includes('image/') && !accept.includes('text/html') ? imagePlaceholder(copy) : notFoundPage(copy)
+}

--- a/server/http/image-hosting/images.integration.test.ts
+++ b/server/http/image-hosting/images.integration.test.ts
@@ -309,7 +309,7 @@ describe('POST /api/image-hosting/images/presign (JSON two-stage)', () => {
     const body = (await res.json()) as Record<string, unknown>
     expect(body.uploadUrl).toBe('https://presigned-upload.example.com')
     expect(body.id).toBeTruthy()
-    expect(String(body.token)).toMatch(/^ih_/)
+    expect(String(body.token)).toMatch(/^ih[A-Za-z0-9]{10}$/)
     expect(body.path).toBe('blog/2026/shot.png')
     expect(String(body.storageKey)).toMatch(/^ih\//)
   })
@@ -589,7 +589,7 @@ describe('POST /api/image-hosting/images (multipart)', () => {
     const body = (await res.json()) as { data: Record<string, unknown> }
     expect(body.data).toBeDefined()
     expect(body.data.url).toBeTruthy()
-    expect(String(body.data.urlAlt)).toMatch(/\/r\/ih_/)
+    expect(String(body.data.urlAlt)).toMatch(/\/r\/ih[A-Za-z0-9]{10}$/)
     expect(String(body.data.markdown)).toContain('![](')
     expect(String(body.data.html)).toContain('<img src=')
     expect(String(body.data.bbcode)).toContain('[img]')
@@ -724,7 +724,7 @@ describe('POST /api/image-hosting/images (multipart)', () => {
     const body = (await res.json()) as { data: Record<string, unknown> }
     // url and urlAlt should both be the token URL when no custom domain
     expect(body.data.url).toBe(body.data.urlAlt)
-    expect(String(body.data.url)).toMatch(/\/r\/ih_/)
+    expect(String(body.data.url)).toMatch(/\/r\/ih[A-Za-z0-9]{10}$/)
   })
 
   it('cleans up DB row and refunds quota when S3 put fails', async () => {
@@ -1077,6 +1077,37 @@ describe('GET /api/image-hosting/images', () => {
     expect(body.items[0].path).toBe('active.png')
   })
 
+  it('returns token URLs when no verified custom domain is configured', async () => {
+    const { app, db } = await createTestApp()
+    await insertStorage(db)
+    const headers = await authedHeaders(app)
+    const orgId = await getOrgId(db)
+    await insertImageHostingConfig(db, orgId)
+    const image = await insertImageHosting(db, orgId, { path: 'plain.png' })
+
+    const res = await app.request('/api/image-hosting/images', { headers })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { items: Array<{ url: string }> }
+    expect(body.items[0].url).toBe(`http://localhost/r/${image.token}.png`)
+  })
+
+  it('returns custom-domain path URLs when the domain is verified', async () => {
+    const { app, db } = await createTestApp()
+    await insertStorage(db)
+    const headers = await authedHeaders(app)
+    const orgId = await getOrgId(db)
+    await insertImageHostingConfig(db, orgId, {
+      customDomain: 'images.example.com',
+      domainVerifiedAt: Date.now(),
+    })
+    await insertImageHosting(db, orgId, { path: 'blog/cover.png' })
+
+    const res = await app.request('/api/image-hosting/images', { headers })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { items: Array<{ url: string }> }
+    expect(body.items[0].url).toBe('https://images.example.com/blog/cover.png')
+  })
+
   it('paginates with cursor', async () => {
     const { app, db } = await createTestApp()
     await insertStorage(db)
@@ -1142,6 +1173,7 @@ describe('GET /api/image-hosting/images/:id', () => {
     expect(res.status).toBe(200)
     const body = (await res.json()) as Record<string, unknown>
     expect(body.id).toBe(id)
+    expect(body.url).toMatch(/^http:\/\/localhost\/r\/ih_/)
   })
 })
 

--- a/server/http/image-hosting/images.ts
+++ b/server/http/image-hosting/images.ts
@@ -46,6 +46,7 @@ const imageHostingSchema = z
     orgId: z.string(),
     token: z.string(),
     path: z.string(),
+    url: z.string(),
     storageId: z.string(),
     storageKey: z.string(),
     size: z.number().int(),
@@ -61,9 +62,15 @@ const imageHostingSchema = z
 
 type ImageHostingDTO = z.infer<typeof imageHostingSchema>
 
-function toImageHostingDTO(r: ImageHostingRecord): ImageHostingDTO {
+function toImageHostingDTO(
+  r: ImageHostingRecord,
+  config: { customDomain: string | null; domainVerifiedAt: Date | null },
+  origin: string,
+): ImageHostingDTO {
+  const tokenUrl = `${origin}/r/${r.token}.${mimeToExt(r.mime)}`
   return {
     ...r,
+    url: buildImageUrl(config, r.path, tokenUrl),
     lastAccessedAt: r.lastAccessedAt ? r.lastAccessedAt.toISOString() : null,
     createdAt: r.createdAt.toISOString(),
   }
@@ -341,9 +348,10 @@ const ihost = app
       codec: createdAtIdCursorCodec,
     })
     const result = await listImageHostings(c.get('deps'), orgId, { pathPrefix, after, limit: pageSize })
+    const origin = new URL(c.req.url).origin
     return c.json(
       {
-        items: result.items.map(toImageHostingDTO),
+        items: result.items.map((item) => toImageHostingDTO(item, enabled.config, origin)),
         nextPageToken: await encodeNextPageToken(c.get('platform'), result.nextBoundary, {
           query: fingerprint,
           codec: createdAtIdCursorCodec,
@@ -360,7 +368,7 @@ const ihost = app
 
     const row = await getImageHosting(c.get('deps'), c.req.valid('param').id, orgId)
     if (!row) throw notFound()
-    return c.json(toImageHostingDTO(row), 200)
+    return c.json(toImageHostingDTO(row, enabled.config, new URL(c.req.url).origin), 200)
   })
   .openapi(confirmRoute, async (c) => {
     const orgId = c.get('orgId')
@@ -370,7 +378,7 @@ const ihost = app
 
     const result = await confirmImageHosting(c.get('deps'), c.req.valid('param').id, orgId)
     if (!result.ok) throw result.error
-    return c.json(toImageHostingDTO(result.row), 200)
+    return c.json(toImageHostingDTO(result.row, enabled.config, new URL(c.req.url).origin), 200)
   })
   .openapi(deleteRoute, async (c) => {
     const orgId = c.get('orgId')

--- a/server/http/redirect.cf-test.ts
+++ b/server/http/redirect.cf-test.ts
@@ -106,15 +106,15 @@ describe('[CF] /r/:token ds_ direct shares', () => {
   })
 })
 
-// ─── CF ih_ image hosting tests ───────────────────────────────────────────────
+// ─── CF image hosting token tests ─────────────────────────────────────────────
 
-describe('[CF] /r/:token ih_ image hosting', () => {
-  it('returns 302 for active image hosting token', async () => {
+describe('[CF] /r/:token image hosting', () => {
+  it('returns 302 for a new active image-hosting token without an underscore', async () => {
     vi.spyOn(S3Service.prototype, 'presignInline').mockResolvedValue(MOCK_INLINE_URL)
     const { app, db } = await buildApp()
     const { orgId } = await signUpAndGetIds(app, db)
     await insertStorage(db)
-    const token = `ih_cf${Date.now()}`
+    const token = `ihcf${Date.now()}`
     await insertImageHosting(db, orgId, { id: `cf-ih-${Date.now()}`, token })
 
     const res = await app.request(`/r/${token}`, { redirect: 'manual' })

--- a/server/http/redirect.integration.test.ts
+++ b/server/http/redirect.integration.test.ts
@@ -285,9 +285,9 @@ describe('GET /r/:token (ds_ direct shares)', () => {
   })
 })
 
-// ─── ih_ image hosting tests ──────────────────────────────────────────────────
+// ─── image hosting token tests ────────────────────────────────────────────────
 
-describe('GET /r/:token (ih_ image hosting)', () => {
+describe('GET /r/:token (image hosting)', () => {
   it('returns 302 with inline disposition and no-store cache for active image [spec: redirect/image]', async () => {
     const { app, db } = await createTestApp()
     await authedHeaders(app)
@@ -312,6 +312,19 @@ describe('GET /r/:token (ih_ image hosting)', () => {
     expect(events).toEqual([
       { actorType: 'anonymous', bytes: 1024, source: 'image_hosting', trafficEventId: expect.any(String) },
     ])
+  })
+
+  it('serves a new image-hosting token without an underscore', async () => {
+    const { app, db } = await createTestApp()
+    await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    await insertImageHosting(db, orgId, { id: 'ih-new-token', token: 'ihnewtoken1' })
+
+    const res = await app.request('/r/ihnewtoken1.png', { redirect: 'manual' })
+
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe(MOCK_INLINE_URL)
   })
 
   it('strips .png extension and resolves same image [spec: redirect/image-strip-ext]', async () => {

--- a/server/http/redirect.ts
+++ b/server/http/redirect.ts
@@ -1,6 +1,7 @@
 import type { Context } from 'hono'
 import { Hono } from 'hono'
 import { ZPAN_CLOUD_URL_DEFAULT } from '../../shared/constants'
+import { isImageHostingToken } from '../domain/image-hosting'
 import { isDownloadFailureStatus, transferAuditActor, transferFailureReason } from '../middleware/audit-transfers'
 import type { Env } from '../middleware/platform'
 import { notFound } from '../usecases/ports'
@@ -13,7 +14,7 @@ import {
 } from '../usecases/redirect'
 import { recordDownloadFailure, recordDownloadIssued } from '../usecases/transfer-activity'
 
-// Strip optional file extension from token (e.g. "ih_aB3xK9.png" → "ih_aB3xK9")
+// Strip optional file extension from token (e.g. "ihaB3xK9.png" → "ihaB3xK9")
 function stripExtension(token: string): string {
   const dot = token.lastIndexOf('.')
   return dot > 0 ? token.slice(0, dot) : token
@@ -99,7 +100,7 @@ app.get('/:token', async (c) => {
   const token = stripExtension(raw)
 
   if (token.startsWith('ds_')) return handleDirectShare(c, token)
-  if (token.startsWith('ih_')) return handleImageHosting(c, token)
+  if (isImageHostingToken(token)) return handleImageHosting(c, token)
 
   throw notFound()
 })

--- a/server/middleware/image-hosting-domain.cf-test.ts
+++ b/server/middleware/image-hosting-domain.cf-test.ts
@@ -95,6 +95,24 @@ describe('[CF] imageHostingDomain — custom Host serves image redirect', () => 
     expect(res.headers.get('location')).toBe(MOCK_INLINE_URL)
     vi.restoreAllMocks()
   })
+
+  it('returns a localized image placeholder when a rewritten image path is missing', async () => {
+    const { app, db } = await buildApp()
+    const orgId = await signUpAndGetOrgId(app, db)
+    await insertImageHostingConfig(db, orgId, { customDomain: 'img.cf-missing.com' })
+
+    const res = await app.request('/ih/missing.png', {
+      headers: {
+        host: 'img.cf-missing.com',
+        Accept: 'image/avif,image/webp,image/svg+xml,image/*,*/*;q=0.8',
+        'Accept-Language': 'zh-CN,zh;q=0.9',
+      },
+    })
+
+    expect(res.status).toBe(404)
+    expect(res.headers.get('content-type')).toBe('image/svg+xml; charset=utf-8')
+    expect(await res.text()).toContain('图片不存在')
+  })
 })
 
 describe('[CF] imageHostingDomain — workers.dev preview host uses normal routing', () => {

--- a/server/middleware/image-hosting-domain.integration.test.ts
+++ b/server/middleware/image-hosting-domain.integration.test.ts
@@ -339,7 +339,7 @@ describe('imageHostingDomain middleware — custom domain redirect', () => {
     expect(await getAccessCount(db, 'dm-sign-fail')).toBe(0)
   })
 
-  it('verified custom domain, path not found → 404', async () => {
+  it('verified custom domain, path not found → English HTML 404 for direct navigation', async () => {
     const { app, db } = await createTestApp()
     await authedHeaders(app)
     await insertStorage(db)
@@ -351,6 +351,37 @@ describe('imageHostingDomain middleware — custom domain redirect', () => {
       redirect: 'manual',
     })
     expect(res.status).toBe(404)
+    expect(res.headers.get('content-type')).toBe('text/html; charset=utf-8')
+    expect(res.headers.get('cache-control')).toBe('no-store')
+    expect(res.headers.get('x-robots-tag')).toBe('noindex, nofollow')
+    const body = await res.text()
+    expect(body).toContain('<html lang="en">')
+    expect(body).toContain('Image not found')
+    expect(body).toContain('The image does not exist or has been removed.')
+  })
+
+  it('verified custom domain, path not found → Chinese SVG 404 for embedded images', async () => {
+    const { app, db } = await createTestApp()
+    await authedHeaders(app)
+    await insertStorage(db)
+    const orgId = await getOrgId(db)
+    await insertImageHostingConfig(db, orgId, { customDomain: 'img.missing-zh.com' })
+
+    const res = await app.request('/blog/notexist.png', {
+      headers: {
+        host: 'img.missing-zh.com',
+        Accept: 'image/avif,image/webp,image/svg+xml,image/*,*/*;q=0.8',
+        'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
+      },
+      redirect: 'manual',
+    })
+    expect(res.status).toBe(404)
+    expect(res.headers.get('content-type')).toBe('image/svg+xml; charset=utf-8')
+    expect(res.headers.get('cache-control')).toBe('no-store')
+    const body = await res.text()
+    expect(body).toContain('<svg')
+    expect(body).toContain('图片不存在')
+    expect(body).toContain('这张图片不存在或已被删除。')
   })
 
   it('host with port suffix still matches', async () => {
@@ -383,7 +414,7 @@ describe('imageHostingDomain middleware — custom domain redirect', () => {
     expect(res.status).toBe(302)
   })
 
-  it('empty path (root /) → 404 with path required error', async () => {
+  it('empty path (root /) → image-hosting HTML 404', async () => {
     const { app, db } = await createTestApp()
     await authedHeaders(app)
     await insertStorage(db)
@@ -394,8 +425,8 @@ describe('imageHostingDomain middleware — custom domain redirect', () => {
       headers: { host: 'img.empty.com' },
     })
     expect(res.status).toBe(404)
-    const body = (await res.json()) as { error: { message: string } }
-    expect(body.error.message).toBe('path required')
+    expect(res.headers.get('content-type')).toBe('text/html; charset=utf-8')
+    expect(await res.text()).toContain('Image not found')
   })
 })
 

--- a/server/middleware/image-hosting-domain.ts
+++ b/server/middleware/image-hosting-domain.ts
@@ -1,4 +1,5 @@
 import type { Context, Next } from 'hono'
+import { imageHostingNotFound } from '../http/image-hosting-not-found'
 import { PRESIGN_TTL_SECS } from '../http/share-utils'
 import { reportTrafficForDownload } from '../http/store/traffic-metering'
 import type { Env } from '../middleware/platform'
@@ -41,7 +42,7 @@ function checkReferer(refererAllowlist: string[], refererHeader: string | null):
 
 async function handleImageByPath(c: Context<Env>, orgId: string, virtualPath: string): Promise<Response> {
   const resolved = await c.get('deps').imageHosting.resolveActiveByOrgPath(orgId, virtualPath)
-  if (!resolved) throw notFound('Not found')
+  if (!resolved) return imageHostingNotFound(c.req.raw)
 
   const { image, refererAllowlist } = resolved
 
@@ -191,7 +192,7 @@ export async function imageHostingDomain(c: Context<Env>, next: Next): Promise<R
   if (!orgId) return next()
 
   const virtualPath = c.req.path.replace(/^\/ih(?:\/|$)/, '').replace(/^\/+/, '')
-  if (!virtualPath) throw notFound('path required')
+  if (!virtualPath) return imageHostingNotFound(c.req.raw)
 
   return handleImageByPath(c, orgId, virtualPath)
 }

--- a/server/usecases/ports/image-hosting.ts
+++ b/server/usecases/ports/image-hosting.ts
@@ -31,7 +31,7 @@ export interface ImageResolution {
 
 export interface ImageHostingRepo {
   // Redirect resolution. Both return the active image plus its org's referer
-  // allowlist (parsed): the /r/:token ih_ path and the custom-domain middleware.
+  // allowlist (parsed): the /r/:token ih path and the custom-domain middleware.
   resolveActiveByToken(token: string): Promise<ImageResolution | null>
   resolveActiveByOrgPath(orgId: string, path: string): Promise<ImageResolution | null>
   resolveCustomDomain(host: string): Promise<string | null>

--- a/server/usecases/redirect.ts
+++ b/server/usecases/redirect.ts
@@ -1,6 +1,6 @@
 // The redirect resource usecase. Owns every business decision behind the
 // /r/:token short-link download routes — the two sub-resources served there:
-// `ds_` direct shares and `ih_` image-hosting links. Each resolves a token,
+// `ds_` direct shares and `ih` image-hosting links. Each resolves a token,
 // runs its access/expiry/limit gates, meters the download (egress quota + cloud
 // report, with refund-on-presign-failure rollback), and presigns the object.
 //
@@ -8,6 +8,7 @@
 // inputs (cloud base URL, referer header, request origin), and renders the
 // route-specific Responses from the discriminated outcomes below.
 
+import { isImageHostingToken } from '../domain/image-hosting'
 import {
   type AppError,
   expired as expiredError,
@@ -64,7 +65,7 @@ export async function resolveRedirectDownloadAuditTarget(
     }
   }
 
-  if (token.startsWith('ih_')) {
+  if (isImageHostingToken(token)) {
     const resolved = await deps.imageHosting.resolveActiveByToken(token)
     if (!resolved) return null
     return {
@@ -188,7 +189,7 @@ export async function resolveDirectShareDownload(
   }
 }
 
-// ─── Image hosting (ih_) ─────────────────────────────────────────────────────
+// ─── Image hosting (ih) ──────────────────────────────────────────────────────
 
 export type ImageHostingOutcome =
   | {
@@ -205,7 +206,7 @@ export type ImageHostingOutcome =
     }
   | { ok: false; error: AppError }
 
-// Resolve an ih_ token to a presigned inline URL. Order matters and mirrors the
+// Resolve an ih token to a presigned inline URL. Order matters and mirrors the
 // historical flow: enforce the referer allowlist, consume traffic quota, presign
 // (refunding the quota on failure → 500), THEN report egress to Cloud (refunding
 // + 402 on a credit block, so the presigned URL is discarded) and only then bump

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -641,6 +641,7 @@ export interface ImageHosting {
   orgId: string
   token: string
   path: string
+  url: string
   storageId: string
   storageKey: string
   size: number

--- a/src/components/image-host/image-host-data-source.test.ts
+++ b/src/components/image-host/image-host-data-source.test.ts
@@ -29,6 +29,7 @@ function makeImageHosting(overrides: Partial<ImageHosting> = {}): ImageHosting {
     orgId: 'org-1',
     token: 'tok_abc',
     path: 'folder/photo.png',
+    url: '/r/tok_abc.png',
     storageId: 'stor-1',
     storageKey: 'ih/tok_abc',
     size: 1024,
@@ -129,54 +130,15 @@ describe('imageHostDataSource.list', () => {
     expect(ihostItem.token).toBe('tok_xyz')
   })
 
-  it('computes url from token and extension for png mime', async () => {
-    const img = makeImageHosting({ token: 'tok_abc', mime: 'image/png' })
+  it('keeps the token URL for previews and thumbnails', async () => {
+    const img = makeImageHosting({ url: 'https://images.example.com/folder/photo.png' })
     vi.mocked(listIhostImages).mockResolvedValue({ items: [img], nextPageToken: null })
 
     const result = await imageHostDataSource.list('', {})
 
-    const ihostItem = result.items[0] as { url: string }
+    const ihostItem = result.items[0] as { url: string; publicUrl: string }
     expect(ihostItem.url).toBe('/r/tok_abc.png')
-  })
-
-  it('computes url with jpg ext for image/jpeg mime', async () => {
-    const img = makeImageHosting({ token: 'tok_jpg', mime: 'image/jpeg' })
-    vi.mocked(listIhostImages).mockResolvedValue({ items: [img], nextPageToken: null })
-
-    const result = await imageHostDataSource.list('', {})
-
-    const ihostItem = result.items[0] as { url: string }
-    expect(ihostItem.url).toBe('/r/tok_jpg.jpg')
-  })
-
-  it('computes url with gif ext for image/gif mime', async () => {
-    const img = makeImageHosting({ token: 'tok_gif', mime: 'image/gif' })
-    vi.mocked(listIhostImages).mockResolvedValue({ items: [img], nextPageToken: null })
-
-    const result = await imageHostDataSource.list('', {})
-
-    const ihostItem = result.items[0] as { url: string }
-    expect(ihostItem.url).toBe('/r/tok_gif.gif')
-  })
-
-  it('computes url with webp ext for image/webp mime', async () => {
-    const img = makeImageHosting({ token: 'tok_webp', mime: 'image/webp' })
-    vi.mocked(listIhostImages).mockResolvedValue({ items: [img], nextPageToken: null })
-
-    const result = await imageHostDataSource.list('', {})
-
-    const ihostItem = result.items[0] as { url: string }
-    expect(ihostItem.url).toBe('/r/tok_webp.webp')
-  })
-
-  it('computes url with bin ext for unknown mime', async () => {
-    const img = makeImageHosting({ token: 'tok_unk', mime: 'application/octet-stream' })
-    vi.mocked(listIhostImages).mockResolvedValue({ items: [img], nextPageToken: null })
-
-    const result = await imageHostDataSource.list('', {})
-
-    const ihostItem = result.items[0] as { url: string }
-    expect(ihostItem.url).toBe('/r/tok_unk.bin')
+    expect(ihostItem.publicUrl).toBe('https://images.example.com/folder/photo.png')
   })
 
   it('computes dimensions string when width and height are set', async () => {
@@ -441,7 +403,7 @@ describe('imageHostDataSource.getThumbnailUrl', () => {
 // ---------------------------------------------------------------------------
 
 describe('imageHostDataSource.getShareUrl', () => {
-  it('returns item.url', () => {
+  it('returns item.publicUrl', () => {
     const item = {
       id: 'img-1',
       orgId: 'org-1',
@@ -459,16 +421,17 @@ describe('imageHostDataSource.getShareUrl', () => {
       updatedAt: '',
       token: 'tok_abc',
       url: '/r/tok_abc.png',
+      publicUrl: 'https://images.example.com/photo.png',
       dimensions: null,
       accessCount: 0,
     }
 
     const result = imageHostDataSource.getShareUrl(item)
 
-    expect(result).toBe('/r/tok_abc.png')
+    expect(result).toBe('https://images.example.com/photo.png')
   })
 
-  it('returns empty string when url is undefined/null', () => {
+  it('returns empty string when publicUrl is undefined/null', () => {
     const item = {
       id: 'img-1',
       orgId: 'org-1',

--- a/src/components/image-host/image-host-data-source.ts
+++ b/src/components/image-host/image-host-data-source.ts
@@ -9,6 +9,7 @@ import { confirmIhostImage, createIhostImagePresign, deleteIhostImage, listIhost
 export interface IhostItem extends StorageObject {
   token: string
   url: string
+  publicUrl: string
   dimensions: string | null
   accessCount: number
 }
@@ -46,6 +47,7 @@ function toIhostItem(img: ImageHosting): IhostItem {
     // IhostItem extra fields
     token: img.token,
     url: `/r/${img.token}.${mimeToExt(img.mime)}`,
+    publicUrl: img.url,
     dimensions,
     accessCount: img.accessCount,
   }
@@ -112,6 +114,6 @@ export const imageHostDataSource = {
 
   getShareUrl(item: StorageObject): string {
     const ihostItem = item as IhostItem
-    return ihostItem.url ?? ''
+    return ihostItem.publicUrl ?? ''
   },
 }

--- a/src/components/image-host/image-host-view.test.ts
+++ b/src/components/image-host/image-host-view.test.ts
@@ -71,6 +71,7 @@ function makeIhostItem(id: string, overrides: Partial<IhostItem> = {}): IhostIte
     updatedAt: '2024-01-01T00:00:00.000Z',
     token: `tok_${id}`,
     url: `/r/tok_${id}.png`,
+    publicUrl: `/r/tok_${id}.png`,
     dimensions: null,
     accessCount: 0,
     ...overrides,
@@ -100,7 +101,7 @@ function handleCopyUrl(
   copy?: (text: string, key: string) => void,
 ): string {
   const ihostItem = item as IhostItem
-  const path = ihostItem.url ?? ''
+  const path = ihostItem.publicUrl ?? ''
   const url = path.startsWith('/') ? `${window.location.origin}${path}` : path
   const text = buildCopyText(url, format)
   if (copy) copy(text, 'ihost.copy.copied')
@@ -185,6 +186,14 @@ describe('ImageHostView — handleCopyUrl format logic', () => {
     expect(text).toBe('http://localhost:3000/r/tok_img-1.png')
   })
 
+  it('uses an absolute custom-domain URL returned by the server', () => {
+    const item = makeIhostItem('img-1', { publicUrl: 'https://images.example.com/blog/photo.png' })
+
+    const text = handleCopyUrl(item, 'raw')
+
+    expect(text).toBe('https://images.example.com/blog/photo.png')
+  })
+
   it('returns markdown format', () => {
     const item = makeIhostItem('img-1')
 
@@ -253,8 +262,8 @@ describe('ImageHostView — handleCopyUrl format logic', () => {
     expect(copy).toHaveBeenCalledWith('[img]http://localhost:3000/r/tok_img-1.png[/img]', 'ihost.copy.copied')
   })
 
-  it('uses empty string url when item has no url', () => {
-    const item = makeIhostItem('img-1', { url: '' })
+  it('uses empty string url when item has no public URL', () => {
+    const item = makeIhostItem('img-1', { publicUrl: '' })
 
     const text = handleCopyUrl(item, 'raw')
 

--- a/src/components/image-host/image-host-view.tsx
+++ b/src/components/image-host/image-host-view.tsx
@@ -67,7 +67,7 @@ export function ImageHostView() {
 
   function handleCopyUrl(item: StorageObject, format?: 'raw' | 'markdown' | 'html' | 'bbcode') {
     const ihostItem = item as IhostItem
-    const path = ihostItem.url ?? ''
+    const path = ihostItem.publicUrl ?? ''
     const url = path.startsWith('/') ? `${window.location.origin}${path}` : path
     let text: string
     switch (format) {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,7 +6,7 @@ compatibility_flags = ["nodejs_compat", "global_fetch_strictly_public"]
 [assets]
 binding = "ASSETS"
 not_found_handling = "single-page-application"
-run_worker_first = ["/api/*", "/dav", "/dav/*", "/ih", "/ih/*", "/r/*", "/s/*"]
+run_worker_first = ["/api/*", "/dav", "/dav/*", "/ih/*", "/r/*", "/s/*"]
 
 [[d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## What changed

- Generate new image-hosting tokens as `ih` plus 10 alphanumeric characters while preserving legacy `ih_` link compatibility.
- Return the verified custom-domain URL from image APIs and use it for copied raw/Markdown/HTML/BBCode links.
- Keep thumbnails and previews on the instance `/r/` URL so opening the gallery does not create customer-domain Worker traffic.
- Return localized HTML 404 pages for direct navigation and localized SVG placeholders for embedded missing images.
- Route only `/ih/*` ahead of static assets; the Cloudflare for SaaS `*/ih/*` Worker Route remains the narrow dispatch rule after the managed rewrite.
- Regenerate the Go OpenAPI client for the new image `url` response field.

## Why

Custom-domain image hosting should expose clean customer URLs when users copy links, without routing unrelated/static traffic through the Worker. Missing image URLs should also produce a useful browser result instead of JSON, and the new token format should remove the underscore without breaking existing links.

## Local validation

- `pnpm lint` — passed
- `pnpm typecheck` — passed
- `pnpm test` — 5,114 passed
- `pnpm test:cf` — 76 passed
- Relevant Node/frontend tests — 172 passed
- Relevant Workers tests — 10 passed
- `pnpm build` — passed
- Wrangler deploy dry run — passed
- Image-hosting Playwright flow passed on desktop, tablet, and mobile, including custom-domain Markdown copy

A full local Playwright run completed 88/98 tests; its unrelated failures require local MinIO (`localhost:9000`), ZPan Cloud services, or reproduce existing concurrent test cleanup issues. GitHub CI subsequently passed both complete Node and Cloudflare Workers E2E jobs in the configured environment.

## Preview verification

Verified on the deployed Cloudflare Workers branch preview in English and Chinese. The screenshot-backed PASS report is posted in the PR conversation, including proof of the exact copied custom-domain Markdown URL. Temporary staging records were removed after verification.