### PR TITLE
fix(store): recover interrupted capacity purchases

### DIFF
--- a/server/http/store/store.integration.test.ts
+++ b/server/http/store/store.integration.test.ts
@@ -751,7 +751,7 @@ describe('Quota Store API', () => {
     expect(res.status).toBe(403)
   })
 
-  it('returns the standard x402 challenge for an owner capacity purchase', async () => {
+  it('returns the standard x402 challenge and lets a fresh caller recover it', async () => {
     const { app, db } = await createTestApp()
     await seedBusinessLicense(db)
     const headers = await authedHeaders(app, 'capacity-owner@example.com')
@@ -777,6 +777,10 @@ describe('Quota Store API', () => {
       )
       .mockResolvedValueOnce(response(cloudOrder({ status: 'pending', paymentStatus: 'pending' }), 201))
       .mockResolvedValueOnce(response({ ...capacityAttempt(), reused: false }, 201))
+      .mockResolvedValueOnce(response(capacityPublication()))
+      .mockResolvedValueOnce(response(cloudProduct()))
+      .mockResolvedValueOnce(response(capacityReceiver()))
+      .mockResolvedValueOnce(response(capacityAttempt()))
 
     const res = await app.request('/api/store/capacity-purchases/cloud-pkg-1%3Aprice-usd', {
       method: 'POST',
@@ -788,6 +792,16 @@ describe('Quota Store API', () => {
     expect(res.headers.get('PAYMENT-REQUIRED')).toBe('required-header')
     await expect(res.json()).resolves.toEqual(capacityAttempt().paymentRequired)
     expect(orderPayload().idempotencyKey).toMatch(/^zpan-x402-capacity:/)
+
+    const recovered = await app.request('/api/store/capacity-purchases/cloud-pkg-1%3Aprice-usd', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ requestHash: 'hash-1', idempotencyKey: 'fresh-caller-key' }),
+    })
+
+    expect(recovered.status).toBe(402)
+    expect(recovered.headers.get('PAYMENT-REQUIRED')).toBe('required-header')
+    await expect(recovered.json()).resolves.toEqual(capacityAttempt().paymentRequired)
   })
 
   it('rate-limits unpaid capacity purchases before creating another Cloud order', async () => {

--- a/server/http/store/storefront.ts
+++ b/server/http/store/storefront.ts
@@ -165,7 +165,7 @@ const capacityPurchaseRoute = authRoute(
     operationId: 'purchaseStorageCapacity',
     summary: 'Purchase workspace storage capacity with x402',
     description:
-      'Call without PAYMENT-SIGNATURE to receive a standard x402 PAYMENT-REQUIRED challenge. Pay it and retry this same request with PAYMENT-SIGNATURE. A delivered response means the workspace capacity entitlement is active; retry the original createObject request.',
+      'Call without PAYMENT-SIGNATURE to receive a standard x402 PAYMENT-REQUIRED challenge. Pay it and retry this same request with PAYMENT-SIGNATURE. An authorized caller may recover an interrupted purchase by using the same requestHash with a fresh idempotencyKey. A delivered response means the workspace capacity entitlement is active; retry the original createObject request.',
     tags: ['Store'],
     method: 'post',
     path: '/capacity-purchases/{resourceId}',

--- a/server/openapi.test.ts
+++ b/server/openapi.test.ts
@@ -507,6 +507,7 @@ describe('global OpenAPI document', () => {
     })
     expect(doc.paths['/api/store/capacity-purchases/{resourceId}']?.post).toMatchObject({
       operationId: 'purchaseStorageCapacity',
+      description: expect.stringContaining('same requestHash with a fresh idempotencyKey'),
       'x-zpan-auth': {
         public: false,
         scopes: [AuthorizationScope.QUOTA_PURCHASE],

--- a/server/usecases/store/store.test.ts
+++ b/server/usecases/store/store.test.ts
@@ -617,6 +617,17 @@ describe('cloud-store usecase', () => {
       })
     })
 
+    it('rejects a capacity purchase when the x402 receiver is not active', async () => {
+      const { deps, requests } = makeDeps({
+        responses: [ok(publication()), ok(pkg()), ok({ ...receiver, status: 'pending_verification' })],
+      })
+
+      const out = await purchaseCapacity(deps, CLOUD, params)
+
+      expectError(out, { httpStatus: 502, message: 'x402_receiver_not_active' })
+      expect(requests).toHaveLength(3)
+    })
+
     it('returns a retryable conflict when another request is creating the Cloud order', async () => {
       const { deps, requests } = makeDeps({
         responses: [ok(publication()), ok(pkg()), ok(receiver)],

--- a/server/usecases/store/store.test.ts
+++ b/server/usecases/store/store.test.ts
@@ -667,29 +667,32 @@ describe('cloud-store usecase', () => {
       expect(requests).toHaveLength(3)
     })
 
-    it('rejects a different idempotency key for an existing purchase request', async () => {
+    it('recovers an existing purchase request with a different idempotency key', async () => {
+      const quoted = attempt()
       const { deps, requests } = makeDeps({
         responses: [
           ok(publication()),
           ok(pkg()),
           ok(receiver),
           ok(order()),
-          ok({ ...attempt(), reused: false }),
+          ok({ ...quoted, reused: false }),
           ok(publication()),
           ok(pkg()),
           ok(receiver),
+          ok(quoted),
         ],
       })
       await purchaseCapacity(deps, CLOUD, params)
 
       const out = await purchaseCapacity(deps, CLOUD, { ...params, idempotencyKey: 'different-key' })
 
-      expectError(out, {
-        httpStatus: 409,
-        reason: 'X402_PURCHASE_CONFLICT',
-        message: 'Purchase request conflict',
+      expect(out).toEqual({
+        ok: true,
+        kind: 'payment_required',
+        paymentRequired: quoted.paymentRequired,
+        paymentRequiredHeader: quoted.paymentRequiredHeader,
       })
-      expect(requests).toHaveLength(8)
+      expect(requests).toHaveLength(9)
     })
 
     it('releases the local order claim when Cloud order creation fails', async () => {
@@ -702,6 +705,38 @@ describe('cloud-store usecase', () => {
 
       expectError(out, { httpStatus: 502, message: 'cloud_down' })
       expect(updateCloudState).toHaveBeenCalledWith('intent-1', { status: 'created' })
+    })
+
+    it('lets a fresh caller recover an intent after Cloud order creation fails', async () => {
+      const quoted = attempt()
+      const { deps } = makeDeps({
+        responses: [
+          ok(publication()),
+          ok(pkg()),
+          ok(receiver),
+          fail(503, { error: 'cloud_down' }),
+          ok(publication()),
+          ok(pkg()),
+          ok(receiver),
+          ok(order()),
+          ok({ ...quoted, reused: false }),
+        ],
+      })
+
+      const first = await purchaseCapacity(deps, CLOUD, params)
+      expectError(first, { httpStatus: 502, message: 'cloud_down' })
+
+      const recovered = await purchaseCapacity(deps, CLOUD, {
+        ...params,
+        idempotencyKey: 'fresh-caller-key',
+      })
+
+      expect(recovered).toEqual({
+        ok: true,
+        kind: 'payment_required',
+        paymentRequired: quoted.paymentRequired,
+        paymentRequiredHeader: quoted.paymentRequiredHeader,
+      })
     })
 
     it('reuses the intent, verifies payment, settles, and returns the receipt', async () => {

--- a/server/usecases/store/store.ts
+++ b/server/usecases/store/store.ts
@@ -427,10 +427,8 @@ export async function purchaseCapacity(
       }
     }
   }
-  if (intent.idempotencyKey !== params.idempotencyKey) {
-    return { ok: false, error: conflict('Purchase request conflict', 'X402_PURCHASE_CONFLICT') }
-  }
-
+  // The request hash is the stable recovery identity. A caller may not know the
+  // creation key after an Agent handoff or an interrupted initialization.
   let cloudOrderId = intent.cloudOrderId
   if (!cloudOrderId) {
     const claimed = await deps.x402CapacityPurchases.claimCloudOrder(


### PR DESCRIPTION
## Summary
- recover an existing capacity purchase by its stable request hash even when a new Agent supplies a fresh idempotency key
- preserve workspace-scoped idempotency-key uniqueness for different purchase requests
- document the public recovery contract and cover quoted plus failed-initialization recovery

## Verification
- pnpm exec vitest run server/usecases/store/store.test.ts server/http/store/store.integration.test.ts server/openapi.test.ts
- pnpm lint
- pre-commit architecture, HTTP boundary, spec traceability, typecheck, and OpenAPI client checks